### PR TITLE
Fixed subtractive scoring

### DIFF
--- a/src/ScoreKeeperMAX2.cpp
+++ b/src/ScoreKeeperMAX2.cpp
@@ -347,12 +347,11 @@ void ScoreKeeperMAX2::HandleTapRowScore( TapNoteScore scoreOfLastTap, int iNumTa
 	// Update dance points.
 	if( !m_pPlayerStageStats->bFailed )
 		m_pPlayerStageStats->iActualDancePoints += TapNoteScoreToDancePoints( scoreOfLastTap );
-	m_pPlayerStageStats->iCurPossibleDancePoints += TapNoteScoreToDancePoints( TNS_MARVELOUS );
+
 	// update judged row totals
 	m_pPlayerStageStats->iTapNoteScores[scoreOfLastTap] += 1;
 
 	// increment the current total possible dance score
-
 	m_pPlayerStageStats->iCurPossibleDancePoints += TapNoteScoreToDancePoints( TNS_MARVELOUS );
 
 	//
@@ -417,11 +416,10 @@ void ScoreKeeperMAX2::HandleHoldScore( HoldNoteScore holdScore, TapNoteScore tap
 	// update dance points totals
 	if( !m_pPlayerStageStats->bFailed )
 		m_pPlayerStageStats->iActualDancePoints += HoldNoteScoreToDancePoints( holdScore );
-	m_pPlayerStageStats->iCurPossibleDancePoints += HoldNoteScoreToDancePoints( HNS_OK );
+
 	m_pPlayerStageStats->iHoldNoteScores[holdScore] ++;
 
 	// increment the current total possible dance score
-
 	m_pPlayerStageStats->iCurPossibleDancePoints += HoldNoteScoreToDancePoints( HNS_OK );
 
 	if( holdScore == HNS_OK )


### PR DESCRIPTION
In ScoreKeeperMAX2.cpp, iCurPossibleDancePoints would grow at least twice as fast as your actual dance points, which means getting a fantastic will still subtract from your score. You always end up with 0% at the end of the song. This was easily reproduced by enabling subtractive scoring in PlayerOptions.cpp:36
`m_ScoreDisplay = SCORING_SUBTRACT;`

I also logged the resulting dance points after each call to HandleTapRowScore. This is from a chart with 4 notes. iCurPossibleDancePoints makes no sense.

> iPossibleDancePoints = 35, iCurPossibleDancePoints = 10, iActualDancePoints = 0
> iPossibleDancePoints = 35, iCurPossibleDancePoints = 30, iActualDancePoints = 10
> iPossibleDancePoints = 35, iCurPossibleDancePoints = 50, iActualDancePoints = 20
> iPossibleDancePoints = 35, iCurPossibleDancePoints = 70, iActualDancePoints = 27

And this is after the fix:

> iPossibleDancePoints = 35, iCurPossibleDancePoints = 5, iActualDancePoints = 5
> iPossibleDancePoints = 35, iCurPossibleDancePoints = 15, iActualDancePoints = 15
> iPossibleDancePoints = 35, iCurPossibleDancePoints = 25, iActualDancePoints = 25
> iPossibleDancePoints = 35, iCurPossibleDancePoints = 35, iActualDancePoints = 35

Both SM4 (partially) and SM5 have fixed the bug in the same way.