### PR TITLE
Fixed a bug where patch data would not get loaded

### DIFF
--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -82,10 +82,8 @@
  * for arcade cabinets without testing it first... -- vyhd */
 
 #if defined(ITG_ARCADE) && defined(LINUX)
-#define PATCH_DIR	"/stats/patch"
 #define PATCH_FILE	"/rootfs/stats/patch/patch.zip"
 #else
-#define PATCH_DIR	"Data/patch"
 #define PATCH_FILE	"Data/patch/patch.zip"
 #endif
 
@@ -1045,12 +1043,19 @@ int main(int argc, char* argv[])
 	if( IsADirectory(PATCH_DATA_DIR) )
 	{
 		LOG->Info( "VFS: mounting Data/patch/patch/." );
-		FILEMAN->Mount( "dirro", PATCH_DATA_DIR, "/", false );
+
+		// IsADirectory checks against the VFS, but we need to mount against a physical path
+		CString physicalPath = FILEMAN->ResolvePath( PATCH_DATA_DIR );
+		FILEMAN->Mount( "dirro", physicalPath, "/", false );
 	}
 	else if( IsAFile(PATCH_FILE) )
 	{
 		LOG->Info( "VFS: mounting patch.zip." );
-		FILEMAN->Mount( "patch", PATCH_DIR, "/Patch" );
+
+		CString patchFileVirtualDir = Dirname(PATCH_FILE);
+		CString patchDirPhysicalPath = FILEMAN->ResolvePath( patchFileVirtualDir );
+
+		FILEMAN->Mount( "patch", patchDirPhysicalPath, "/Patch" );
 		FILEMAN->Mount( "zip", "/Patch/patch.zip", "/", false );
 	}
 	else


### PR DESCRIPTION
If you start openitg with a working directory other than that of the parent of the executable, patch data will fail to load. Which will among other problems cause a crash when entering options. 

The problem was that we tried to mount a relative physical path after checking that it exists against the VFS.
The solution is to keep the check against the VFS and then extract the absolute physical path to the checked virtual path using ResolvePath.

The bug does not occur on arcade builds.

I haven’t not tested arcade or windows builds.
I have tested mounting patches with both relative and absolute paths. The parameters sent to FILEMAN::Mount() are the same now as before, provided your current working directory was the same as the parent of the executable.

PATCH_DIR is no longer needed, which is good. PATCH_DIR referred to a physical path while PATCH_FILE refers to a virtual path. Because of this, when relative, they did not match.