### PR TITLE
Fixed crash when reloading songs

### DIFF
--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -512,6 +512,7 @@ void SongManager::FreeSongs()
 
 	for( unsigned i=0; i<m_pSongs.size(); i++ )
 		SAFE_DELETE( m_pSongs[i] );
+	m_pSongs.clear();
 
 	m_sSongGroupBannerPaths.clear();
 


### PR DESCRIPTION
Reloading songs in the options menu crashes the game 100% of the time.

After deleting all objects in m_pSongs, FreeSongs() left the list full of NULL values causing a crash later when searching for songs in that list.