### PR TITLE
Fix compile error on VS 2013 (lrintf)

### DIFF
--- a/src/RageSurfaceUtils.cpp
+++ b/src/RageSurfaceUtils.cpp
@@ -453,7 +453,7 @@ void RageSurfaceUtils::BlitTransform( const RageSurface *src, RageSurface *dst,
 				sum += v[1][i] * (1-weight_x) * (weight_y);
 				sum += v[2][i] * (weight_x)   * (1-weight_y);
 				sum += v[3][i] * (weight_x)   * (weight_y);
-				out[i] = (uint8_t) clamp( lrintf(sum), 0, 255 );
+				out[i] = (uint8_t) clamp( (int)lrintf(sum), 0, 255 );
 			}
 
 			/* If the source has no alpha, set the destination to opaque. */

--- a/src/archutils/Win32/arch_setup.h
+++ b/src/archutils/Win32/arch_setup.h
@@ -109,6 +109,11 @@ static inline int64_t llabs( int64_t i ) { return i >= 0? i: -i; }
 //our cross-platform stdint covers us here
 //#define MISSING_STDINT_H
 
+// MinGW provides us with this function already
+#if !defined(__MINGW32__) \
+		/* VC++ 2013 added support for lrintf	*/\
+		&& (!defined(_MSC_VER) || _MSC_VER < 1800)
+
 inline int lrintf( float f )
 {
 	int retval;
@@ -118,6 +123,8 @@ inline int lrintf( float f )
 
 	return retval;
 }
+#endif
+
 
 /* For RageLog. */
 #define HAVE_VERSION_INFO


### PR DESCRIPTION
lrintf is now provided by the windows sdk. We need to conditionally exclude the openitg implementation for it to build.