### PR TITLE
Compile error with multiple git tags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -330,7 +330,7 @@ else
 fi
 
 if test "$have_git_repo" = "yes"; then
-	build_version=`git tag`
+	build_version=`git describe --abbrev=0`
 	build_rev_date=`git log -1 --pretty="format:%ad" --date="short"`
 	build_rev_tag=`git describe`
 


### PR DESCRIPTION
Running configure with multiple git tags caused config.h to get corrupted. git tag outputs multiple lines which is not expected by the code.
We would get a macro definition without a closing quote:
#define BUILD_VERSION "beta3

Which later causes a compile error.
git describe --abbrev=0 does what we want. It gets only the latest tag on short form (only the tag name).