### PR TITLE
Fixed crash when a song is missing a background in a marathon

### DIFF
--- a/assets/patch-data/Themes/fallback/Scripts/Sprite.lua
+++ b/assets/patch-data/Themes/fallback/Scripts/Sprite.lua
@@ -1,0 +1,42 @@
+function Sprite:LoadFromSongBanner(song)
+	local Path = song:GetBannerPath()
+	if not Path then
+		Path = THEME:GetPath(EC_GRAPHICS,"Common","fallback banner")
+	end
+
+	self:LoadBanner( Path )
+end
+
+function Sprite:LoadFromSongBackground(song)
+	local Path = song:GetBackgroundPath()
+	if not Path then
+		Path = THEME:GetPath(EC_GRAPHICS,"Common","fallback background")
+	end
+
+	self:LoadBackground( Path )
+end
+
+
+
+-- (c) 2005 Glenn Maynard
+-- All rights reserved.
+-- 
+-- Permission is hereby granted, free of charge, to any person obtaining a
+-- copy of this software and associated documentation files (the
+-- "Software"), to deal in the Software without restriction, including
+-- without limitation the rights to use, copy, modify, merge, publish,
+-- distribute, and/or sell copies of the Software, and to permit persons to
+-- whom the Software is furnished to do so, provided that the above
+-- copyright notice(s) and this permission notice appear in all copies of
+-- the Software and that both the above copyright notice(s) and this
+-- permission notice appear in supporting documentation.
+-- 
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+-- OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+-- MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+-- THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
+-- INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
+-- OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+-- OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+-- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.


### PR DESCRIPTION
This bug as well as the fix was reported by Zetorux.

If the second song (or a later song) in a marathon does not have a valid background openitg crashes with the message:

> Error: [string "/Themes/fallback/Scripts/Sprite.lua"]:13: calling `GetPath' on bad self (number expected, got nil)

Simply love and many other themes have already fixed this bug in their own copies of Sprite.lua. So the bug is fairly contained to the default theme.

Sprite.lua calls THEME:GetPath with ELEMENT_CATEGORY_GRAPHICS as the first argument. If we check ThemeManager.h we can see it's actually supposed to be EC_GRAPHICS.

There are no other references to ELEMENT_CATEGORY_GRAPHICS.