### PR TITLE
Fixed gen-arcade-patch.sh failing in a clean repository

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -54,14 +54,11 @@ function has_file
 		return 1
 	fi
 
-	set +e
-	file "$1" &> /dev/null
-	RET=$?
-	set -e
-
-	if [ $RET -eq 0 ]; then return 0; fi
-
-	# use the custom error message if we have it
-	printf "${2-$FILE_ERROR}\n" $1
-	return 1
+	if [ -f $1 ]; then
+		return 0;
+	else
+		# use the custom error message if we have it
+		printf "${2-$FILE_ERROR}\n" $1
+		return 1
+	fi
 }


### PR DESCRIPTION
has_file failed to warn about missing itg2-util because the command "file" always had exit code 0.
Using "if [ -f $1 ]; then" is probably more portable.