### PR TITLE
Dont reset rate mod between songs

### DIFF
--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -139,9 +139,6 @@ void ScreenSelectMusic::Init()
 	/* Load low-res banners, if needed. */
 	BANNERCACHE->Demand();
 
-	// About 3/4 of the time, the user forgets this was set.  Let's cut him/her some slack.
-	GAMESTATE->m_SongOptions.m_fMusicRate = 1.0f;
-
 	m_MusicWheel.Load( MUSIC_WHEEL_TYPE );
 
 	// pop'n music has this under the songwheel...


### PR DESCRIPTION
Requested by MadMatt here: http://www.aaronin.jp/boards/viewtopic.php?p=477190#477190
And by Zetorux here: http://www.aaronin.jp/boards/viewtopic.php?p=470894#470894

I think its a sensible change, this way we dont reset the rate mod just like we dont reset other options. Its also a behavioral difference between openitg and 3.95/itg2. Themes may rely on the fact that the rate mod is not reset. 
Simply love does exactly that and it causes the displayed rate mod to get out of sync with the actually used rate mod. But only in openitg.