### PR TITLE
Require ffmpeg 2.0

### DIFF
--- a/autoconf/m4/ffmpeg.m4
+++ b/autoconf/m4/ffmpeg.m4
@@ -9,14 +9,14 @@ if test "$with_ffmpeg" = "yes"; then
     if test "$with_legacy_ffmpeg" = "no"; then
 
         if pkg-config --libs libavcodec &> /dev/null; then AVCODEC_LIBS="`pkg-config --libs libavcodec`"; else AVCODEC_LIBS="-lavcodec"; fi
-		if pkg-config --libs libavformat &> /dev/null; then AVFORMAT_LIBS="`pkg-config --libs libavformat`"; else AVFORMAT_LIBS="-lavcodec"; fi
+		if pkg-config --libs libavformat &> /dev/null; then AVFORMAT_LIBS="`pkg-config --libs libavformat`"; else AVFORMAT_LIBS="-lavformat"; fi
 		if pkg-config --libs libswscale &> /dev/null; then SWSCALE_LIBS="`pkg-config --libs libswscale`"; else SWSCALE_LIBS="-swscale"; fi
         if pkg-config --libs libavutil &> /dev/null; then AVUTIL_LIBS="`pkg-config --libs libavutil`"; else AVUTIL_LIBS="-lavutil"; fi
         
         if pkg-config --cflags libavcodec &> /dev/null; then AVCODEC_CFLAGS="`pkg-config --cflags libavcodec`"; else AVCODEC_CFLAGS=""; fi
 		if pkg-config --cflags libavformat &> /dev/null; then AVFORMAT_CFLAGS="`pkg-config --cflags libavformat`"; else AVFORMAT_CFLAGS=""; fi
 		if pkg-config --cflags libswscale &> /dev/null; then SWSCALE_CFLAGS="`pkg-config --cflags libswscale`"; else SWSCALE_CFLAGS=""; fi
-        if pkg-config --cflags libavutil &> /dev/null; then AVUTIL_CFLAGS="`pkg-config --cflags libavutil`"; else AVUTIL_CFLAGS="-lavutil"; fi
+        if pkg-config --cflags libavutil &> /dev/null; then AVUTIL_CFLAGS="`pkg-config --cflags libavutil`"; else AVUTIL_CFLAGS=""; fi
         
         ffmpeg_save_CFLAGS="$CFLAGS"
 		ffmpeg_save_CXXFLAGS="$CXXFLAGS"
@@ -33,42 +33,54 @@ if test "$with_ffmpeg" = "yes"; then
 		AC_CHECK_FUNC([avcodec_find_decoder], have_libavcodec=yes, have_libavcodec=no)
 		AC_CHECK_FUNC([avformat_open_input], have_libavformat=yes, have_libavformat=no)
 		AC_CHECK_FUNC([swscale_version], have_libswscale=yes, have_libswscale=no)
-        AC_CHECK_FUNC([av_frame_free], have_libavutil=yes, have_libavutil=no)
+        AC_CHECK_FUNC([av_free], have_libavutil=yes, have_libavutil=no)
 
         if test "$have_libavcodec" = "yes"; then
-        AC_MSG_CHECKING([for libavcodec >= 0.5.2])
+        AC_MSG_CHECKING([for libavcodec >= 2.0])
         AC_TRY_RUN([
             #include <libavcodec/avcodec.h>
             int main()
             {
-                return ( LIBAVCODEC_VERSION_INT < 0x341401 )? 1:0;
+                return ( LIBAVCODEC_VERSION_INT < AV_VERSION_INT(55,18,102) )? 1:0;
             }
             ],,have_libavcodec=no,)
         AC_MSG_RESULT($have_libavcodec)
         fi
 
         if test "$have_libavformat" = "yes"; then
-        AC_MSG_CHECKING([for libavformat >= 0.5.2])
+        AC_MSG_CHECKING([for libavformat >= 2.0])
         AC_TRY_RUN([
             #include <libavformat/avformat.h>
             int main()
             {
-                return ( LIBAVFORMAT_VERSION_INT < 0x341F00 )? 1:0;
+                return ( LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(55,12,100) )? 1:0;
             }
             ],,have_libavformat=no,)
         AC_MSG_RESULT($have_libavformat)
         fi
 
         if test "$have_libswscale" = "yes"; then
-        AC_MSG_CHECKING([for libswscale >= 0.5.2])
+        AC_MSG_CHECKING([for libswscale >= 2.0])
         AC_TRY_RUN([
             #include <libswscale/swscale.h>
             int main()
             {
-                return ( LIBSWSCALE_VERSION_INT < 0x000701 )? 1:0;
+                return ( LIBSWSCALE_VERSION_INT < AV_VERSION_INT(2,3,100) )? 1:0;
             }
             ],,have_libswscale=no,)
         AC_MSG_RESULT($have_libswscale)
+        fi
+
+        if test "$have_libavutil" = "yes"; then
+        AC_MSG_CHECKING([for libavutil >= 2.0])
+        AC_TRY_RUN([
+            #include <libavutil/avutil.h>
+            int main()
+            {
+                return ( LIBAVUTIL_VERSION_INT < AV_VERSION_INT(52,38,100) )? 1:0;
+            }
+            ],,have_libavutil=no,)
+        AC_MSG_RESULT($have_libavutil)
         fi
 
         CFLAGS="$ffmpeg_save_CFLAGS"


### PR DESCRIPTION
This will check for ffmpeg 2.0 during configuration. I'm not sure exactly what version we require at the moment, but i do know that 0.5.2 (the previous requirement) is too old.
Recent versions of most distros now have at least version 2.7 of ffmpeg.

I've also fixed a couple mistakes in the pkgconfig code.