### PR TITLE
Updates to autotools scripts

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,11 +1,13 @@
 # only tested with autoconf 2.57
 AC_PREREQ(2.53)
-AC_INIT(src/StepMania.cpp)
+
+AC_INIT([OpenITG], [1.0])
+AC_CONFIG_SRCDIR([src/StepMania.cpp])
+
 AC_CONFIG_AUX_DIR(autoconf)
 AC_CANONICAL_TARGET
-
-AM_INIT_AUTOMAKE(OpenITG, 1.01)
-AM_CONFIG_HEADER(src/config.h)
+AM_INIT_AUTOMAKE([subdir-objects])
+AM_CONFIG_HEADER([src/config.h])
 AM_MAINTAINER_MODE
 
 # We don't want PROG_CC/CXX default settings, but don't ignore explicit settings.


### PR DESCRIPTION
The goal is to make the package configuration run better on modern linux aswell as the older debian sarge used to build itg arcade compatible binaries.

I'm starting with updates to configure.ac for newer versions of autoconf. The changes are also backwards compatible with the sarge environment, I tested to make sure.