### PR TITLE
Updated help text in ScreenUserPacks

### DIFF
--- a/assets/game-data/Themes/home/metrics.ini
+++ b/assets/game-data/Themes/home/metrics.ini
@@ -48,7 +48,7 @@ Class=ScreenUserPacks
 Fallback=ScreenWithMenuElements
 PrevScreen=ScreenOptionsMenu
 NextScreen=ScreenOptionsMenu
-HelpText=Transfer add-on zip files from your USB drive::zip files go in the /AdditionalSongs folder on the drive root
+HelpText=Transfer add-on zip files from your USB drive::zip files go in the /UserPacks folder on the drive root
 
 LinkedOptionsMenuUSBZipsX=
 LinkedOptionsMenuUSBZipsY=


### PR DESCRIPTION
Updated help text in ScreenUserPacks that referred to the wrong location on an USB drive.

UserPackManager.h has the correct path in a macro.