### PR TITLE
Mount a VFS root in ~/.openitg for home builds

### DIFF
--- a/src/arch/ArchHooks/ArchHooks_Unix.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Unix.cpp
@@ -128,6 +128,14 @@ struct stat st;
 	/* OpenITG-specific paths */
 	FILEMAN->Mount( "oitg", Root + "/CryptPackages", "/Packages" );
 
+	/*
+	* Mount an OpenITG root in the home directory.
+	* This is where custom data (songs, themes, etc) should go. 
+	* Any files OpenITG tries to modify will be written here.
+	*/
+	CString home = CString( getenv( "HOME" ) ) + "/";
+	FILEMAN->Mount( "dir", home + ".openitg", "/" );
+
 	/* This mounts everything else, including Cache, Data, UserPacks, etc. */
 	FILEMAN->Mount( "dir", Root, "/" );
 #endif // ITG_ARCADE


### PR DESCRIPTION
Mounting ~/.openitg for home builds enables openitg to be installed in /opt or /usr without requiring the user to have write permission to the game content.
Any file read from /opt will have its modifications written to ~/.openitg. Upon subsequent reads the modified file will be read.

This change is already made through a custom patch with various alterations by everyone who maintains a package of stepmania or its derivatives.
For the packaging process of openitg to be as smooth as possible it's best to make this change "upstream". This is very related to the docker build system I've been working on.

SM5 mounts ~/.stepmania-5.0 by default since a while back.