### PR TITLE
Fixed crash on very long charts caused by MAX2 scoring calculation

### DIFF
--- a/src/ScoreKeeperMAX2.cpp
+++ b/src/ScoreKeeperMAX2.cpp
@@ -193,7 +193,7 @@ void ScoreKeeperMAX2::OnNextSong( int iSongInCourseIndex, const Steps* pSteps, c
 	m_iTapNotesHit = 0;
 }
 
-static int GetScore(int p, int B, int S, int n)
+static int GetScore(int p, int B, int64_t S, int n)
 {
 	/* There's a problem with the scoring system described below.  B/S is truncated
 	 * to an int.  However, in some cases we can end up with very small base scores.
@@ -275,8 +275,8 @@ void ScoreKeeperMAX2::AddScore( TapNoteScore score )
 
 	m_iTapNotesHit++;
 
-	const int N = m_iNumTapsAndHolds;
-	const int sum = (N * (N + 1)) / 2;
+	const int64_t N = m_iNumTapsAndHolds;
+	const int64_t sum = (N * (N + 1)) / 2;
 	const int B = m_iMaxPossiblePoints/10;
 
 	// Don't use a multiplier if the player has failed


### PR DESCRIPTION
Simple change that replaces a few ints with int64_t. Zetorux did an amazing job both finding the bug and laying out the technical details behind it.

Recreated the bug by making a 500 bpm chart filled with 48,000 notes with 64th spacing. Putting openitg on AutoPlayCPU crashed the game within 20 notes.

Verified that the above chart played all the way through after applying the fix.
Verified that it builds for both home and arcade on Debian i386.

This closes #44 