### PR TITLE
Switch theme crash

### DIFF
--- a/src/Preference.h
+++ b/src/Preference.h
@@ -64,6 +64,11 @@ public:
 		return m_currentValue;
 	}
 	
+	const T &GetDefault() const
+	{
+		return m_defaultValue;
+	}
+	
 	operator const T () const
 	{
 		return Get();

--- a/src/PrefsManager.cpp
+++ b/src/PrefsManager.cpp
@@ -295,6 +295,7 @@ PrefsManager::PrefsManager() :
 	m_bLogCheckpoints				( "LogCheckpoints",				false ),
 
 	/* Game-specific prefs: */
+	m_sTheme						( "Theme",						"default" ),
 	m_sDefaultModifiers				( "DefaultModifiers",			"" )
 
 #if defined(XBOX)

--- a/src/PrefsManager.h
+++ b/src/PrefsManager.h
@@ -312,6 +312,7 @@ public:
 	Preference<bool>	m_bLogCheckpoints;
 
 	/* Game-specific prefs: */
+	Preference<CString> m_sTheme;
 	Preference<CString>	m_sDefaultModifiers;
 
 #if defined(XBOX)

--- a/src/ScreenOptionsMaster.cpp
+++ b/src/ScreenOptionsMaster.cpp
@@ -221,7 +221,7 @@ void ScreenOptionsMaster::HandleScreenMessage( const ScreenMessage SM )
 			// Override ScreenOptions's calling of ExportOptions
 			//
 			m_iChangeMask = 0;
-		
+
 			CHECKPOINT;
 
 			for( unsigned r = 0; r < OptionRowHandlers.size(); ++r )
@@ -247,7 +247,11 @@ void ScreenOptionsMaster::HandleScreenMessage( const ScreenMessage SM )
 			if( (m_iChangeMask & OPT_APPLY_THEME) || 
 				(m_iChangeMask & OPT_APPLY_GRAPHICS) ||
 				(m_iChangeMask & OPT_APPLY_ASPECT_RATIO) )
+			{
+				CString sNewTheme = PREFSMAN->m_sTheme.Get();
+				THEME->SwitchThemeAndLanguage( sNewTheme, THEME->GetCurLanguage() );
 				ApplyGraphicOptions();
+			}
 
 			if( m_iChangeMask & OPT_SAVE_PREFERENCES )
 			{

--- a/src/ScreenOptionsMasterPrefs.cpp
+++ b/src/ScreenOptionsMasterPrefs.cpp
@@ -187,12 +187,12 @@ static void Theme( int &sel, bool ToSel, const ConfOption *pConfOption )
 	{
 		sel = 0;
 		for( unsigned i=1; i<choices.size(); i++ )
-			if( !stricmp(choices[i], THEME->GetCurThemeName()) )
+			if( !stricmp(choices[i], PREFSMAN->m_sTheme.Get()) )
 				sel = i;
 	} else {
 		const CString sNewTheme = choices[sel];
 		if( THEME->GetCurThemeName() != sNewTheme )
-			THEME->SwitchThemeAndLanguage( sNewTheme, THEME->GetCurLanguage() );
+			PREFSMAN->m_sTheme.Set( sNewTheme ); // OPT_APPLY_THEME will load the theme
 	}
 }
 

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -301,7 +301,7 @@ void ResetGame()
 		if( THEME->DoesThemeExist( sGameName ) )
 			THEME->SwitchThemeAndLanguage( sGameName, THEME->GetCurLanguage() );
 		else
-			THEME->SwitchThemeAndLanguage( "default", THEME->GetCurLanguage() );
+			THEME->SwitchThemeAndLanguage( PREFSMAN->m_sTheme.GetDefault(), THEME->GetCurLanguage() );
 		TEXTUREMAN->DoDelayedDelete();
 	}
 	SaveGamePrefsToDisk();
@@ -818,6 +818,7 @@ void ReadGamePrefsFromDisk( bool bSwitchToLastPlayedGame )
 	ini.GetValue( sGameName, "Announcer",			sAnnouncer );
 	ini.GetValue( sGameName, "Theme",				sTheme );
 	ini.GetValue( sGameName, "DefaultModifiers",	sDefaultModifiers );
+	PREFSMAN->m_sTheme.Set( sTheme );
 	PREFSMAN->m_sDefaultModifiers.Set( sDefaultModifiers );
 
 	// it's OK to call these functions with names that don't exist.
@@ -838,7 +839,7 @@ void SaveGamePrefsToDisk()
 	ini.ReadFile( GAMEPREFS_INI_PATH );	// it's OK if this fails
 
 	ini.SetValue( sGameName, "Announcer",			ANNOUNCER->GetCurAnnouncerName() );
-	ini.SetValue( sGameName, "Theme",				THEME->GetCurThemeName() );
+	ini.SetValue( sGameName, "Theme",				PREFSMAN->m_sTheme );
 	ini.SetValue( sGameName, "DefaultModifiers",	PREFSMAN->m_sDefaultModifiers );
 	ini.SetValue( "Options", "Game",				(CString)GAMESTATE->GetCurrentGame()->m_szName );
 

--- a/src/ThemeManager.cpp
+++ b/src/ThemeManager.cpp
@@ -266,6 +266,8 @@ void ThemeManager::SwitchThemeAndLanguage( const CString &sThemeName, const CStr
 	m_sCurThemeName = sTheme;
 	m_sCurLanguage = sLang;
 
+	PREFSMAN->m_sTheme.Set( sTheme );
+
 	// clear theme path cache
 	for( int i = 0; i < NUM_ElementCategory; ++i )
 		g_ThemePathCache[i].clear();


### PR DESCRIPTION
Fixed a crash that would happen anytime the theme is changed using the standard option row metric "conf,Theme". The bug affects virtually all themes including Simply love and GrooveNights. The only theme i found that did not have the bug is the default theme. It has a custom theme switcher which circumvents the problem with "conf,Theme".
The problem was that all option rows are saved in the order they are showed on screen. Saving the theme option causes an immediate theme switch which unloads all lua scripts the previous theme had loaded.
When the following option row is saved it will fail and crash if it calls a lua function that was unloaded. The introduction of Theme as a preference does not change the fact that GamePrefs.ini stores what theme is actually supposed to be used. This solution was borrowed from SM4 where the same problem could be found. The theme preference is needed to delay switching the theme.