### PR TITLE
Remove struct alignment attributes

### DIFF
--- a/src/RageTypes.h
+++ b/src/RageTypes.h
@@ -95,7 +95,7 @@ public:
 	friend RageVector4 operator * ( float f, const RageVector4& other )	{ return other*f; }
 
 	float x, y, z, w;
-} ALIGN(16);
+};
 
 struct RageColor
 {
@@ -159,7 +159,7 @@ public:
 
 	CString ToString() { return ssprintf( "%f,%f,%f,%f", r, g, b, a ); }
 	float r, g, b, a;
-} ALIGN(16);
+};
 
 /* Convert floating-point 0..1 value to integer 0..255 value. *
  *
@@ -281,7 +281,7 @@ public:
     RageMatrix GetTranspose() const;
 
 	float m[4][4];
-} ALIGN(16);
+};
 
 RageColor scale( float x, float l1, float h1, const RageColor &a, const RageColor &b );
 

--- a/src/global.h
+++ b/src/global.h
@@ -147,14 +147,6 @@ void ShowWarning( const char *file, int line, const char *message ); // don't pu
 #define PRINTF(a,b)
 #endif
 
-#if !defined(ALIGN)
-#if defined(__GNUC__)
-#define ALIGN(n) __attribute__((aligned(n)))
-#else
-#define ALIGN(n)
-#endif
-#endif
-
 /* Include this here to make sure our assertion handler is always
  * used.  (This file is a dependency of most everything anyway,
  * so there's no real problem putting it here.) */


### PR DESCRIPTION
Fixes crash when compiled with gcc 4.7
