### PR TITLE
Lua error in ScreenDemonstration

### DIFF
--- a/assets/patch-data/Themes/default/BGAnimations/ScreenDemonstration2 underlay/default.xml
+++ b/assets/patch-data/Themes/default/BGAnimations/ScreenDemonstration2 underlay/default.xml
@@ -93,7 +93,7 @@
 	</children></ActorFrame>
 	
 	<ActorFrame
-		Condition="GAMESTATE:IsHumanPlayer(PLAYER_1) and GAMESTATE:GetPlayMode()==PLAY_MODE_REGULAR and GAMESTATE:GetCurrentSteps(PLAYER_1):GetDifficulty()==DIFFICULTY_BEGINNER"
+		Condition="GAMESTATE:IsHumanPlayer(PLAYER_1) and GAMESTATE:GetPlayMode()==PLAY_MODE_REGULAR and GAMESTATE:GetCurrentSteps(PLAYER_1) and GAMESTATE:GetCurrentSteps(PLAYER_1):GetDifficulty()==DIFFICULTY_BEGINNER"
 		OnCommand="x,SCREEN_CENTER_X-160;y,SCREEN_CENTER_Y+40;zoom,1.2;rotationx,-20"
 		FOV="45"
 		VanishX="SCREEN_CENTER_X-160"
@@ -126,7 +126,7 @@
 	</children></ActorFrame>
 
 	<ActorFrame
-		Condition="GAMESTATE:IsHumanPlayer(PLAYER_2) and GAMESTATE:GetPlayMode()==PLAY_MODE_REGULAR and GAMESTATE:GetCurrentSteps(PLAYER_2):GetDifficulty()==DIFFICULTY_BEGINNER"
+		Condition="GAMESTATE:IsHumanPlayer(PLAYER_2) and GAMESTATE:GetPlayMode()==PLAY_MODE_REGULAR and GAMESTATE:GetCurrentSteps(PLAYER_2) and GAMESTATE:GetCurrentSteps(PLAYER_2):GetDifficulty()==DIFFICULTY_BEGINNER"
 		OnCommand="x,SCREEN_CENTER_X+160;y,SCREEN_CENTER_Y+40;zoom,1.2;rotationx,-20"
 		FOV="45"
 		VanishX="SCREEN_CENTER_X+160"

--- a/assets/patch-data/Themes/default/BGAnimations/ScreenGameplay underlay/default.xml
+++ b/assets/patch-data/Themes/default/BGAnimations/ScreenGameplay underlay/default.xml
@@ -92,7 +92,7 @@
 	</children></ActorFrame>
 	
 	<ActorFrame
-		Condition="GAMESTATE:IsHumanPlayer(PLAYER_1) and GAMESTATE:GetPlayMode()==PLAY_MODE_REGULAR and GAMESTATE:GetCurrentSteps(PLAYER_1):GetDifficulty()==DIFFICULTY_BEGINNER"
+		Condition="GAMESTATE:IsHumanPlayer(PLAYER_1) and GAMESTATE:GetPlayMode()==PLAY_MODE_REGULAR and GAMESTATE:GetCurrentSteps(PLAYER_1) and GAMESTATE:GetCurrentSteps(PLAYER_1):GetDifficulty()==DIFFICULTY_BEGINNER"
 		OnCommand="x,SCREEN_CENTER_X-160;y,SCREEN_CENTER_Y+40;zoom,1.2;rotationx,-20"
 		FOV="45"
 		VanishX="SCREEN_CENTER_X-160"
@@ -125,7 +125,7 @@
 	</children></ActorFrame>
 
 	<ActorFrame
-		Condition="GAMESTATE:IsHumanPlayer(PLAYER_2) and GAMESTATE:GetPlayMode()==PLAY_MODE_REGULAR and GAMESTATE:GetCurrentSteps(PLAYER_2):GetDifficulty()==DIFFICULTY_BEGINNER"
+		Condition="GAMESTATE:IsHumanPlayer(PLAYER_2) and GAMESTATE:GetPlayMode()==PLAY_MODE_REGULAR and GAMESTATE:GetCurrentSteps(PLAYER_2) and GAMESTATE:GetCurrentSteps(PLAYER_2):GetDifficulty()==DIFFICULTY_BEGINNER"
 		OnCommand="x,SCREEN_CENTER_X+160;y,SCREEN_CENTER_Y+40;zoom,1.2;rotationx,-20"
 		FOV="45"
 		VanishX="SCREEN_CENTER_X+160"

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -1883,7 +1883,7 @@ Difficulty GameState::GetEasiestStepsDifficulty() const
 	{
 		if( this->m_pCurSteps[p] == NULL )
 		{
-			LOG->Warn( "GetEasiestNotesDifficulty called but p%i hasn't chosen notes", p+1 );
+			LOG->Warn( "GetEasiestStepsDifficulty called but p%i hasn't chosen notes", p+1 );
 			continue;
 		}
 		dc = min( dc, this->m_pCurSteps[p]->GetDifficulty() );

--- a/src/ScreenDemonstration.cpp
+++ b/src/ScreenDemonstration.cpp
@@ -59,6 +59,7 @@ void ScreenDemonstration::Init()
 
 	if( GAMESTATE->m_pCurSong == NULL )	// we didn't find a song.
 	{
+		LOG->Info("ScreenDemonstration: Couldn't find a song. Aborting demonstration.");
 		HandleScreenMessage( SM_GoToNextScreen );	// Abort demonstration.
 		return;
 	}


### PR DESCRIPTION
Reported by Zetorux.

ScreenDemonstration inherits from ScreenJukebox and relies on it to set a random song during init.

If no song is found that meet the requirements of ScreenJukebox::SetSong() GAMESTATE->m_pCurSong will be left as NULL, which causes a few lua conditions to fail. For instance this one in ScreenGameplay:
`GAMESTATE:IsHumanPlayer(PLAYER_1) and GAMESTATE:GetPlayMode()==PLAY_MODE_REGULAR and GAMESTATE:GetCurrentSteps(PLAYER_1):GetDifficulty()==DIFFICULTY_BEGINNER`

GAMESTATE:GetCurrentSteps(PLAYER_1) will be null when the song is null causing this error:
Dialog: "Lua runtime error parsing "return GAMESTATE:IsHumanPlayer(PLAYER_1) and 

> GAMESTATE:GetPlayMode()==PLAY_MODE_REGULAR and GAMESTATE:GetCurrentSteps(PLAYER_1):GetDifficulty()==DIFFICULTY_BEGINNER": [string "in"]:1: attempt to index a nil value" [LUA_ERROR]

It'll also pops up a dialog, pausing the game.