### PR TITLE
Fixed crash at ScreenSelectMusic

### DIFF
--- a/src/SongUtil.cpp
+++ b/src/SongUtil.cpp
@@ -123,7 +123,7 @@ void SongUtil::SortSongPointerArrayByGrade( vector<Song*> &vpSongsInOut )
 
 		CString foo;
 		foo.reserve(256);
-		for( int g=GRADE_TIER01; g<=GRADE_NO_DATA; ++g )
+		FOREACH_Grade(g)
 			AppendOctal( iCounts[g], 3, foo );
 		vals.push_back( val(pSong, foo) );
 	}
@@ -273,9 +273,9 @@ CString SongUtil::GetSectionNameFromSongAndSort( const Song* pSong, SortOrder so
 			int iCounts[NUM_GRADES];
 			PROFILEMAN->GetMachineProfile()->GetGrades( pSong, GAMESTATE->GetCurrentStyle()->m_StepsType, iCounts );
 
-			for( int i=GRADE_TIER01; i<NUM_GRADES; ++i )
+			FOREACH_Grade(g)
 			{
-				Grade g = (Grade)i;
+				int i = (int)g;
 				if( iCounts[i] > 0 )
 					return ssprintf( "%4s x %d", GradeToThemedString(g).c_str(), iCounts[i] );
 			}


### PR DESCRIPTION
For some reason the loop at SongUtil.cpp:126 did not respect its condition and kept going with larger and larger value of 'g' until it crashed.
Most likely it has to do with a newer compiler optimization. It doesn't happen on older versions of gcc nor does it happen in debug mode. But I don't know the exact details.

This closes #36 