### PR TITLE
Fix regression in Pull #47 - Patch data not loading

### DIFF
--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -1159,15 +1159,10 @@ int main(int argc, char* argv[])
 	SONGMAN		= new SongManager();
 
 	SONGMAN->InitAll( loading_window );		// this takes a long time
-	LOG->Debug("$$cryptman");
 	CRYPTMAN	= new CryptManager;	// need to do this before ProfileMan
-	LOG->Debug("$$memory man");
 	MEMCARDMAN	= new MemoryCardManager;
-	LOG->Debug("$$profile man");
 	PROFILEMAN	= new ProfileManager;
-	LOG->Debug("$$profile init");
 	PROFILEMAN->Init();				// must load after SONGMAN
-	LOG->Debug("$$unlock man");
 	UNLOCKMAN	= new UnlockManager;
 
 
@@ -1175,21 +1170,16 @@ int main(int argc, char* argv[])
 		/* Now that THEME is loaded, load the icon for the current theme into the
 		 * loading window. */
 		CString sError;
-		LOG->Debug("$$ load icon");
 		RageSurface *pIcon = RageSurfaceUtils::LoadFile( THEME->GetPathG( "Common", "window icon" ), sError );
 		if( pIcon )
 			loading_window->SetIcon( pIcon );
 		delete pIcon;
 	}
-	LOG->Debug("$$  save catalog");
 	/* This shouldn't need to be here; if it's taking long enough that this is
 	 * even visible, we should be fixing it, not showing a progress display. */
 	SaveCatalogXml( loading_window );
-	LOG->Debug("$$  network man");
 	NSMAN 		= new NetworkSyncManager( loading_window ); 
-	LOG->Debug("$$ message man");
 	MESSAGEMAN	= new MessageManager;
-	LOG->Debug("$$ stats man");
 	STATSMAN	= new StatsManager;
 
 	SAFE_DELETE( loading_window );		// destroy this before init'ing Display


### PR DESCRIPTION
This set of changes uses the reverted behavior as a fallback for patch data not mounting from pull #47. Tested working in Windows. Resolves issue #87 .