### PR TITLE
ffmpeg autoconf improvements

### DIFF
--- a/autoconf/m4/ffmpeg.m4
+++ b/autoconf/m4/ffmpeg.m4
@@ -90,9 +90,7 @@ if test "$with_ffmpeg" = "yes"; then
         ffmpeg_option=legacy
         AC_DEFINE(HAVE_LEGACY_FFMPEG, 1, [Legacy FFMPEG support available])
         AC_DEFINE(HAVE_FFMPEG, 1, [FFMPEG support available])
-        
-        #CFLAGS=" $CFLAGS"
-		#CXXFLAGS="$FFMPEG_CXXFLAGS $CXXFLAGS"
+
 		LIBS="-L$PWD/src/ffmpeg/lib -lavformat -lavcodec $LIBS"
     fi
 fi

--- a/autoconf/m4/ffmpeg.m4
+++ b/autoconf/m4/ffmpeg.m4
@@ -1,0 +1,103 @@
+AC_DEFUN([SM_FFMPEG], [
+
+AC_ARG_WITH(ffmpeg, AS_HELP_STRING([--without-ffmpeg],[Disable ffmpeg support]), with_ffmpeg=$withval, with_ffmpeg=yes)
+AC_ARG_WITH(legacy-ffmpeg, AS_HELP_STRING([--with-legacy-ffmpeg],[Use bundled static legacy ffmpeg libraries]), with_legacy_ffmpeg=$withval, with_legacy_ffmpeg=no)
+
+have_ffmpeg=no
+
+if test "$with_ffmpeg" = "yes"; then
+    if test "$with_legacy_ffmpeg" = "no"; then
+
+        if pkg-config --libs libavcodec &> /dev/null; then AVCODEC_LIBS="`pkg-config --libs libavcodec`"; else AVCODEC_LIBS="-lavcodec"; fi
+		if pkg-config --libs libavformat &> /dev/null; then AVFORMAT_LIBS="`pkg-config --libs libavformat`"; else AVFORMAT_LIBS="-lavcodec"; fi
+		if pkg-config --libs libswscale &> /dev/null; then SWSCALE_LIBS="`pkg-config --libs libswscale`"; else SWSCALE_LIBS="-swscale"; fi
+        if pkg-config --libs libavutil &> /dev/null; then AVUTIL_LIBS="`pkg-config --libs libavutil`"; else AVUTIL_LIBS="-lavutil"; fi
+        
+        if pkg-config --cflags libavcodec &> /dev/null; then AVCODEC_CFLAGS="`pkg-config --cflags libavcodec`"; else AVCODEC_CFLAGS=""; fi
+		if pkg-config --cflags libavformat &> /dev/null; then AVFORMAT_CFLAGS="`pkg-config --cflags libavformat`"; else AVFORMAT_CFLAGS=""; fi
+		if pkg-config --cflags libswscale &> /dev/null; then SWSCALE_CFLAGS="`pkg-config --cflags libswscale`"; else SWSCALE_CFLAGS=""; fi
+        if pkg-config --cflags libavutil &> /dev/null; then AVUTIL_CFLAGS="`pkg-config --cflags libavutil`"; else AVUTIL_CFLAGS="-lavutil"; fi
+        
+        ffmpeg_save_CFLAGS="$CFLAGS"
+		ffmpeg_save_CXXFLAGS="$CXXFLAGS"
+		ffmpeg_save_LIBS="$LIBS"
+
+        FFMPEG_CFLAGS="$AVUTIL_CFLAGS $AVCODEC_CFLAGS $AVFORMAT_CFLAGS $SWSCALE_CFLAGS"
+		FFMPEG_CXXFLAGS="$AVUTIL_CFLAGS $AVCODEC_CFLAGS $AVFORMAT_CFLAGS $SWSCALE_CFLAGS"
+		FFMPEG_LIBS="$AVUTIL_LIBS $AVCODEC_LIBS $AVFORMAT_LIBS $SWSCALE_LIBS"
+
+        CFLAGS="$FFMPEG_CFLAGS $CFLAGS"
+		CXXFLAGS="$FFMPEG_CXXFLAGS $CXXFLAGS"
+		LIBS="$FFMPEG_LIBS $LIBS"
+
+		AC_CHECK_FUNC([avcodec_find_decoder], have_libavcodec=yes, have_libavcodec=no)
+		AC_CHECK_FUNC([avformat_open_input], have_libavformat=yes, have_libavformat=no)
+		AC_CHECK_FUNC([swscale_version], have_libswscale=yes, have_libswscale=no)
+        AC_CHECK_FUNC([av_frame_free], have_libavutil=yes, have_libavutil=no)
+
+        if test "$have_libavcodec" = "yes"; then
+        AC_MSG_CHECKING([for libavcodec >= 0.5.2])
+        AC_TRY_RUN([
+            #include <libavcodec/avcodec.h>
+            int main()
+            {
+                return ( LIBAVCODEC_VERSION_INT < 0x341401 )? 1:0;
+            }
+            ],,have_libavcodec=no,)
+        AC_MSG_RESULT($have_libavcodec)
+        fi
+
+        if test "$have_libavformat" = "yes"; then
+        AC_MSG_CHECKING([for libavformat >= 0.5.2])
+        AC_TRY_RUN([
+            #include <libavformat/avformat.h>
+            int main()
+            {
+                return ( LIBAVFORMAT_VERSION_INT < 0x341F00 )? 1:0;
+            }
+            ],,have_libavformat=no,)
+        AC_MSG_RESULT($have_libavformat)
+        fi
+
+        if test "$have_libswscale" = "yes"; then
+        AC_MSG_CHECKING([for libswscale >= 0.5.2])
+        AC_TRY_RUN([
+            #include <libswscale/swscale.h>
+            int main()
+            {
+                return ( LIBSWSCALE_VERSION_INT < 0x000701 )? 1:0;
+            }
+            ],,have_libswscale=no,)
+        AC_MSG_RESULT($have_libswscale)
+        fi
+
+        CFLAGS="$ffmpeg_save_CFLAGS"
+		CXXFLAGS="$ffmpeg_save_CXXFLAGS"
+		LIBS="$ffmpeg_save_LIBS"
+
+        if test "$have_libavformat" = "yes" -a "$have_libavcodec" = "yes" \
+                -a "$have_libswscale" = "yes" -a "$have_libavutil" = "yes"; then
+            have_ffmpeg=yes
+            ffmpeg_option=shared
+            AC_DEFINE(HAVE_FFMPEG, 1, [FFMPEG support available])
+            
+            CFLAGS="$FFMPEG_CFLAGS $CFLAGS"
+		    CXXFLAGS="$FFMPEG_CXXFLAGS $CXXFLAGS"
+		    LIBS="$FFMPEG_LIBS $LIBS"
+        fi
+    else
+        have_ffmpeg=yes
+        ffmpeg_option=legacy
+        AC_DEFINE(HAVE_LEGACY_FFMPEG, 1, [Legacy FFMPEG support available])
+        AC_DEFINE(HAVE_FFMPEG, 1, [FFMPEG support available])
+        
+        #CFLAGS=" $CFLAGS"
+		#CXXFLAGS="$FFMPEG_CXXFLAGS $CXXFLAGS"
+		LIBS="-L$PWD/src/ffmpeg/lib -lavformat -lavcodec $LIBS"
+    fi
+fi
+
+AM_CONDITIONAL(HAVE_FFMPEG, test "$have_ffmpeg" = "yes")
+AM_CONDITIONAL(HAVE_LEGACY_FFMPEG, test "$have_ffmpeg" = "yes" -a "$ffmpeg_option" = "legacy")
+
+])

--- a/build-arcade.sh
+++ b/build-arcade.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 ./autogen.sh
-./configure --with-x --with-gnu-ld --enable-itg-arcade --target=i386-pc-linux-gnu --host=i386-pc-linux-gnu
+./configure --with-x --with-gnu-ld --enable-itg-arcade --with-legacy-ffmpeg --target=i386-pc-linux-gnu --host=i386-pc-linux-gnu
 if [ "x$1" == "x" ];
 then
 	make

--- a/configure.ac
+++ b/configure.ac
@@ -180,6 +180,7 @@ SM_ZLIB
 SM_AUDIO
 SM_TLS
 SM_LIBUSB
+SM_FFMPEG
 
 # for linux joystick hotplug
 have_inotify=no
@@ -188,71 +189,22 @@ AC_CHECK_HEADER([sys/inotify.h],
 	AC_DEFINE(HAVE_INOTIFY, 1, [inotify support in kernel])
 ,)
 
-have_ffmpeg=static
 have_libresample=static
-have_sse2=no
 
 # search for system libs if not building for arcade
 if test "$itg_arcade" = "no"; then
-	AC_SEARCH_LIBS(avcodec_find_decoder, [avcodec], have_libavcodec=yes, have_libavcodec=no)
-	AC_SEARCH_LIBS(avformat_open_input, [avformat], have_libavformat=yes, have_libavformat=no)
-	AC_SEARCH_LIBS(swscale_version, [swscale], have_libswscale=yes, have_libswscale=no)
-    AC_SEARCH_LIBS(av_frame_free, [avutil], have_libavutil=yes, have_libavutil=no)
-
 	have_libresample=yes
 	AC_CHECK_LIB(resample, resample_open, [x=y], have_libresample=static, [-lm])
 	if test "$have_libresample" = "yes"; then
 		LIBS="$LIBS -lresample"
 	fi
-
-	if test "$have_libavcodec" = "yes"; then
-	  AC_MSG_CHECKING([for libavcodec >= 0.5.2])
-	  AC_TRY_RUN([
-	      #include <libavcodec/avcodec.h>
-	      int main()
-	      {
-		      return ( LIBAVCODEC_VERSION_INT < 0x341401 )? 1:0;
-	      }
-	      ],,have_libavcodec=no,)
-	  AC_MSG_RESULT($have_libavcodec)
-	fi
-
-	if test "$have_libavformat" = "yes"; then
-	  AC_MSG_CHECKING([for libavformat >= 0.5.2])
-	  AC_TRY_RUN([
-	      #include <libavformat/avformat.h>
-	      int main()
-	      {
-		      return ( LIBAVFORMAT_VERSION_INT < 0x341F00 )? 1:0;
-	      }
-	      ],,have_libavformat=no,)
-	  AC_MSG_RESULT($have_libavformat)
-	fi
-
-	if test "$have_libswscale" = "yes"; then
-	  AC_MSG_CHECKING([for libswscale >= 0.5.2])
-	  AC_TRY_RUN([
-	      #include <libswscale/swscale.h>
-	      int main()
-	      {
-		      return ( LIBSWSCALE_VERSION_INT < 0x000701 )? 1:0;
-	      }
-	      ],,have_libswscale=no,)
-	  AC_MSG_RESULT($have_libswscale)
-	fi
-
-	if test "$have_libavformat" = "yes" -a "$have_libavcodec" = "yes" \
-            -a "$have_libswscale" = "yes" -a "$have_libavutil" = "yes"; then
-		have_ffmpeg=yes
-		AC_DEFINE(HAVE_FFMPEG, 1, [FFMPEG support available])
-	fi
-
-	# test if processor supports SSE2
-	AC_TRY_RUN([int main() { int a,d; asm ("cpuid":"=a"(a),"=d"(d):"0"(1)); return d & (1 << 26) ? 0 : 1; }], have_sse2=yes, have_sse2=no)
 fi
 
-AM_CONDITIONAL(HAVE_FFMPEG, test "$have_ffmpeg" = "yes")
 AM_CONDITIONAL(HAVE_LIBRESAMPLE, test "$have_libresample" = "yes")
+
+# test if processor supports SSE2
+have_sse2=no
+AC_TRY_RUN([int main() { int a,d; asm ("cpuid":"=a"(a),"=d"(d):"0"(1)); return d & (1 << 26) ? 0 : 1; }], have_sse2=yes, have_sse2=no)
 
 # Don't use SSE2 by default; some GCC versions misoptimise the code, which
 # causes Heisenbugs, and we don't want to inflict that pain unnecessarily.
@@ -393,7 +345,7 @@ echo
 echo "Arcade build		$itg_arcade"
 echo "SSE2 optimizations	$with_sse2 (supported: $have_sse2)"
 echo "SDL			$enable_sdl"
-echo "FFMPEG			$have_ffmpeg"
+echo "FFMPEG			$have_ffmpeg ($ffmpeg_option)"
 echo "libresample		$have_libresample"
 echo "GTK2			$enable_gtk2"
 echo "ALSA			$alsa"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -200,14 +200,17 @@ InputHandler += arch/InputHandler/InputHandler_PIUIO.h \
 		arch/InputHandler/InputHandler_MK3Helper.h
 
 MovieTexture = arch/MovieTexture/MovieTexture.cpp arch/MovieTexture/MovieTexture.h \
-		arch/MovieTexture/MovieTexture_Null.cpp arch/MovieTexture/MovieTexture_Null.h \
-		arch/MovieTexture/MovieTexture_FFMpeg.cpp arch/MovieTexture/MovieTexture_FFMpeg.h \
+		arch/MovieTexture/MovieTexture_Null.cpp arch/MovieTexture/MovieTexture_Null.h
+
+if HAVE_FFMPEG
+MovieTexture += arch/MovieTexture/MovieTexture_FFMpeg.cpp arch/MovieTexture/MovieTexture_FFMpeg.h \
 		arch/MovieTexture/FFMpeg_Helper_Common.h
 
-if !HAVE_FFMPEG
+if HAVE_LEGACY_FFMPEG
 MovieTexture += arch/MovieTexture/FFMpeg_Helper_Legacy.cpp arch/MovieTexture/FFMpeg_Helper_Legacy.h
 else
 MovieTexture += arch/MovieTexture/FFMpeg_Helper.cpp arch/MovieTexture/FFMpeg_Helper.h
+endif
 endif
 
 ####		arch/MovieTexture/MovieTexture_Generic.cpp arch/MovieTexture/MovieTexture_Generic.h
@@ -458,12 +461,7 @@ if !HAVE_LIBRESAMPLE
 main_LDADD += $(srcdir)/libresample/libresample.a
 endif
 
-if !HAVE_FFMPEG
-openitg_LDADD = $(main_LDADD) \
-	$(srcdir)/ffmpeg/lib/libavformat.a $(srcdir)/ffmpeg/lib/libavcodec.a
-else
 openitg_LDADD = $(main_LDADD)
-endif
 
 if HAVE_GTK
 bin_PROGRAMS += GtkModule.so

--- a/src/arch/MovieTexture/FFMpeg_Helper_Common.h
+++ b/src/arch/MovieTexture/FFMpeg_Helper_Common.h
@@ -12,13 +12,13 @@ namespace avcodec
 	#else
 	extern "C"
 	{
-		#if defined(HAVE_FFMPEG)
+		#if defined(HAVE_LEGACY_FFMPEG)
+			#include "ffmpeg/include/ffmpeg/avformat.h"
+		#else
 			#include <libavformat/avformat.h>
 			#include <libswscale/swscale.h>
 			#include <libavutil/avutil.h>
 			#include <libavutil/pixdesc.h>
-		#else
-			#include "ffmpeg/include/ffmpeg/avformat.h"
 		#endif
 	}
 	#endif

--- a/src/arch/MovieTexture/FFMpeg_Helper_Legacy.cpp
+++ b/src/arch/MovieTexture/FFMpeg_Helper_Legacy.cpp
@@ -10,13 +10,13 @@ void img_convert__(avcodec::AVPicture *dst, int dst_pix_fmt,
         const avcodec::AVPicture *src, int pix_fmt,
         int width, int height)
 {
-    #if !defined(HAVE_FFMPEG)
+    #if defined(HAVE_LEGACY_FFMPEG)
         avcodec::img_convert(dst, dst_pix_fmt, src, pix_fmt, width, height);
     #else
         static avcodec::SwsContext* context = 0;
         context = avcodec::sws_getCachedContext(context, width, height, (avcodec::PixelFormat)pix_fmt, width, height, (avcodec::PixelFormat)dst_pix_fmt, avcodec::SWS_BICUBIC, NULL, NULL, NULL);
         avcodec::sws_scale(context, const_cast<uint8_t**>(src->data), const_cast<int*>(src->linesize), 0, height, dst->data, dst->linesize);
-    #endif // !HAVE_FFMPEG
+    #endif // HAVE_LEGACY_FFMPEG
 }
 
 AVPixelFormat_t AVPixelFormats[5] = {
@@ -28,7 +28,7 @@ AVPixelFormat_t AVPixelFormats[5] = {
 		  0x0000FF00,
 		  0x000000FF,
 		  0xFF000000 },
-#if !defined(HAVE_FFMPEG)
+#if defined(HAVE_LEGACY_FFMPEG)
 		avcodec::PIX_FMT_RGBA32,
 		true,
 		false

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -17,7 +17,7 @@
 #include <windows.h>
 #endif
 
-#if !defined(HAVE_FFMPEG)
+#if defined(HAVE_LEGACY_FFMPEG)
 #include "FFMpeg_Helper_Legacy.h"
 #else
 #include "FFMpeg_Helper.h"

--- a/src/arch/MovieTexture/Selector_MovieTexture.h
+++ b/src/arch/MovieTexture/Selector_MovieTexture.h
@@ -8,8 +8,7 @@
 #include "MovieTexture_DShow.h"
 #endif
 
-/* we always have ffmpeg, static or system -hifi */
-#if 1 // def HAVE_FFMPEG
+#if defined(HAVE_FFMPEG)
 #include "MovieTexture_FFMpeg.h"
 #endif
 


### PR DESCRIPTION
These are some ffmpeg autoconf improvements I had lying around that were pretty useless without a major refactoring of the ffmpeg movie driver code. Now that @spigwitmer has taken care of that I dusted off this code.

This PR adds two new options to configure:
1. --without-ffmpeg
2. --with-legacy-ffmpeg

Because ffmpeg is so unstable these new options allow us more flexibility when building. We can explicitly specify which ffmpeg to build against, or if we want to build it at all.
--with-legacy-ffmpeg allows us to separate the behavior --enable-itg-arcade changes from its build requirements. The latter are best defined in build-arcade.sh.
I've also defined a new macro HAVE_LEGACY_FFMPEG. HAVE_FFMPEG used to mean "we are building against system ffmpeg libraries", while it being undefined meant "we are building against the bundled legacy libs". 
HAVE_FFMPEG now means we have ffmpeg at all.
HAVE_LEGACY_FFMPEG means we're building against the bundled legacy ffmpeg libs.

With pkg-config support we can now build on more systems. For instance OpenSUSE has the ffmpeg headers in /usr/include/ffmpeg, requiring an extra -I flag for the compiler to find them. pkg-config takes case of that.

I've tested on Debian 8.4 i386 and OpenSUSE 42.1.
On debian all possible build configurations work that I could think of.
For OpenSUSE it builds but videos don't play, I get the following error messages:
> 
> Couldn't load driver FFMpeg: AVCodec (/Themes/default/BGAnimations/ScreenCompany background/roxor logo.mpg): Couldn't open input (Invalid data found when processing input)
> Couldn't load driver FFMpeg: AVCodec (/Themes/default/BGAnimations/ScreenLogo background/978_JumpBack.mpg): Couldn't open input (Invalid data found when processing input)

But I'm pretty sure the problem is with the system ffmpeg package. The above videos doesn't play in other applications either.