### PR TITLE
Fix MovieTexture_FFMpeg failing to rewind

### DIFF
--- a/src/arch/MovieTexture/FFMpeg_Helper.h
+++ b/src/arch/MovieTexture/FFMpeg_Helper.h
@@ -1,3 +1,4 @@
+/* vim: set noet sw=4 ts=4: */
 #ifndef FFMPEG_HELPER
 #define FFMPEG_HELPER
 
@@ -30,7 +31,7 @@ public:
 	void RegisterProtocols();
 	CString Open(CString what);
 	void Close();
-    void RenderFrame(RageSurface *img, int tex_fmt);
+	void RenderFrame(RageSurface *img, int tex_fmt);
 	float GetTimestamp() const;
 	int GetRawFrameNumber();
 
@@ -50,7 +51,8 @@ private:
 	RageFile *m_pFile;
 	avcodec::AVIOContext *m_ioctx;
 	avcodec::AVFormatContext *m_fctx;
-    avcodec::AVCodecContext *m_cctx;
+	avcodec::AVCodecContext *m_cctx;
 	avcodec::AVStream *m_stream;
+	avcodec::SwsContext *m_swsctx;
 };
 #endif // FFMPEG_HELPER

--- a/src/global.h
+++ b/src/global.h
@@ -51,7 +51,7 @@
 #include <vector>
 
 /* And, as of GCC 4.3, climits and cstring: */
-#if defined(__GNUC__) && (__GNUC__ >= 4) && (__GNUC_MINOR__ >= 3)
+#if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 3)))
 #include <climits>
 #include <cstring>
 #endif


### PR DESCRIPTION
the CR for this looks messed up because it has a dependency on the gcc6+ffmpeg 16-bit depth fix.

To reproduce:
 * run OpenITG
 * press enter to skip to the title screen
 * wait for about 15-20 seconds and observe the red square horizon whateveritis background movie freezing

The fix has been tested on ffmpeg 3.0 and legacy.