### PR TITLE
Windows patch mount

### DIFF
--- a/src/RageFileManager.cpp
+++ b/src/RageFileManager.cpp
@@ -318,6 +318,7 @@ CString LoadedDriver::GetPath( const CString &sPath ) const
 	return sRet;
 }
 
+/* Normalize a virtual path */
 static void NormalizePath( CString &sPath )
 {
 	FixSlashesInPlace( sPath );
@@ -734,8 +735,6 @@ CString RageFileManager::ResolvePath( const CString &sPath_ )
 	}
 
 	UnreferenceAllDrivers( apDriverList );
-
-	NormalizePath( sResolvedPath );
 
 	return sResolvedPath;
 }


### PR DESCRIPTION
Fixes a bug in RageFileManager::ResolvePath which adds a / before all returned physical paths causing the patch data to not get loaded on windows.

This is tested on windows and linux with both patch.zip and a patch folder. With both opengl and d3d.
I've also tested that the bug fixed in PR #47 stays fixed.

Closes #87 