### PR TITLE
Conditionally remount /itgdata as writable only once during startup

### DIFF
--- a/src/ScreenUserPacks.cpp
+++ b/src/ScreenUserPacks.cpp
@@ -336,9 +336,7 @@ void ScreenUserPacks::HandleScreenMessage( const ScreenMessage SM )
 		m_PlayerSongLoadThread.Wait();
 
 		MountMutex.Lock();
-#if defined(LINUX) && defined(ITG_ARCADE)
-		system( "mount -o remount,rw /itgdata" );
-#endif
+
 		MEMCARDMAN->LockCards();
 		MEMCARDMAN->MountCard(m_CurPlayer, 99999);
 		CString sSelection = m_USBZips.GetCurrentSelection();
@@ -377,7 +375,6 @@ m_PlayerSongLoadThread.Create( InitSASSongThread, this )
 		}
 #if defined(LINUX) && defined(ITG_ARCADE)
 		sync();
-		system( "mount -o remount,ro /itgdata" );
 #endif
 		SCREENMAN->HideOverlayMessage();
 		SCREENMAN->ZeroNextUpdate();

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -84,13 +84,7 @@ void SongManager::Reload( LoadingWindow *ld )
 	const bool OldVal = PREFSMAN->m_bFastLoad;
 	PREFSMAN->m_bFastLoad.Set( false );
 
-#if defined(LINUX) && defined(ITG_ARCADE)
-	system("mount -o remount,rw /itgdata");
-#endif
 	InitAll( ld );
-#if defined(LINUX) && defined(ITG_ARCADE)
-	system("mount -o remount,ro /itgdata");
-#endif
 
 	// reload scores afterward
 	PROFILEMAN->LoadMachineProfile();

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -1149,18 +1149,8 @@ int main(int argc, char* argv[])
 	/* depends on SONGINDEX: */
 	SONGMAN		= new SongManager();
 
-	//
-	// 9/25/08: moved the cache sink to /itgdata because
-	//    it would fill up all of stats if the user has too many songs
-	//       --infamouspat
-	//
-#ifdef ITG_ARCADE
-	system( "mount -o remount,rw /itgdata" );
-#endif
 	SONGMAN->InitAll( loading_window );		// this takes a long time
-#ifdef ITG_ARCADE
-	system( "mount -o remount,ro /itgdata" );
-#endif
+
 	CRYPTMAN	= new CryptManager;	// need to do this before ProfileMan
 	MEMCARDMAN	= new MemoryCardManager;
 	PROFILEMAN	= new ProfileManager;

--- a/src/UserPackManager.cpp
+++ b/src/UserPackManager.cpp
@@ -41,15 +41,8 @@ bool UserPackManager::Remove( const CString &sPack )
 	FILEMAN->Unmount( "zip", sPack, "/Songs" );
 	FILEMAN->Unmount( "zip", sPack, "/" );
 
-#if defined(LINUX) && defined(ITG_ARCADE)
-	system( "mount -o remount,rw /itgdata" );
-#endif
-
 	bool bDeleted = FILEMAN->Remove( sPack );
 
-#if defined(LINUX) && defined(ITG_ARCADE)
-	system( "mount -o remount,ro /itgdata" );
-#endif
 	/* refresh directory data after deletion */
 	FILEMAN->FlushDirCache( USER_PACK_SAVE_PATH );
 

--- a/src/arch/ArchHooks/ArchHooks_Unix.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Unix.cpp
@@ -18,6 +18,7 @@
 #include <sys/io.h>
 #include <unistd.h>
 #include <cerrno>
+#include <mntent.h>
 
 extern "C"
 {
@@ -52,6 +53,37 @@ static bool IsFatalSignal( int signal )
 	}
 }
 
+static bool IsReadOnlyMountPoint( const CString &mountPoint )
+{
+	CHECKPOINT;
+	struct mntent *ent;
+	bool found = false;
+	bool isReadOnly = false;
+	
+	FILE *aFile;
+	aFile = setmntent( "/proc/mounts", "r" );
+	if( aFile == NULL )
+	{
+		LOG->Warn( "Can't open /proc/mounts to determine if " + mountPoint + " is a readonly filesystem mountpoint" );
+		return false;
+	}
+	
+	while( (ent = getmntent( aFile )) != NULL )
+	{
+		CString mountDir = ent->mnt_dir;
+		
+		if( mountDir == mountPoint )
+		{
+			found = true;
+			isReadOnly = hasmntopt( ent, "ro" ) != NULL;
+			break;
+		}
+	}
+	
+	endmntent( aFile );
+	return found && isReadOnly;
+}
+
 void ArchHooks_Unix::MountInitialFilesystems( const CString &sDirOfExecutable )
 {
 	/* Mount the root filesystem, so we can read files in /proc, /etc, and so on.
@@ -76,6 +108,15 @@ struct stat st;
 */
 
 #ifdef ITG_ARCADE
+	/* Stock ITG2 filesystem configuration has /stats and /itgdata as their own xfs partitions.
+	 * /stats is writable and /itgdata is readonly.
+	 * Because disk space is sparse in /stats, OpenITG depends on /itgdata to be writable aswell.
+	 * Primarily userpacks and cache is stored by OpenITG in /itgdata.
+	 * Some users may not have configured /itgdata as its own partition, but rather just a directory.
+	 * For them, assume its writable. */
+	if( IsReadOnlyMountPoint( "/itgdata" ) )
+		system( "mount -o remount,rw /itgdata" );
+
 	/* ITG-specific arcade paths */
 	FILEMAN->Mount( "prb", "/itgdata", "/Packages" );
 	FILEMAN->Mount( "dir", "/stats", "/Data" );


### PR DESCRIPTION
Consolidated the responsibility of /itgdata to where it is mounted in the VFS. This way users of the VFS wont have to have intimate knowledge of whether the underlying fs is writable or not.
This does open up /itgdata for writing more than previously, and we might want to keep that to a minimum. But as I see it, that ship has sailed.

This change brings a few advantages:
* Cleaner code. Knowledge of mount options wont have to be spread out across the codebase.
* Respects changes a user might have done in /etc/fstab. For example this: http://aaronin.jp/boards/viewtopic.php?t=10760
* The arcade build is more tolerant towards different system configurations, making running openitg easier.
* Backwards compatibility is preserved.