### PR TITLE
Fixed crash when Simply Love sets preferences during startup

### DIFF
--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -382,7 +382,7 @@ bool LuaHelpers::RunExpressionS( const CString &str, CString &sOut )
 		RageException::Throw( "result is a function; did you forget \"()\"?" );
 
 	int isbool = lua_isboolean(L, -1);
-	if(isbool)
+	if( isbool )
 	{
 		/* lua_tostring automatically converts number to string, but not booleans */
 		int boolOut = lua_toboolean( L, -1 );
@@ -390,7 +390,11 @@ bool LuaHelpers::RunExpressionS( const CString &str, CString &sOut )
 	}
 	else
 	{
-		sOut = lua_tostring( L, -1 );
+		const char* luaString = lua_tostring( L, -1 );
+		if( luaString != NULL )
+			sOut = luaString;
+		else
+			sOut = "";
 	}
 
 	lua_pop( L, 1 );

--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -381,7 +381,18 @@ bool LuaHelpers::RunExpressionS( const CString &str, CString &sOut )
 	if( lua_isfunction( L, -1 ) )
 		RageException::Throw( "result is a function; did you forget \"()\"?" );
 
-	sOut = lua_tostring( L, -1 );
+	int isbool = lua_isboolean(L, -1);
+	if(isbool)
+	{
+		/* lua_tostring automatically converts number to string, but not booleans */
+		int boolOut = lua_toboolean( L, -1 );
+		sOut = boolOut ? "1" : "0";
+	}
+	else
+	{
+		sOut = lua_tostring( L, -1 );
+	}
+
 	lua_pop( L, 1 );
 
 	LUA->Release(L);


### PR DESCRIPTION
As reported in issue #41 by @concubidated, openitg crashes on startup with simply love as the default theme. This is because the theme sets preferences by doing:
```
[Preferences]
SoloSingle=@PREFSMAN:GetPreference('SoloSingle')
```

The lua expression evaluates to a boolean which cannot be converted to a string by lua_tostring, so it returns NULL.
The crash occurs in LuaManager.cpp on the line that reads:
`sOut = lua_tostring( L, -1 );`
In beta2, assigning null to a CString would produce an empty string.
In beta3 and master we get a null pointer exception.

The regression happened in commit e54e5c0959299034dfd7f594877805f536bfb7d3. StdString.h was updated to what I assume was a newer version. The new version no longer contained a null check, which ignored null pointers (in ssasn):

```
// Watch out for NULLs, as always.
if ( 0 == pA )
{
	sDst.erase();
}
```

I chose not to re-add the null check because:
1. It looks like a downstream change.
2. Initializing a CString with null should not be valid.
3. SM5 does not have it.
4. Fixing this bug would revert back to the old behavior, which does not crash, but it's probably still not correct. Sending null to CString gives you an empty string, meaning all lua expressions yielding a boolean would always get converted to empty strings.

I would appreciate if someone with more knowledge about theming could confirm the last point.

This closes #41 