### PR TITLE
Removed unused custom song options 

### DIFF
--- a/assets/patch-data/Themes/default/Languages/english.ini
+++ b/assets/patch-data/Themes/default/Languages/english.ini
@@ -164,16 +164,12 @@ MenuTimer=Turn this &oq;OFF&cq; to disable time limits in menus.
 LifeDifficulty=Increasing this value causes the life meter to drain faster and refill slower.
 
 # ScreenOpenITGOptions
-AllowExtraPlayerOptions=Allow players to use additional USB profile features, such as custom speed modifiers and user-specific preferences.
 CourseEdits=Allow players to load custom courses from a USB drive.
 SoundVolumeAttract=Set the volume level during the attract sequence.
 SongEdits=Choose ON to allow songs to be played from a USB drive.
 LongVersion=Set the Long Version limit. Songs over this length will cost two rounds to play.
 MarathonVersion=Set the Marathon limit. Songs over this length will cost three rounds to play.
 CustomMaxSeconds=Set the absolute maximum length for custom songs. Any song that runs past this length will be rejected.
-CustomMaxSizeMB=Set the maximum music file size limit, in megabytes. 
-CustomMaxStepSizeKB=Set the maximum .SM file size limit, in kilobytes.
-CustomsLoadMax=Set the maximum amount of custom songs that may be loaded from any one profile. This limit applies separately to each player.
 CustomsLoadTimeout=Set the timeout for loading custom songs from a USB profile. This limit applies separately to each player.
 GiveUpTime=Set the amount of time required to give up a song with START.
 
@@ -305,16 +301,12 @@ OpenITG Options=
 Manage Packs=
 
 #ScreenOpenITGOptions
-AllowExtraPlayerOptions=Allow Extra::Player Options
 CourseEdits=Custom Courses
 SoundVolumeAttract=Attract Mode::Volume
 LongVersion=Long Version::Cutoff
 MarathonVersion=Marathon::Cutoff
 CustomMaxSeconds=Maximum::Length
 CustomsLoadTimeout=Load Timeout
-CustomsLoadMax=Custom Song::Limit
-CustomMaxSizeMB=Maximum::Audio Size
-CustomMaxStepSizeKB=Maximum::Step Size
 GiveUpTime=Give Up::Delay
 
 #ScreenOpenITGOptions - custom prefs

--- a/assets/patch-data/Themes/default/Scripts/LuaPrefs.lua
+++ b/assets/patch-data/Themes/default/Scripts/LuaPrefs.lua
@@ -80,20 +80,6 @@ function CustomMaxSecondsRow()
 	return CreatePrefsRow( Params, Names, Values, "CustomMaxSeconds" )
 end
 
-function CustomsLoadMaxRow()
-	-- start with 10, go to 100
-	local Values = {}
-	for i = 1,10 do Values[i] = 10*i end
-	Values[11] = 0
-
-	local Names = {}
-	for i = 1,10 do Names[i] = Values[i] end
-	Names[11] = "UNLIMITED"
-
-	local Params = { Name = "CustomsLoadMax" }
-	return CreatePrefsRow( Params, Names, Values, "CustomsLoadMax" )
-end
-
 function CustomsLoadTimeoutRow()
 	-- start with 1, go to 15
 	local Values = {}
@@ -106,29 +92,6 @@ function CustomsLoadTimeoutRow()
 
 	local Params = { Name = "CustomsLoadTimeout" }
 	return CreatePrefsRow( Params, Names, Values, "CustomsLoadTimeout" )
-end
-
-function CustomMaxSizeRow()
-	local Values = { 3, 4, 5, 6, 7, 8, 9, 10, 0 }
-
-	local Names = {}
-	for i = 1,8 do Names[i] = Values[i] .. " MB" end
-	Names[9] = "UNLIMITED"
-
-	local Params = { Name = "CustomMaxSizeMB" }
-
-	return CreatePrefsRow( Params, Names, Values, "CustomMaxSizeMB" )
-end
-
-function CustomMaxStepSizeRow()
-	-- offset by 30 KB, increments of 15 KB up to 150 KB and unlimited
-	local Names = {}
-	for i=1,9 do Names[i] = (30+((i-1)*15)) .. "KB" end
-	Names[10] = "UNLIMITED"
-
-	local Params = { Name = "CustomMaxStepSizeKB" }
-
-	return CreatePrefsRowRange( Params, Names, "CustomMaxStepSizeKB", 30, 15 )
 end
 
 -- Base function for the below derivations
@@ -191,6 +154,27 @@ function GiveUpTimeRow()
 
 	local Params = { Name="GiveUpTime" }
 	return CreateOptionRow( Params, Names, Load, Save )
+end
+
+-- Deprecated functions
+function CustomsLoadMaxRow()
+	return DeprecatedRow( "CustomsLoadMax" )
+end
+
+function CustomMaxSizeRow()
+	return DeprecatedRow( "CustomMaxSizeMB" )
+end
+
+function CustomMaxStepSizeRow()
+	return DeprecatedRow( "CustomMaxStepSizeKB" )
+end
+
+function DeprecatedRow( name )
+	Debug( name .. " is deprecated." )
+	local Names = { name .. " is deprecated" }
+	local Values = { 1 }
+	local Params = { Name = "DeprecatedOption" }
+	return CreatePrefsRow( Params, Names, Values, "DeprecatedOption" )
 end
 
 local function deprecated( name )

--- a/assets/patch-data/Themes/default/metrics.ini
+++ b/assets/patch-data/Themes/default/metrics.ini
@@ -3575,7 +3575,7 @@ Line1=lua,ThemeSwitcher("ScreenTitleJoin")
 # It's pretty nice, really.
 [ScreenOpenITGOptions]
 Fallback=ScreenOptionsSubmenu
-LineNames=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16
+LineNames=1,2,3,4,5,6,8,9,11,14,15,16
 OptionMenuFlags=together;explanations
 Line1=lua,ThemeSwitcher('ScreenOptionsMenu')
 Line2=lua,SoundVolumeAttractRow()
@@ -3583,13 +3583,9 @@ Line3=lua,CreditTypeRow()
 Line4=lua,MusicSelectSecondsRow()
 Line5=lua,GiveUpTimeRow()
 Line6=lua,CustomPrefsRowBoolSimple('UseOldLogo')
-Line7=lua,CreateSimplePrefsRowBool('AllowExtraPlayerOptions')
 Line8=lua,CreateSimplePrefsRowBool('SongEdits')
 Line9=lua,CreateSimplePrefsRowBool('CourseEdits')
-Line10=lua,CustomsLoadMaxRow()
 Line11=lua,CustomsLoadTimeoutRow()
-Line12=lua,CustomMaxSizeRow()
-Line13=lua,CustomMaxStepSizeRow()
 Line14=lua,CustomMaxSecondsRow()
 Line15=lua,LongVersionRow()
 Line16=lua,MarathonVersionRow()


### PR DESCRIPTION
Removed CustomsLoadMax, CustomMaxSizeMB, CustomMaxStepSizeKB and AllowExtraPlayerOptions. They were previously removed from PrefsManager.cpp but not from the theme.

Backwards compatibility is preserved by keeping the lua functions but returning dummy option rows. Themes using the deprecated lua functions wont crash.