### PR TITLE
Pop lua stack after RunScript fails

### DIFF
--- a/src/LuaReference.cpp
+++ b/src/LuaReference.cpp
@@ -63,9 +63,11 @@ void LuaReference::SetFromStack( Lua *L )
 	m_iReference = luaL_ref( L, LUA_REGISTRYINDEX );
 }
 
-void LuaReference::SetFromNil()
+void LuaReference::SetFromNil( Lua *L )
 {
 	Unregister();
+	
+	lua_pop( L, 1 );
 	m_iReference = LUA_REFNIL;
 }
 
@@ -145,7 +147,7 @@ void LuaExpression::Register()
 
 	if( !LuaHelpers::RunScript(L, m_sExpression, "expression", 1, m_bSandboxed) )
 	{
-		this->SetFromNil();
+		this->SetFromNil( L );
 		LUA->Release( L );
 		return;
 	}

--- a/src/LuaReference.h
+++ b/src/LuaReference.h
@@ -19,7 +19,7 @@ public:
 	/* Create a reference pointing to the item at the top of the stack, and pop
 	 * the stack. */
 	void SetFromStack( Lua *L );
-	void SetFromNil();
+	void SetFromNil( Lua *L );
 
 	/* Push the referenced object onto the stack.  If not set (or set to nil), push nil. */
 	virtual void PushSelf( Lua *L ) const;


### PR DESCRIPTION
Found this while debugging the theme switch crash. It's a separate bug and Im not sure if it is ever a problem. 
I reproduced it by switching themes in Simply love. The game crashed because of an assert in OptionRowHandler.cpp:836
`ASSERT( lua_gettop(L) == 0 );`
OptionRowHandlerLua::ExportOption expects the lua stack to be empty. Because SetFromNil() never pops the stack, values from failed RunScript invocations are left on the stack.