### PR TITLE
Fix issue #27: ScreenUserPacks menu button tokens not expanded

### DIFF
--- a/assets/patch-data/Themes/default/Languages/english.ini
+++ b/assets/patch-data/Themes/default/Languages/english.ini
@@ -131,6 +131,10 @@ HelpText=@GetUserPacksHelpText()
 HelpTextNormal=Press &MENULEFT; &MENURIGHT; to select a pack::Press &START; to add or delete a pack
 HelpTextAppendSelect=Use &SELECT; to switch between lists
 HelpTextAppendNoSelect=Use &MENULEFT; + &MENURIGHT; to switch between lists
+CancelTextSelect=Pressing &SELECT; will cancel this selection.
+CancelTextNoSelect=Pressing &MENULEFT; + &MENURIGHT; will cancel this selection.
+TransferCancelText=@GetUserPacksCancelText()
+TransferWaitText=Please Wait...
 
 [ScreenSelectGame]
 HelpText=&UP; &DOWN; to change row   &MENULEFT; &MENURIGHT; to select between options::&START; to accept changes   BACK to discard changes

--- a/assets/patch-data/Themes/default/Scripts/Other.lua
+++ b/assets/patch-data/Themes/default/Scripts/Other.lua
@@ -6,6 +6,18 @@ function SelectButtonAvailable()
 	return true
 end
 
+function GetUserPacksCancelText()
+	local screen = "ScreenUserPacks"
+
+	if SelectButtonAvailable() then
+		ret = THEME:GetMetric( screen, "CancelTextSelect" )
+	else
+		ret = THEME:GetMetric( screen, "CancelTextNoSelect" )
+	end
+
+	return ret
+end
+
 function GetWorkoutMenuCommand()
 	GAMESTATE:SetTemporaryEventMode(true)
 	return "difficulty," .. GetInitialDifficulty() .. ";screen,ScreenWorkoutMenu;PlayMode,regular;SetEnv,Workout,1"

--- a/src/ScreenUserPacks.cpp
+++ b/src/ScreenUserPacks.cpp
@@ -1,3 +1,4 @@
+/* vim: set noet */
 #include "global.h"
 #include "ScreenUserPacks.h"
 #include "ScreenPrompt.h"
@@ -12,8 +13,8 @@
 #define NEXT_SCREEN					THEME->GetMetric (m_sName,"NextScreen")
 #define PREV_SCREEN					THEME->GetMetric (m_sName,"PrevScreen")
 
-ThemeMetric<CString> USER_PACK_WAIT_TEXT( "ScreenUserPacks", "TransferWaitText" );
-ThemeMetric<CString> USER_PACK_CANCEL_TEXT( "ScreenUserPacks", "TransferCancelText" );
+#define USER_PACK_WAIT_TEXT			THEME->GetMetric ("ScreenUserPacks","TransferWaitText")
+#define USER_PACK_CANCEL_TEXT		THEME->GetMetric ("ScreenUserPacks","TransferCancelText")
 
 static RageMutex MountMutex("ITGDataMount");
 
@@ -70,15 +71,6 @@ int InitSASSongThread( void *pSAS )
 void ScreenUserPacks::Init()
 {
 	ScreenWithMenuElements::Init();
-
-	if ( USER_PACK_WAIT_TEXT.GetValue().empty() )
-		USER_PACK_WAIT_TEXT.SetValue("Please Wait...");
-
-	if ( USER_PACK_CANCEL_TEXT.GetValue().empty() )
-	{
-		USER_PACK_CANCEL_TEXT.SetValue(ssprintf( "Pressing %s will cancel this selection.",
-			DiagnosticsUtil::GetInputType() == "ITGIO" ? "&MENULEFT;+&MENURIGHT;" : "&SELECT;" ));
-	}
 
 	m_SoundDelete.Load( THEME->GetPathS( m_sName, "delete" ) );
 	m_SoundTransferDone.Load( THEME->GetPathS( m_sName, "transfer done" ) );
@@ -260,10 +252,10 @@ bool UpdateXferProgress( uint64_t iBytesCurrent, uint64_t iBytesTotal )
 	const CString sRate = FormatByteValue( iTransferRate ) + "/sec";
 
 	CString sMessage = ssprintf( "\n\n%s\n%.2f%% %s\n\n%s",
-		USER_PACK_WAIT_TEXT.GetValue().c_str(),
+		USER_PACK_WAIT_TEXT.c_str(),
 		fPercent,
 		sRate.c_str(),
-		USER_PACK_CANCEL_TEXT.GetValue().c_str()
+		USER_PACK_CANCEL_TEXT.c_str()
 	);
 	SCREENMAN->OverlayMessage( sMessage );
 


### PR DESCRIPTION
The old behavior hardcoded the cancel and wait messages in ::Init() if they weren't available as a theme metric (and they aren't in the default theme's english.ini). When these hardcoded strings were used, they weren't evaluated by ThemeManager (see `ThemeManager::EvaluateString()`) in the same manner as ones taken from a language file, so dumb things happened. We could set `bAlwaysReload` for those ThemeMetric instances, but really I'm not sure if they belong hardcoded in ::Init() in the first place.