### PR TITLE
Release notes for beta 3, beta 4 and 0.9

### DIFF
--- a/README
+++ b/README
@@ -12,10 +12,8 @@ Project source code: https://github.com/openitg/openitg
 
 Short-term
 1. Getting Started Guide - build and development
-2. streamline build and release process - works out of box for arcade and home
-3. test / bugfix beta-3 (currently master branch)
-4. self-contained cache-rebuilding solution
-5. OpenGL Driver uses fix function pipeline rather than shader
+2. self-contained cache-rebuilding solution
+3. OpenGL Driver uses fix function pipeline rather than shader
 
 Long-term
 1. Kernel source with ITG patches to rebuild kernels (talk to us, should live in a separate repo)

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,6 +1,36 @@
-OpenITG, beta 4 (April ??, 2011)
+OpenITG, 0.9 (in development)
+-------------------------------------
 
-It's been a long time in coming, but OpenITG beta 3 is here!
+-Simply love compatibility improved.
+-Tons of crashes eliminated.
+-Multiple bugs fixed.
+-Rate mods are no longer reset between songs.
+    Main motivation for this is ITG2 and SM 3.95 compatibility (they don’t reset). PR #53.
+-Linux home releases now write user data to "~/.openitg".
+-For arcade builds /itgdata is now only remounted once during startup.
+    /itgdata has to be remounted by openitg to make sure the partition is writeable.
+    Previously it was temporarily remounted as writeable during write operations
+    which caused problems in some situations.
+-Unmount logic for memory cards have been improved to prevent device name leaks. PR #71.
+-It’s now possible to switch themes in the options menu without a crash. PR #50.
+-Subtractive scoring calculations are now correct.
+-The reload songs option no longer crashes the game. PR #57.
+-The green 1 excellent flag at evaluation has been replaced with the intended orange flag.
+    This was an ancient ITG2 bug.
+-Build chain improvements
+    It should now be a little easier to build and contribute to the project.
+    Binary packages are now built automatically using docker.
+
+Changes in this release were contributed by augustg and infamouspat.
+
+Note that official releases will be signed by our private key but anyone could
+generate their own key and make their own releases if they wanted to.
+
+For detailed instructions on checking out the code, contributing, or making
+release, see: README or https://github.com/openitg/openitg/wiki
+
+OpenITG, beta 3 (February 7th, 2013 - never officially released)
+-------------------------------------
 
 -Accepted patches to improve building on 64-bit and more modern Linux (thanks, hifi!)
 -Fixed problem where USB cards sounds don't occur if attract sound is set to none.
@@ -27,12 +57,6 @@ generate their own key and make their own releases if they wanted to.
 
 For detailed instructions on checking out the code, contributing, or making
 release, see: README or https://github.com/openitg/openitg/wiki
-
-OpenITG, beta 3 (January-ish, 2011)
--------------------------------------
-
-Unofficial release candidate, nothing public.  See beta 4 for complete list of
-changes since beta 2.
 
 OpenITG, beta 2 (August 9th, 2009)
 ----------------------------------

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,28 @@
-OpenITG, beta 3 (in development)
+OpenITG, 0.9 (in development)
+--------------------------------
+-Miscellaneous changes:
+    Rate mods are no longer reset between songs.
+    Linux home releases now write data to ~/.openitg
+-Improvements:
+    For arcade builds /itgdata is now only remounted once during startup.
+    DirectX 8 support has been replaced by DirectX 9.
+    Binary packages are now built automatically using docker.
+    FFmpeg has been updated for home releases.
+-Fixed bugs:
+    Subtractive scoring calculations are now correct.
+    Fixed a lua error in ScreenDemonstration when no demo friendly song are found.
+    The green 1 excellent flag at evaluation has been replaced with the intended orange flag.
+    Unmount logic for memory cards have been improved to prevent device name leaks. 
+-Fixed crashes:
+    Fixed a crash when starting OpenITG with Simply Love as the default theme.
+    Songs with tens of thousands of notes would crash in MAX2 score keeper
+        (http://aaronin.jp/boards/viewtopic.php?t=11258).
+    The default theme no longer crashes if a marathon doesn't have a background.
+    Fixed a crash when entering the music wheel.
+    Using the reload songs option no longer crashes the game.
+    Switching themes is now possible without elaborate workarounds.
+
+OpenITG, beta 3 (February 7th, 2013 - never officially released)
 --------------------------------
 -New GameCommands:
      "clearmachinelogs" - clears crash logs from machine.


### PR DESCRIPTION
I have updated the changelog, release notes and readme to reflect the changes since the large batch of commits by @vyhd february 7th 2013.

**beta 3**
I set the release date to february 7th 2013 since:
- These were the last changes by vyhd and were followed by a long period of project inactivity
- The releases he made early 2013 were still under the beta 3 version

**beta 4**
I combined beta 3 and beta 4 into beta 3 with the same reasoning as above. Even though beta 4 was recorded in the changelog, WIP releases were still made as "beta 3". Beta 4 was therefore killed.

**0.9**
This is what I chose to call everything developed since early 2013. It can be renamed. No release date has been set.

**README**
I removed two TODO entries from the README. With the changes made during 2016, I think we can cross them off the list.