### PR TITLE
Fixed device name leak when using pmount for memory cards

### DIFF
--- a/src/arch/MemoryCard/MemoryCardDriverThreaded_Linux.h
+++ b/src/arch/MemoryCard/MemoryCardDriverThreaded_Linux.h
@@ -15,6 +15,10 @@ protected:
 	bool TestWrite( UsbStorageDevice* pDevice );
 
 	CString m_sLastDevices;
+
+private:
+	bool RetryUnmount( UsbStorageDevice* pDevice, int tries );
+	bool TryUnmount( UsbStorageDevice* pDevice, bool lazy );
 };
 
 #ifdef ARCH_MEMORY_CARD_DRIVER


### PR DESCRIPTION
Set "UsePmount=1" in stepmania.ini to use pmount instead of fstab and mount to mount memory cards. pmount only exists for debian based linux distributions.

Two changes have been made:
* Fixed device name leak when using pmount for memory cards. When mounting a memory card the device is mounted write checked and unmounted. The unmount always failed, causing a device name leak. A lack of the -l parameter for pmount was the cause. The actual parameter for pmount is nowadays "--yes-I-really-want-lazy-unmount" (advertising danger).
* Because of the dangers of "-l", p/umount will now retry instead of using -l immediately. -l is used as a last resort.