### PR TITLE
Migrate to DirectX 9

### DIFF
--- a/src/RageDisplay_D3D.cpp
+++ b/src/RageDisplay_D3D.cpp
@@ -51,7 +51,7 @@ CString GetErrorString( HRESULT hr )
 // Globals
 //
 #if !defined(XBOX)
-HMODULE					g_D3D8_Module = NULL;
+HMODULE					g_D3D9_Module = NULL;
 #endif
 LPDIRECT3D9				g_pd3d = NULL;
 LPDIRECT3DDEVICE9		g_pd3dDevice = NULL;
@@ -210,8 +210,7 @@ RageDisplay_D3D::RageDisplay_D3D()
 }
 
 #define D3D_NOT_INSTALLED \
-	"DirectX 8.1 or greater is not installed.  You can download it from:\n" \
-	"http://www.microsoft.com/downloads/details.aspx?FamilyID=a19bed22-0b25-4e5d-a584-6389d8a3dad0&displaylang=en"
+	"DirectX 9 or greater is not installed."
 
 CString RageDisplay_D3D::Init( VideoModeParams p )
 {
@@ -221,26 +220,26 @@ CString RageDisplay_D3D::Init( VideoModeParams p )
 	LOG->MapLog("renderer", "Current renderer: Direct3D");
 
 	typedef IDirect3D9 * (WINAPI * Direct3DCreate9_t) (UINT SDKVersion);
-	Direct3DCreate9_t pDirect3DCreate8;
+	Direct3DCreate9_t pDirect3DCreate9;
 #if defined(XBOX)
 	pDirect3DCreate8 = Direct3DCreate8;
 #else
-	g_D3D8_Module = LoadLibrary("D3D8.dll");
-	if(!g_D3D8_Module)
+	g_D3D9_Module = LoadLibrary("D3D9.dll");
+	if(!g_D3D9_Module)
 		return D3D_NOT_INSTALLED;
 
-	pDirect3DCreate8 = (Direct3DCreate9_t) GetProcAddress(g_D3D8_Module, "Direct3DCreate8");
-	if(!pDirect3DCreate8)
+	pDirect3DCreate9 = (Direct3DCreate9_t) GetProcAddress(g_D3D9_Module, "Direct3DCreate9");
+	if(!pDirect3DCreate9)
 	{
-		LOG->Trace( "Direct3DCreate8 not found" );
+		LOG->Trace( "Direct3DCreate9 not found" );
 		return D3D_NOT_INSTALLED;
 	}
 #endif
 
-	g_pd3d = pDirect3DCreate8( D3D_SDK_VERSION );
+	g_pd3d = pDirect3DCreate9( D3D_SDK_VERSION );
 	if(!g_pd3d)
 	{
-		LOG->Trace( "Direct3DCreate8 failed" );
+		LOG->Trace( "Direct3DCreate9 failed" );
 		return D3D_NOT_INSTALLED;
 	}
 
@@ -301,10 +300,10 @@ RageDisplay_D3D::~RageDisplay_D3D()
 	    g_pd3d->Release();
 
 #if !defined(XBOX)
-	if( g_D3D8_Module )
+	if( g_D3D9_Module )
 	{
-		FreeLibrary( g_D3D8_Module );
-		g_D3D8_Module = NULL;
+		FreeLibrary( g_D3D9_Module );
+		g_D3D9_Module = NULL;
 	}
 #endif
 

--- a/src/RageDisplay_D3D.cpp
+++ b/src/RageDisplay_D3D.cpp
@@ -1,7 +1,6 @@
 #include "global.h"
 #include "RageDisplay.h"
 #include "RageDisplay_D3D.h"
-#include "D3D8.h"
 #include "RageUtil.h"
 #include "RageLog.h"
 #include "RageTimer.h"
@@ -14,11 +13,13 @@
 #include "GameConstantsAndTypes.h"
 #include "StepMania.h"
 #include "RageUtil.h"
-#include "D3dx8math.h"
-#include "D3DX8Core.h"
 #include "PrefsManager.h"
 #include "RageSurface.h"
 #include "RageSurfaceUtils.h"
+
+#include <d3dx9tex.h>
+#include <d3d9.h>
+#include <DxErr.h>
 
 #if !defined(XBOX)
 #include "archutils/Win32/GraphicsWindow.h"
@@ -30,10 +31,11 @@
 #include "ScreenDimensions.h"
 
 // Static libraries
-// load Windows D3D8 dynamically
+// load Windows D3D9 dynamically
 #if defined(_MSC_VER) && !defined(_XBOX)
-	#pragma comment(lib, "D3dx8.lib")
-	#pragma comment(lib, "Dxerr8.lib")
+	#pragma comment(lib, "d3d9.lib")
+	#pragma comment(lib, "d3dx9.lib")
+	#pragma comment(lib, "DxErr.lib")
 #endif
 
 #include <math.h>
@@ -42,9 +44,7 @@
 
 CString GetErrorString( HRESULT hr )
 {
-	char szError[1024] = "";
-	D3DXGetErrorString( hr, szError, sizeof(szError) );
-	return szError;
+	return DXGetErrorString(hr);
 }
 
 //
@@ -53,14 +53,18 @@ CString GetErrorString( HRESULT hr )
 #if !defined(XBOX)
 HMODULE					g_D3D8_Module = NULL;
 #endif
-LPDIRECT3D8				g_pd3d = NULL;
-LPDIRECT3DDEVICE8		g_pd3dDevice = NULL;
-D3DCAPS8				g_DeviceCaps;
+LPDIRECT3D9				g_pd3d = NULL;
+LPDIRECT3DDEVICE9		g_pd3dDevice = NULL;
+D3DCAPS9				g_DeviceCaps;
 D3DDISPLAYMODE			g_DesktopMode;
 D3DPRESENT_PARAMETERS	g_d3dpp;
 int						g_ModelMatrixCnt=0;
 int						g_iCurrentTextureIndex = 0;
 bool					g_bSphereMapping[MAX_TEXTURE_UNITS];
+
+// TODO: Instead of defining this here, enumerate the possible formats and select whatever one we want to use. This format should
+// be fine for the uses of this application though.
+const D3DFORMAT g_DefaultAdapterFormat = D3DFMT_X8R8G8B8;
 
 /* Direct3D doesn't associate a palette with textures.
  * Instead, we load a palette into a slot.  We need to keep track
@@ -216,8 +220,8 @@ CString RageDisplay_D3D::Init( VideoModeParams p )
 	LOG->Trace( "RageDisplay_D3D::RageDisplay_D3D()" );
 	LOG->MapLog("renderer", "Current renderer: Direct3D");
 
-	typedef IDirect3D8 * (WINAPI * Direct3DCreate8_t) (UINT SDKVersion);
-	Direct3DCreate8_t pDirect3DCreate8;
+	typedef IDirect3D9 * (WINAPI * Direct3DCreate9_t) (UINT SDKVersion);
+	Direct3DCreate9_t pDirect3DCreate8;
 #if defined(XBOX)
 	pDirect3DCreate8 = Direct3DCreate8;
 #else
@@ -225,7 +229,7 @@ CString RageDisplay_D3D::Init( VideoModeParams p )
 	if(!g_D3D8_Module)
 		return D3D_NOT_INSTALLED;
 
-	pDirect3DCreate8 = (Direct3DCreate8_t) GetProcAddress(g_D3D8_Module, "Direct3DCreate8");
+	pDirect3DCreate8 = (Direct3DCreate9_t) GetProcAddress(g_D3D8_Module, "Direct3DCreate8");
 	if(!pDirect3DCreate8)
 	{
 		LOG->Trace( "Direct3DCreate8 not found" );
@@ -245,7 +249,7 @@ CString RageDisplay_D3D::Init( VideoModeParams p )
 			"Your system is reporting that Direct3D hardware acceleration is not available.  "
 			"Please obtain an updated driver from your video card manufacturer.\n\n";
 
-	D3DADAPTER_IDENTIFIER8	identifier;
+	D3DADAPTER_IDENTIFIER9	identifier;
 	g_pd3d->GetAdapterIdentifier( D3DADAPTER_DEFAULT, 0, &identifier );
 
 	LOG->Trace( 
@@ -260,8 +264,10 @@ CString RageDisplay_D3D::Init( VideoModeParams p )
 
 	LOG->Trace( "This display adaptor supports the following modes:" );
 	D3DDISPLAYMODE mode;
-	for( UINT u=0; u<g_pd3d->GetAdapterModeCount(D3DADAPTER_DEFAULT); u++ )
-		if( SUCCEEDED( g_pd3d->EnumAdapterModes( D3DADAPTER_DEFAULT, u, &mode ) ) )
+	UINT modeCount = g_pd3d->GetAdapterModeCount(D3DADAPTER_DEFAULT, g_DefaultAdapterFormat);
+	
+	for( UINT u=0; u<modeCount; u++ )
+		if( SUCCEEDED( g_pd3d->EnumAdapterModes( D3DADAPTER_DEFAULT, g_DefaultAdapterFormat, u, &mode ) ) )
 			LOG->Trace( "  %ux%u %uHz, format %d", mode.Width, mode.Height, mode.RefreshRate, mode.Format );
 
 	g_PaletteIndex.clear();
@@ -408,14 +414,14 @@ bool D3DReduceParams( D3DPRESENT_PARAMETERS	*pp )
 	current.Width = pp->BackBufferWidth;
 	current.RefreshRate = pp->FullScreen_RefreshRateInHz;
 
-	const int iCnt = g_pd3d->GetAdapterModeCount( D3DADAPTER_DEFAULT );
+	const int iCnt = g_pd3d->GetAdapterModeCount( D3DADAPTER_DEFAULT, g_DefaultAdapterFormat );
 	int iBest = -1;
 	int iBestScore = 0;
 	LOG->Trace( "cur: %ux%u %uHz, format %i", current.Width, current.Height, current.RefreshRate, current.Format );
 	for( int i = 0; i < iCnt; ++i )
 	{
 		D3DDISPLAYMODE mode;
-		g_pd3d->EnumAdapterModes( D3DADAPTER_DEFAULT, i, &mode );
+		g_pd3d->EnumAdapterModes( D3DADAPTER_DEFAULT, g_DefaultAdapterFormat, i, &mode );
 
 		/* Never change the format. */
 		if( mode.Format != current.Format )
@@ -468,7 +474,7 @@ bool D3DReduceParams( D3DPRESENT_PARAMETERS	*pp )
 		return false;
 
 	D3DDISPLAYMODE BestMode;
-	g_pd3d->EnumAdapterModes( D3DADAPTER_DEFAULT, iBest, &BestMode );
+	g_pd3d->EnumAdapterModes( D3DADAPTER_DEFAULT, g_DefaultAdapterFormat, iBest, &BestMode );
 	pp->BackBufferHeight = BestMode.Height;
 	pp->BackBufferWidth = BestMode.Width;
 	pp->FullScreen_RefreshRateInHz = BestMode.RefreshRate;
@@ -513,9 +519,9 @@ CString RageDisplay_D3D::TryVideoMode( VideoModeParams p, bool &bNewDeviceOut )
 	g_d3dpp.AutoDepthStencilFormat	=	D3DFMT_D16;
 
 	if(p.windowed)
-		g_d3dpp.FullScreen_PresentationInterval = D3DPRESENT_INTERVAL_DEFAULT;
+		g_d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_DEFAULT;
 	else
-		g_d3dpp.FullScreen_PresentationInterval = p.vsync ? D3DPRESENT_INTERVAL_ONE : D3DPRESENT_INTERVAL_IMMEDIATE;
+		g_d3dpp.PresentationInterval = p.vsync ? D3DPRESENT_INTERVAL_ONE : D3DPRESENT_INTERVAL_IMMEDIATE;
 
 #if !defined(XBOX)
 	g_d3dpp.FullScreen_RefreshRateInHz = D3DPRESENT_RATE_DEFAULT;
@@ -545,7 +551,7 @@ CString RageDisplay_D3D::TryVideoMode( VideoModeParams p, bool &bNewDeviceOut )
 		g_d3dpp.MultiSampleType, g_d3dpp.SwapEffect, g_d3dpp.hDeviceWindow,
 		g_d3dpp.Windowed, g_d3dpp.EnableAutoDepthStencil, g_d3dpp.AutoDepthStencilFormat,
 		g_d3dpp.Flags, g_d3dpp.FullScreen_RefreshRateInHz,
-		g_d3dpp.FullScreen_PresentationInterval
+		g_d3dpp.PresentationInterval
 	);
 
 #if defined(XBOX)
@@ -612,7 +618,7 @@ void RageDisplay_D3D::SetViewport(int shift_left, int shift_down)
 	shift_left = int( shift_left * float(p.width) / SCREEN_WIDTH );
 	shift_down = int( shift_down * float(p.height) / SCREEN_HEIGHT );
 
-	D3DVIEWPORT8 viewData = { shift_left, -shift_down, p.width, p.height, 0.f, 1.f };
+	D3DVIEWPORT9 viewData = { shift_left, -shift_down, p.width, p.height, 0.f, 1.f };
 	g_pd3dDevice->SetViewport( &viewData );
 }
 
@@ -689,52 +695,59 @@ RageSurface* RageDisplay_D3D::CreateScreenshot()
 #if defined(XBOX)
 	return NULL;
 #else
-	/* Get the back buffer. */
-	IDirect3DSurface8* pSurface;
-	g_pd3dDevice->GetBackBuffer( 0, D3DBACKBUFFER_TYPE_MONO, &pSurface );
+	RageSurface * result = NULL;
 
-	/* Get the back buffer description. */
-	D3DSURFACE_DESC desc;
-	pSurface->GetDesc( &desc );
-
-	/* Copy the back buffer into a surface of a type we support. */
-	IDirect3DSurface8* pCopy;
-	g_pd3dDevice->CreateImageSurface( desc.Width, desc.Height, D3DFMT_A8R8G8B8, &pCopy );
-
-	D3DXLoadSurfaceFromSurface( pCopy, NULL, NULL, pSurface, NULL, NULL, D3DX_DEFAULT, 0 );
-
-	pSurface->Release();
-
-	/* Update desc from the copy. */
-	pCopy->GetDesc( &desc );
-
-	D3DLOCKED_RECT lr;
-
+	// Get the back buffer.
+	IDirect3DSurface9* pSurface;
+	if( SUCCEEDED( g_pd3dDevice->GetBackBuffer( 0, 0, D3DBACKBUFFER_TYPE_MONO, &pSurface ) ) )
 	{
-		RECT rect; 
-		rect.left = 0;
-		rect.top = 0;
-		rect.right = desc.Width;
-		rect.bottom = desc.Height;
-		pCopy->LockRect( &lr, &rect, D3DLOCK_READONLY );
+		// Get the back buffer description.
+		D3DSURFACE_DESC desc;
+		pSurface->GetDesc( &desc );
+
+		// Copy the back buffer into a surface of a type we support.
+		IDirect3DSurface9* pCopy;
+		if( SUCCEEDED( g_pd3dDevice->CreateOffscreenPlainSurface( desc.Width, desc.Height, D3DFMT_A8R8G8B8, D3DPOOL_SCRATCH, &pCopy, NULL ) ) )
+		{
+			if( SUCCEEDED( D3DXLoadSurfaceFromSurface( pCopy, NULL, NULL, pSurface, NULL, NULL, D3DX_FILTER_NONE, 0) ) )
+			{
+				// Update desc from the copy.
+				pCopy->GetDesc( &desc );
+
+				D3DLOCKED_RECT lr;
+
+				{
+					RECT rect;
+					rect.left = 0;
+					rect.top = 0;
+					rect.right = desc.Width;
+					rect.bottom = desc.Height;
+
+					pCopy->LockRect( &lr, &rect, D3DLOCK_READONLY );
+				}
+
+				RageSurface *surface = CreateSurfaceFromPixfmt( FMT_RGBA8, lr.pBits, desc.Width, desc.Height, lr.Pitch);
+				ASSERT( surface != NULL );
+
+				// We need to make a copy, since lr.pBits will go away when we call UnlockRect().
+				result = 
+					CreateSurface( surface->w, surface->h,
+						surface->format->BitsPerPixel,
+						surface->format->Rmask, surface->format->Gmask,
+						surface->format->Bmask, surface->format->Amask );
+				RageSurfaceUtils::CopySurface( surface, result );
+				delete surface;
+
+				pCopy->UnlockRect();
+			}
+
+			pCopy->Release();
+		}
+
+		pSurface->Release();
 	}
 
-	RageSurface *surface = CreateSurfaceFromPixfmt( FMT_RGBA8, lr.pBits, desc.Width, desc.Height, lr.Pitch);
-	ASSERT( surface );
-
-	/* We need to make a copy, since lr.pBits will go away when we call UnlockRect(). */
-	RageSurface *SurfaceCopy = 
-		CreateSurface( surface->w, surface->h,
-			surface->format->BitsPerPixel,
-			surface->format->Rmask, surface->format->Gmask,
-			surface->format->Bmask, surface->format->Amask );
-	RageSurfaceUtils::CopySurface( surface, SurfaceCopy );
-	delete surface;
-
-	pCopy->UnlockRect();
-	pCopy->Release();
-
-	return SurfaceCopy;
+	return result;
 #endif
 }
 
@@ -760,7 +773,7 @@ void RageDisplay_D3D::SendCurrentMatrices()
 		g_pd3dDevice->SetTextureStageState( tu, D3DTSS_TEXTURETRANSFORMFLAGS, D3DTTFF_COUNT2 );
 		
 		// If no texture is set for this texture unit, don't bother setting it up.
-		IDirect3DBaseTexture8* pTexture = NULL;
+		IDirect3DBaseTexture9* pTexture = NULL;
 		g_pd3dDevice->GetTexture( tu, &pTexture );
 		if( pTexture == NULL )
 			 continue;
@@ -847,7 +860,7 @@ public:
 			g_pd3dDevice->SetTransform( D3DTS_TEXTURE0, (D3DMATRIX*)&m );
 		}
 
-		g_pd3dDevice->SetVertexShader( D3DFVF_RageModelVertex );
+		g_pd3dDevice->SetFVF( D3DFVF_RageModelVertex );
 		g_pd3dDevice->DrawIndexedPrimitiveUP(
 			D3DPT_TRIANGLELIST,			// PrimitiveType
 			meshInfo.iVertexStart,		// MinIndex
@@ -897,7 +910,7 @@ void RageDisplay_D3D::DrawQuadsInternal( const RageSpriteVertex v[], int iNumVer
 		vIndices[i*6+5] = i*4+0;
 	}
 
-	g_pd3dDevice->SetVertexShader( D3DFVF_RageSpriteVertex );
+	g_pd3dDevice->SetFVF( D3DFVF_RageSpriteVertex );
 	SendCurrentMatrices();
 	g_pd3dDevice->DrawIndexedPrimitiveUP(
 		D3DPT_TRIANGLELIST, // PrimitiveType
@@ -933,7 +946,7 @@ void RageDisplay_D3D::DrawQuadStripInternal( const RageSpriteVertex v[], int iNu
 		vIndices[i*6+5] = i*2+3;
 	}
 
-	g_pd3dDevice->SetVertexShader( D3DFVF_RageSpriteVertex );
+	g_pd3dDevice->SetFVF( D3DFVF_RageSpriteVertex );
 	SendCurrentMatrices();
 	g_pd3dDevice->DrawIndexedPrimitiveUP(
 		D3DPT_TRIANGLELIST, // PrimitiveType
@@ -949,7 +962,7 @@ void RageDisplay_D3D::DrawQuadStripInternal( const RageSpriteVertex v[], int iNu
 
 void RageDisplay_D3D::DrawFanInternal( const RageSpriteVertex v[], int iNumVerts )
 {
-	g_pd3dDevice->SetVertexShader( D3DFVF_RageSpriteVertex );
+	g_pd3dDevice->SetFVF( D3DFVF_RageSpriteVertex );
 	SendCurrentMatrices();
 	g_pd3dDevice->DrawPrimitiveUP(
 		D3DPT_TRIANGLEFAN, // PrimitiveType
@@ -961,7 +974,7 @@ void RageDisplay_D3D::DrawFanInternal( const RageSpriteVertex v[], int iNumVerts
 
 void RageDisplay_D3D::DrawStripInternal( const RageSpriteVertex v[], int iNumVerts )
 {
-	g_pd3dDevice->SetVertexShader( D3DFVF_RageSpriteVertex );
+	g_pd3dDevice->SetFVF( D3DFVF_RageSpriteVertex );
 	SendCurrentMatrices();
 	g_pd3dDevice->DrawPrimitiveUP(
 		D3DPT_TRIANGLESTRIP, // PrimitiveType
@@ -973,7 +986,7 @@ void RageDisplay_D3D::DrawStripInternal( const RageSpriteVertex v[], int iNumVer
 
 void RageDisplay_D3D::DrawTrianglesInternal( const RageSpriteVertex v[], int iNumVerts )
 {
-	g_pd3dDevice->SetVertexShader( D3DFVF_RageSpriteVertex );
+	g_pd3dDevice->SetFVF( D3DFVF_RageSpriteVertex );
 	SendCurrentMatrices();
 	g_pd3dDevice->DrawPrimitiveUP(
 		D3DPT_TRIANGLELIST, // PrimitiveType
@@ -1052,7 +1065,7 @@ void RageDisplay_D3D::SetTexture( int iTextureUnitIndex, RageTexture* pTexture )
 	else
 	{
 		unsigned uTexHandle = pTexture->GetTexHandle();
-		IDirect3DTexture8* pTex = (IDirect3DTexture8*)uTexHandle;
+		IDirect3DTexture9* pTex = (IDirect3DTexture9*)uTexHandle;
 		g_pd3dDevice->SetTexture( g_iCurrentTextureIndex, pTex );
 		
 		//g_pd3dDevice->SetTextureStageState( g_iCurrentTextureIndex, D3DTSS_COLOROP,   D3DTOP_MODULATE );
@@ -1105,8 +1118,8 @@ void RageDisplay_D3D::SetTextureFiltering( bool b )
 	if( g_iCurrentTextureIndex >= (int) g_DeviceCaps.MaxSimultaneousTextures )	// not supported
 		return;
 
-	g_pd3dDevice->SetTextureStageState( g_iCurrentTextureIndex, D3DTSS_MINFILTER, b ? D3DTEXF_LINEAR : D3DTEXF_POINT );
-	g_pd3dDevice->SetTextureStageState( g_iCurrentTextureIndex, D3DTSS_MAGFILTER, b ? D3DTEXF_LINEAR : D3DTEXF_POINT );
+	g_pd3dDevice->SetSamplerState( g_iCurrentTextureIndex, D3DSAMP_MINFILTER, b ? D3DTEXF_LINEAR : D3DTEXF_POINT );
+	g_pd3dDevice->SetSamplerState( g_iCurrentTextureIndex, D3DSAMP_MAGFILTER, b ? D3DTEXF_LINEAR : D3DTEXF_POINT );
 }
 
 void RageDisplay_D3D::SetBlendMode( BlendMode mode )
@@ -1141,7 +1154,7 @@ bool RageDisplay_D3D::IsZWriteEnabled() const
 void RageDisplay_D3D::SetZBias( float f )
 {
 	//g_pd3dDevice->SetRenderState( D3DRS_ZBIAS, (int) SCALE( f, 0.0f, 1.0f, 0, 30 ) );
-	D3DVIEWPORT8 viewData;
+	D3DVIEWPORT9 viewData;
 	g_pd3dDevice->GetViewport( &viewData );
 	viewData.MinZ = SCALE( f, 0.0f, 1.0f, 0.05f, 0.0f );
 	viewData.MaxZ = SCALE( f, 0.0f, 1.0f, 1.0f, 0.95f );
@@ -1186,8 +1199,8 @@ void RageDisplay_D3D::SetTextureWrapping( bool b )
 		return;
 
 	int mode = b ? D3DTADDRESS_WRAP : D3DTADDRESS_CLAMP;
-    g_pd3dDevice->SetTextureStageState( g_iCurrentTextureIndex, D3DTSS_ADDRESSU, mode );
-    g_pd3dDevice->SetTextureStageState( g_iCurrentTextureIndex, D3DTSS_ADDRESSV, mode );
+    g_pd3dDevice->SetSamplerState( g_iCurrentTextureIndex, D3DSAMP_ADDRESSU, mode );
+    g_pd3dDevice->SetSamplerState( g_iCurrentTextureIndex, D3DSAMP_ADDRESSV, mode );
 }
 
 void RageDisplay_D3D::SetMaterial( 
@@ -1209,7 +1222,7 @@ void RageDisplay_D3D::SetMaterial(
 
 	if( bLighting )
 	{
-		D3DMATERIAL8 mat;
+		D3DMATERIAL9 mat;
 		memcpy( &mat.Diffuse, diffuse, sizeof(float)*4 );
 		memcpy( &mat.Ambient, ambient, sizeof(float)*4 );
 		memcpy( &mat.Specular, specular, sizeof(float)*4 );
@@ -1252,7 +1265,7 @@ void RageDisplay_D3D::SetLightDirectional(
 {
 	g_pd3dDevice->LightEnable( index, true );
 
-	D3DLIGHT8 light;
+	D3DLIGHT9 light;
 	ZERO( light );
 	light.Type = D3DLIGHT_DIRECTIONAL;
 
@@ -1294,7 +1307,7 @@ void RageDisplay_D3D::SetCullMode( CullMode mode )
 
 void RageDisplay_D3D::DeleteTexture( unsigned uTexHandle )
 {
-	IDirect3DTexture8* pTex = (IDirect3DTexture8*) uTexHandle;
+	IDirect3DTexture9* pTex = (IDirect3DTexture9*) uTexHandle;
 	pTex->Release();
 
 	// Delete palette (if any)
@@ -1316,8 +1329,8 @@ unsigned RageDisplay_D3D::CreateTexture(
 
 
 	HRESULT hr;
-	IDirect3DTexture8* pTex;
-	hr = g_pd3dDevice->CreateTexture( img->w, img->h, 1, 0, D3DFORMATS[pixfmt], D3DPOOL_MANAGED, &pTex );
+	IDirect3DTexture9* pTex;
+	hr = g_pd3dDevice->CreateTexture( img->w, img->h, 1, 0, D3DFORMATS[pixfmt], D3DPOOL_MANAGED, &pTex, NULL );
 
 #if defined(XBOX)
 	while(hr == E_OUTOFMEMORY)
@@ -1362,7 +1375,7 @@ void RageDisplay_D3D::UpdateTexture(
 	RageSurface* img,
 	int xoffset, int yoffset, int width, int height )
 {
-	IDirect3DTexture8* pTex = (IDirect3DTexture8*)uTexHandle;
+	IDirect3DTexture9* pTex = (IDirect3DTexture9*)uTexHandle;
 	ASSERT( pTex != NULL );
 	
 	RECT rect; 

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -346,9 +346,9 @@ CString vssprintf( const char *szFormat, va_list argList )
 #  include <D3DX8Core.h>
 #else
 #  include <windows.h>
-#  include <dxerr8.h>
+#  include <DxErr.h>
 #  if defined(_MSC_VER) && !defined(_XBOX)
-#    pragma comment(lib, "dxerr8.lib")
+#    pragma comment(lib, "DxErr.lib")
 #  endif
 #endif
 
@@ -363,7 +363,7 @@ CString hr_ssprintf( int hr, const char *fmt, ...)
 	char szError[1024] = "";
 	D3DXGetErrorString( hr, szError, sizeof(szError) );
 #else	
-	const char *szError = DXGetErrorString8( hr );
+	const char *szError = DXGetErrorString(hr);
 #endif
 
 	return s + ssprintf( " (%s)", szError );

--- a/src/arch/InputHandler/InputHandler_DirectInputHelper.cpp
+++ b/src/arch/InputHandler/InputHandler_DirectInputHelper.cpp
@@ -6,12 +6,12 @@
 #include "archutils/Win32/GraphicsWindow.h"
 
 #if defined(_MSC_VER)
-#pragma comment(lib, "dinput.lib")
+#pragma comment(lib, "dinput8.lib")
 #if defined(_WINDOWS)
 #pragma comment(lib, "dxguid.lib")
 #endif
 #endif
-LPDIRECTINPUT dinput = NULL;
+LPDIRECTINPUT8 dinput = NULL;
 
 static int ConvertScancodeToKey( int scancode );
 static BOOL CALLBACK DIJoystick_EnumDevObjectsProc(LPCDIDEVICEOBJECTINSTANCE dev, LPVOID data);
@@ -30,7 +30,7 @@ bool DIDevice::Open()
 	LOG->Trace( "Opening device '%s'", JoystickInst.tszProductName );
 	buffered = true;
 	
-	LPDIRECTINPUTDEVICE tmpdevice;
+	LPDIRECTINPUTDEVICE8 tmpdevice;
 	HRESULT hr = dinput->CreateDevice( JoystickInst.guidInstance, &tmpdevice, NULL );
 	if ( hr != DI_OK )
 	{
@@ -38,7 +38,7 @@ bool DIDevice::Open()
 		return false;
 	}
 
-	hr = tmpdevice->QueryInterface( IID_IDirectInputDevice2, (LPVOID *) &Device );
+	hr = tmpdevice->QueryInterface( IID_IDirectInputDevice8, (LPVOID *) &Device );
 	tmpdevice->Release();
 	if ( hr != DI_OK )
 	{

--- a/src/arch/InputHandler/InputHandler_DirectInputHelper.h
+++ b/src/arch/InputHandler/InputHandler_DirectInputHelper.h
@@ -3,9 +3,9 @@
 
 #include "InputFilter.h"
 
-#define DIRECTINPUT_VERSION 0x0500
+#define DIRECTINPUT_VERSION 0x0800
 #include <dinput.h>
-extern LPDIRECTINPUT dinput;
+extern LPDIRECTINPUT8 dinput;
 
 #define INPUT_QSIZE	32
 


### PR DESCRIPTION
This migrates the Direct 3D and DirectInput related code to DirectX 9. DirectX 8 headers and libs are hard to find these days and with DX9 at least SM5 and OpenITG share the same dependency, making the threshold for developing OpenITG somewhat lower.
DirectX 9 libs can be found in the following SDK: https://www.microsoft.com/en-us/download/details.aspx?id=6812 

Tested on windows 8.1. I ran through most screens I could think of, took screenshots, changed graphics settings etc. Seems to be working fine.
Since DX9 is also so old I dont think we will have any compatibility issues with older versions of windows. Hopefully people aren't running OpenITG on versions earlier than Windows XP.