### PR TITLE
Proactively renaming RageDisplay::PixelFormat to RageDisplay::RagePixelF...

### DIFF
--- a/src/BannerCache.cpp
+++ b/src/BannerCache.cpp
@@ -220,7 +220,7 @@ struct BannerTexture: public RageTexture
 		/* Find a supported texture format.  If it happens to match the stored
 		 * file, we won't have to do any conversion here, and that'll happen often
 		 * with paletted images. */
-		RageDisplay::PixelFormat pf = img->format->BitsPerPixel == 8? RageDisplay::FMT_PAL: RageDisplay::FMT_RGB5A1;
+		RageDisplay::RagePixelFormat pf = img->format->BitsPerPixel == 8? RageDisplay::FMT_PAL: RageDisplay::FMT_RGB5A1;
 		if( !DISPLAY->SupportsTextureFormat(pf) )
 			pf = RageDisplay::FMT_RGBA4;
 		ASSERT( DISPLAY->SupportsTextureFormat(pf) );

--- a/src/RageBitmapTexture.cpp
+++ b/src/RageBitmapTexture.cpp
@@ -153,7 +153,7 @@ void RageBitmapTexture::Create()
 		RageSurfaceUtils::Zoom( img, m_iImageWidth, m_iImageHeight );
 
 	// Format of the image that we will pass to OpenGL and that we want OpenGL to use
-	RageDisplay::PixelFormat pixfmt;
+	RageDisplay::RagePixelFormat pixfmt;
 
 	if( actualID.iGrayscaleBits != -1 && DISPLAY->SupportsTextureFormat(RageDisplay::FMT_PAL) )
 	{

--- a/src/RageDisplay.cpp
+++ b/src/RageDisplay.cpp
@@ -30,7 +30,7 @@ RageDisplay*		DISPLAY	= NULL;
 
 Preference<bool>  LOG_FPS( "LogFPS", true );
 
-CString RageDisplay::PixelFormatToString( PixelFormat pixfmt )
+CString RageDisplay::PixelFormatToString( RagePixelFormat pixfmt )
 {
 	const CString s[NUM_PIX_FORMATS] = {
 		"FMT_RGBA8",
@@ -530,7 +530,7 @@ RageMatrix RageDisplay::GetPerspectiveMatrix(float fovy, float aspect, float zNe
    return GetFrustumMatrix(xmin, xmax, ymin, ymax, zNear, zFar);
 }
 
-RageSurface *RageDisplay::CreateSurfaceFromPixfmt( PixelFormat pixfmt,
+RageSurface *RageDisplay::CreateSurfaceFromPixfmt( RagePixelFormat pixfmt,
 						void *pixels, int width, int height, int pitch )
 {
 	const PixelFormatDesc *tpf = GetPixelFormatDesc(pixfmt);
@@ -543,20 +543,20 @@ RageSurface *RageDisplay::CreateSurfaceFromPixfmt( PixelFormat pixfmt,
 	return surf;
 }
 
-RageDisplay::PixelFormat RageDisplay::FindPixelFormat( 
+RageDisplay::RagePixelFormat RageDisplay::FindPixelFormat( 
 	int bpp, unsigned Rmask, unsigned Gmask, unsigned Bmask, unsigned Amask, bool realtime )
 {
 	PixelFormatDesc tmp = { bpp, { Rmask, Gmask, Bmask, Amask } };
 
 	for(int pixfmt = 0; pixfmt < NUM_PIX_FORMATS; ++pixfmt)
 	{
-		const PixelFormatDesc *pf = GetPixelFormatDesc(PixelFormat(pixfmt));
-		if(!SupportsTextureFormat( PixelFormat(pixfmt), realtime ))
+		const PixelFormatDesc *pf = GetPixelFormatDesc(RagePixelFormat(pixfmt));
+		if(!SupportsTextureFormat( RagePixelFormat(pixfmt), realtime ))
 			continue;
 
 		if(memcmp(pf, &tmp, sizeof(tmp)))
 			continue;
-		return PixelFormat(pixfmt);
+		return RagePixelFormat(pixfmt);
 	}
 
 	return NUM_PIX_FORMATS;

--- a/src/RageDisplay.h
+++ b/src/RageDisplay.h
@@ -52,7 +52,7 @@ public:
 		unsigned int masks[4];
 	};
 
-	enum PixelFormat {
+	enum RagePixelFormat {
 		FMT_RGBA8,
 		FMT_RGBA4,
 		FMT_RGB5A1,
@@ -67,8 +67,8 @@ public:
 		NUM_PIX_FORMATS
 	};
 
-	static CString PixelFormatToString( PixelFormat pixfmt );
-	virtual const PixelFormatDesc *GetPixelFormatDesc(PixelFormat pf) const = 0;
+	static CString PixelFormatToString( RagePixelFormat pixfmt );
+	virtual const PixelFormatDesc *GetPixelFormatDesc(RagePixelFormat pf) const = 0;
 
 	struct VideoModeParams
 	{
@@ -145,12 +145,12 @@ public:
 	
 	virtual void SetBlendMode( BlendMode mode ) = 0;
 
-	virtual bool SupportsTextureFormat( PixelFormat pixfmt, bool realtime=false ) = 0;
+	virtual bool SupportsTextureFormat( RagePixelFormat pixfmt, bool realtime=false ) = 0;
 
 	/* return 0 if failed or internal texture resource handle 
 	 * (unsigned in OpenGL, texture pointer in D3D) */
 	virtual unsigned CreateTexture( 
-		PixelFormat pixfmt,			// format of img and of texture in video mem
+		RagePixelFormat pixfmt,			// format of img and of texture in video mem
 		RageSurface* img, 		// must be in pixfmt
 		bool bGenerateMipMaps
 		) = 0;
@@ -291,8 +291,8 @@ public:
 	/* Centering matrix */
 	void ChangeCentering( int trans_x, int trans_y, int add_width, int add_height );
 
-	RageSurface *CreateSurfaceFromPixfmt( PixelFormat pixfmt, void *pixels, int width, int height, int pitch );
-	PixelFormat FindPixelFormat( int bpp, unsigned Rmask, unsigned Gmask, unsigned Bmask, unsigned Amask, bool realtime=false );
+	RageSurface *CreateSurfaceFromPixfmt( RagePixelFormat pixfmt, void *pixels, int width, int height, int pitch );
+	RagePixelFormat FindPixelFormat( int bpp, unsigned Rmask, unsigned Gmask, unsigned Bmask, unsigned Amask, bool realtime=false );
 
 protected:
 	RageMatrix GetPerspectiveMatrix(float fovy, float aspect, float zNear, float zFar);

--- a/src/RageDisplay_D3D.cpp
+++ b/src/RageDisplay_D3D.cpp
@@ -192,7 +192,7 @@ static D3DFORMAT D3DFORMATS[RageDisplay::NUM_PIX_FORMATS] =
 	D3DFMT_UNKNOWN /* no ABGR */
 };
 
-const RageDisplay::PixelFormatDesc *RageDisplay_D3D::GetPixelFormatDesc(PixelFormat pf) const
+const RageDisplay::PixelFormatDesc *RageDisplay_D3D::GetPixelFormatDesc(RagePixelFormat pf) const
 {
 	ASSERT( pf < NUM_PIX_FORMATS );
 	return &PIXEL_FORMAT_DESC[pf];
@@ -652,7 +652,7 @@ void RageDisplay_D3D::EndFrame()
 	ProcessStatsOnFlip();
 }
 
-bool RageDisplay_D3D::SupportsTextureFormat( PixelFormat pixfmt, bool realtime )
+bool RageDisplay_D3D::SupportsTextureFormat( RagePixelFormat pixfmt, bool realtime )
 {
 #if defined(XBOX)
 	// Lazy...  Xbox handles paletted textures completely differently
@@ -1306,7 +1306,7 @@ void RageDisplay_D3D::DeleteTexture( unsigned uTexHandle )
 
 
 unsigned RageDisplay_D3D::CreateTexture( 
-	PixelFormat pixfmt,
+	RagePixelFormat pixfmt,
 	RageSurface* img,
 	bool bGenerateMipMaps )
 {
@@ -1399,7 +1399,7 @@ void RageDisplay_D3D::UpdateTexture(
 		if(D3DFORMATS[texpixfmt] == desc.Format) break;
 	ASSERT( texpixfmt != NUM_PIX_FORMATS );
 
-	RageSurface *Texture = CreateSurfaceFromPixfmt(PixelFormat(texpixfmt), lr.pBits, width, height, lr.Pitch);
+	RageSurface *Texture = CreateSurfaceFromPixfmt(RagePixelFormat(texpixfmt), lr.pBits, width, height, lr.Pitch);
 	ASSERT( Texture );
 	RageSurfaceUtils::Blit( img, Texture, width, height );
 

--- a/src/RageDisplay_D3D.h
+++ b/src/RageDisplay_D3D.h
@@ -14,15 +14,15 @@ public:
 	virtual CString GetApiDescription() const { return "D3D"; }
 
 	void ResolutionChanged();
-	const PixelFormatDesc *GetPixelFormatDesc(PixelFormat pf) const;
+	const PixelFormatDesc *GetPixelFormatDesc(RagePixelFormat pf) const;
 
 	bool BeginFrame();	
 	void EndFrame();
 	VideoModeParams GetVideoModeParams() const;
 	void SetBlendMode( BlendMode mode );
-	bool SupportsTextureFormat( PixelFormat pixfmt, bool realtime=false );
+	bool SupportsTextureFormat( RagePixelFormat pixfmt, bool realtime=false );
 	unsigned CreateTexture( 
-		PixelFormat pixfmt, 
+		RagePixelFormat pixfmt, 
 		RageSurface* img, 
 		bool bGenerateMipMaps );
 	void UpdateTexture( 

--- a/src/RageDisplay_Null.cpp
+++ b/src/RageDisplay_Null.cpp
@@ -82,7 +82,7 @@ RageSurface* RageDisplay_Null::CreateScreenshot()
 	return image;
 }
 
-const RageDisplay::PixelFormatDesc *RageDisplay_Null::GetPixelFormatDesc(PixelFormat pf) const
+const RageDisplay::PixelFormatDesc *RageDisplay_Null::GetPixelFormatDesc(RagePixelFormat pf) const
 {
 	ASSERT( pf < NUM_PIX_FORMATS );
 	return &PIXEL_FORMAT_DESC[pf];

--- a/src/RageDisplay_Null.h
+++ b/src/RageDisplay_Null.h
@@ -12,15 +12,15 @@ public:
 	virtual CString GetApiDescription() const { return "Null"; }
 
 	void ResolutionChanged() { }
-	const PixelFormatDesc *GetPixelFormatDesc(PixelFormat pf) const;
+	const PixelFormatDesc *GetPixelFormatDesc(RagePixelFormat pf) const;
 
 	bool BeginFrame() { return true; }
 	void EndFrame();
 	VideoModeParams GetVideoModeParams() const { return m_Params; }
 	void SetBlendMode( BlendMode mode ) { }
-	bool SupportsTextureFormat( PixelFormat pixfmt, bool realtime=false ) { return true; }
+	bool SupportsTextureFormat( RagePixelFormat pixfmt, bool realtime=false ) { return true; }
 	unsigned CreateTexture( 
-		PixelFormat pixfmt, 
+		RagePixelFormat pixfmt, 
 		RageSurface* img,
 		bool bGenerateMipMaps ) { return 1; }
 	void UpdateTexture( 
@@ -81,7 +81,7 @@ protected:
 	RageSurface* CreateScreenshot();
 	void SetViewport(int shift_left, int shift_down) { }
 	RageMatrix GetOrthoMatrix( float l, float r, float b, float t, float zn, float zf ); 
-	bool SupportsSurfaceFormat( PixelFormat pixfmt ) { return true; }
+	bool SupportsSurfaceFormat( RagePixelFormat pixfmt ) { return true; }
 };
 
 #endif

--- a/src/RageDisplay_OGL.cpp
+++ b/src/RageDisplay_OGL.cpp
@@ -1586,7 +1586,7 @@ void RageDisplay_OGL::SetCullMode( CullMode mode )
 	}
 }
 
-const RageDisplay::PixelFormatDesc *RageDisplay_OGL::GetPixelFormatDesc(PixelFormat pf) const
+const RageDisplay::PixelFormatDesc *RageDisplay_OGL::GetPixelFormatDesc(RagePixelFormat pf) const
 {
 	ASSERT( pf < NUM_PIX_FORMATS );
 	return &PIXEL_FORMAT_DESC[pf];
@@ -1603,9 +1603,9 @@ void RageDisplay_OGL::DeleteTexture( unsigned uTexHandle )
 }
 
 
-RageDisplay::PixelFormat RageDisplay_OGL::GetImgPixelFormat( RageSurface* &img, bool &FreeImg, int width, int height, bool bPalettedTexture )
+RageDisplay::RagePixelFormat RageDisplay_OGL::GetImgPixelFormat( RageSurface* &img, bool &FreeImg, int width, int height, bool bPalettedTexture )
 {
-	PixelFormat pixfmt = FindPixelFormat( img->format->BitsPerPixel, img->format->Rmask, img->format->Gmask, img->format->Bmask, img->format->Amask );
+	RagePixelFormat pixfmt = FindPixelFormat( img->format->BitsPerPixel, img->format->Rmask, img->format->Gmask, img->format->Bmask, img->format->Amask );
 	
 	/* If img is paletted, we're setting up a non-paletted texture, and color indexes
 	 * are too small, depalettize. */
@@ -1670,7 +1670,7 @@ void SetPixelMapForSurface( int glImageFormat, int glTexFormat, const RageSurfac
 }
 
 unsigned RageDisplay_OGL::CreateTexture( 
-	PixelFormat pixfmt,
+	RagePixelFormat pixfmt,
 	RageSurface* img,
 	bool bGenerateMipMaps )
 {
@@ -1680,7 +1680,7 @@ unsigned RageDisplay_OGL::CreateTexture(
 
 	/* Find the pixel format of the image we've been given. */
 	bool FreeImg;
-	PixelFormat imgpixfmt = GetImgPixelFormat( img, FreeImg, img->w, img->h, pixfmt == FMT_PAL );
+	RagePixelFormat imgpixfmt = GetImgPixelFormat( img, FreeImg, img->w, img->h, pixfmt == FMT_PAL );
 
 	GLenum glTexFormat = GL_PIXFMT_INFO[pixfmt].internalfmt;
 	GLenum glImageFormat = GL_PIXFMT_INFO[imgpixfmt].format;
@@ -1833,7 +1833,7 @@ void RageDisplay_OGL::UpdateTexture(
 	glBindTexture( GL_TEXTURE_2D, uTexHandle );
 
 	bool FreeImg;
-	PixelFormat pixfmt = GetImgPixelFormat( img, FreeImg, width, height, false );
+	RagePixelFormat pixfmt = GetImgPixelFormat( img, FreeImg, width, height, false );
 
 	glPixelStorei(GL_UNPACK_ROW_LENGTH, img->pitch / img->format->BytesPerPixel);
 
@@ -1900,7 +1900,7 @@ void RageDisplay_OGL::SetAlphaTest( bool b )
  * Another case of this is incomplete packed pixels support.  Some implementations
  * neglect GL_UNSIGNED_SHORT_*_REV. 
  */
-bool RageDisplay_OGL::SupportsSurfaceFormat( PixelFormat pixfmt )
+bool RageDisplay_OGL::SupportsSurfaceFormat( RagePixelFormat pixfmt )
 {
 	switch( GL_PIXFMT_INFO[pixfmt].type )
 	{
@@ -1912,7 +1912,7 @@ bool RageDisplay_OGL::SupportsSurfaceFormat( PixelFormat pixfmt )
 }
 
 
-bool RageDisplay_OGL::SupportsTextureFormat( PixelFormat pixfmt, bool realtime )
+bool RageDisplay_OGL::SupportsTextureFormat( RagePixelFormat pixfmt, bool realtime )
 {
 	/* If we support a pixfmt for texture formats but not for surface formats, then
 	 * we'll have to convert the texture to a supported surface format before uploading.

--- a/src/RageDisplay_OGL.h
+++ b/src/RageDisplay_OGL.h
@@ -15,15 +15,15 @@ public:
 
 	bool IsSoftwareRenderer();
 	void ResolutionChanged();
-	const PixelFormatDesc *GetPixelFormatDesc(PixelFormat pf) const;
+	const PixelFormatDesc *GetPixelFormatDesc(RagePixelFormat pf) const;
 
 	bool BeginFrame();	
 	void EndFrame();
 	VideoModeParams GetVideoModeParams() const;
 	void SetBlendMode( BlendMode mode );
-	bool SupportsTextureFormat( PixelFormat pixfmt, bool realtime=false );
+	bool SupportsTextureFormat( RagePixelFormat pixfmt, bool realtime=false );
 	unsigned CreateTexture( 
-		PixelFormat pixfmt, 
+		RagePixelFormat pixfmt, 
 		RageSurface* img,
 		bool bGenerateMipMaps );
 	void UpdateTexture( 
@@ -88,8 +88,8 @@ protected:
 	CString TryVideoMode( VideoModeParams params, bool &bNewDeviceOut );
 	RageSurface* CreateScreenshot();
 	void SetViewport(int shift_left, int shift_down);
-	PixelFormat GetImgPixelFormat( RageSurface* &img, bool &FreeImg, int width, int height, bool bPalettedTexture );
-	bool SupportsSurfaceFormat( PixelFormat pixfmt );
+	RagePixelFormat GetImgPixelFormat( RageSurface* &img, bool &FreeImg, int width, int height, bool bPalettedTexture );
+	bool SupportsSurfaceFormat( RagePixelFormat pixfmt );
 	
 	void SendCurrentMatrices();
 };

--- a/src/RageSoundResampler.cpp
+++ b/src/RageSoundResampler.cpp
@@ -112,16 +112,16 @@ void RageSoundResampler::eof()
 }
 
 
-int RageSoundResampler::read(void *data, unsigned bytes)
+int RageSoundResampler::read(void *data, size_t bytes)
 {
-	/* Don't be silly. */
+	// Don't be silly.
 	ASSERT( (bytes % sizeof(int16_t)) == 0);
 
-	/* If no data is available, and we're at_eof, return -1. */
+	// If no data is available, and we're at_eof, return -1.
 	if(outbuf.size() == 0 && at_eof)
 		return -1;
 
-	/* Fill as much as we have. */
+	// Fill as much as we have. 
 	int Avail = min(outbuf.size()*sizeof(int16_t), bytes);
 	memcpy(data, &outbuf[0], Avail);
 	outbuf.erase(outbuf.begin(), outbuf.begin() + Avail/sizeof(int16_t));

--- a/src/RageSoundResampler.h
+++ b/src/RageSoundResampler.h
@@ -38,7 +38,7 @@ public:
 	/* Read converted data.  Returns the number of bytes filled.
 	 * If eof() has been called and the output is completely
 	 * flushed, returns -1. */
-	int read(void *data, unsigned bytes);
+	int read(void *data, size_t bytes);
 };
 
 #endif

--- a/src/arch/MovieTexture/MovieTexture_DShow.cpp
+++ b/src/arch/MovieTexture/MovieTexture_DShow.cpp
@@ -442,7 +442,7 @@ void MovieTexture_DShow::CreateTexture()
 	if(m_uTexHandle)
 		return;
 
-	RageDisplay::PixelFormat pixfmt;
+	RageDisplay::RagePixelFormat pixfmt;
 	switch( TEXTUREMAN->GetPrefs().m_iMovieColorDepth )
 	{
 	default:

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -145,7 +145,7 @@ static void FixLilEndian()
 #endif
 }
 
-static int FindCompatibleAVFormat( RageDisplay::PixelFormat &pixfmt, bool HighColor )
+static int FindCompatibleAVFormat( RageDisplay::RagePixelFormat &pixfmt, bool HighColor )
 {
 	for( int i = 0; AVPixelFormats[i].bpp; ++i )
 	{
@@ -745,7 +745,7 @@ void MovieTexture_FFMpeg::CreateTexture()
 	m_iTextureHeight = power_of_two(m_iImageHeight);
 
 	/* Bogus assignment to shut gcc up. */
-    RageDisplay::PixelFormat pixfmt = RageDisplay::FMT_RGBA8;
+    RageDisplay::RagePixelFormat pixfmt = RageDisplay::FMT_RGBA8;
 	bool PreferHighColor = (TEXTUREMAN->GetPrefs().m_iMovieColorDepth == 32);
 	m_AVTexfmt = FindCompatibleAVFormat( pixfmt, PreferHighColor );
 

--- a/src/arch/MovieTexture/MovieTexture_Null.cpp
+++ b/src/arch/MovieTexture/MovieTexture_Null.cpp
@@ -27,7 +27,7 @@ MovieTexture_Null::MovieTexture_Null(RageTextureID ID) : RageMovieTexture(ID)
 
     CreateFrameRects();
 
-    RageDisplay::PixelFormat pixfmt = RageDisplay::FMT_RGBA4;
+    RageDisplay::RagePixelFormat pixfmt = RageDisplay::FMT_RGBA4;
     if( !DISPLAY->SupportsTextureFormat(pixfmt) )
 	    pixfmt = RageDisplay::FMT_RGBA8;
     ASSERT( DISPLAY->SupportsTextureFormat(pixfmt) );


### PR DESCRIPTION
Proactively renaming RageDisplay::PixelFormat to RageDisplay::RagePixelFormat to resolve naming conflict with newer versionf of FFMpeg. Resolving problem with RageSoundResampler that was causing build failures on 64-bit machines.

Tested by playing through a set.
