### PR TITLE
1 excellent award is a green flag at the evaluation screen

### DIFF
--- a/assets/patch-data/Themes/default/Graphics/_award models/flag materials orange.txt
+++ b/assets/patch-data/Themes/default/Graphics/_award models/flag materials orange.txt
@@ -1,0 +1,19 @@
+Materials: 2
+"2 - Default"
+1 1 1 1
+1 1 1 1
+1 1 1 1
+0 0 0 1
+12.799999
+1.000000
+"flag pole.png"
+""
+"1 - Default"
+1 1 1 1
+1 1 1 1
+1 1 1 1
+0 0 0 1
+12.799999
+1.000000
+"flag orange.png"
+"flag sphere add.png"


### PR DESCRIPTION
If you get 1 excellent on a song the evaluation screen will show a green flag instead of an orange flag. The award for 1 excellent referred to an orange flag in the default theme but the material for the orange flag was green. This bug exists in the default theme in stock ITG2.

This is what it looks like in stock itg2 https://www.youtube.com/watch?v=ikI51b9pnNA 
(i just searched for "1 ex itg" and picked a random video confirming the bug. I assume they run stock itg2)