### PR TITLE
libpng 1.6 compatibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -117,7 +117,7 @@ fi
 have_libpng=yes
 PNG_LIBS=
 PNG_CFLAGS=
-AC_CHECK_LIB(png12, png_create_read_struct, [x=y], have_libpng=no, 
+AC_CHECK_LIB(png12, png_create_read_struct, have_libpng=yes, have_libpng=no, 
              [-lz -lm])
 if test "$have_libpng" = "yes"; then
     png_header_found=yes
@@ -129,7 +129,7 @@ if test "$have_libpng" = "yes"; then
     fi
     LIBS="$LIBS -lpng12 -lz -lm"
 else
-    AC_CHECK_LIB(png, png_create_read_struct, [x=y], have_libpng=no, [-lz -lm]) # x=y to stop autoconf from messing with LIBS
+    AC_CHECK_LIB(png, png_create_read_struct, have_libpng=yes, have_libpng=no, [-lz -lm]) # x=y to stop autoconf from messing with LIBS
     AC_CHECK_HEADER(png.h, , have_libpng=no)
     LIBS="$LIBS -lpng -lz -lm"
 fi

--- a/src/RageSurface_Load_PNG.cpp
+++ b/src/RageSurface_Load_PNG.cpp
@@ -49,7 +49,7 @@ namespace
 void RageFile_png_read( png_struct *png, png_byte *p, png_size_t size )
 {
 	CHECKPOINT;
-	RageFile *f = (RageFile *) png->io_ptr;
+	RageFile *f = (RageFile *) png_get_io_ptr( png );
 
 	int got = f->Read( p, size );
 	if( got == -1 )
@@ -75,7 +75,7 @@ struct error_info
 void PNG_Error( png_struct *png, const char *error )
 {
 	CHECKPOINT;
-	error_info *info = (error_info *) png->error_ptr;
+	error_info *info = (error_info *) png_get_error_ptr( png );
 	strncpy( info->err, error, 1024 );
 	info->err[1023] = 0;
 	LOG->Trace( "loading \"%s\": err: %s", info->fn, info->err );
@@ -85,7 +85,7 @@ void PNG_Error( png_struct *png, const char *error )
 void PNG_Warning( png_struct *png, const char *warning )
 {
 	CHECKPOINT;
-	error_info *info = (error_info *) png->error_ptr;
+	error_info *info = (error_info *) png_get_error_ptr( png );
 	LOG->Trace( "loading \"%s\": warning: %s", info->fn, warning );
 }
 


### PR DESCRIPTION
In libpng 1.4 accessing io_ptr and error_ptr directly in png_struct was deprecated. Png_struct no longer exposes those members. Instead we are supposed to use accessor functions exported by libpng. The ones we need existed as far back as version 1.2. With these changes we are therefore compatible with libpng 1.2 all through to the latest version (1.6 as of now).

The change to configure.ac fixes a bug where the second try to detect “png” never succeeded. That block was entered when have_libpng=no, but it was never changed to yes. So detection always failed.

Tested manually on OpenSUSE 42.1
- With libpng 1.6.8
- With libpng 1.2.50

Also tested on Arch linux, but only that it builds.

All builds using the new docker build system succeeded
- Arcade machine revision
- Opensuse
- Ubuntu

Verified 
- Sarge image used to build arcade binary has libpng 1.2.8
- Stock itg2 image has libpng 1.2.x
- Stock itg2 libpng exports symbols “png_get_io_ptr” and “png_get_error_ptr”