### PR TITLE
Add libncurses5-dev to list of chroot packages

### DIFF
--- a/chroot-arcade.sh
+++ b/chroot-arcade.sh
@@ -52,7 +52,7 @@ echo "Installing necessary dev packages..."
 echo "deb $DEBIAN_SARGE_MIRROR $SARGE_DIST_NAME main contrib non-free" >/etc/apt/sources.list
 echo "$DEBIAN_SARGE_BACKPORTS" >>/etc/apt/sources.list
 apt-get update
-apt-get install build-essential gettext automake1.8 gcc g++ libavcodec-dev libavformat-dev libxt-dev libogg-dev libpng-dev libjpeg-dev libvorbis-dev libusb-dev libglu1-mesa-dev libx11-dev libxrandr-dev liblua50-dev liblualib50-dev nvidia-glx-dev libmad0-dev libasound2-dev git-core automake1.7 autoconf gettext
+apt-get install build-essential gettext automake1.8 gcc g++ libavcodec-dev libavformat-dev libxt-dev libogg-dev libpng-dev libjpeg-dev libvorbis-dev libusb-dev libglu1-mesa-dev libx11-dev libxrandr-dev liblua50-dev liblualib50-dev nvidia-glx-dev libmad0-dev libasound2-dev git-core automake1.7 autoconf libncurses5-dev
 echo "OpenITG AC chroot successfully set up!"
 exec /bin/bash
 !


### PR DESCRIPTION
Added libncurses5-dev to the list of packages to install in an arcade chroot environment.
This is needed for running "make menuconfig" when compiling the linux kernel, which is something you might do when working on openitg.

(gettext was removed because it was in the list twice)