### PR TITLE
Added support for playing mp4 and mkv files as song backgrounds

### DIFF
--- a/src/ActorUtil.cpp
+++ b/src/ActorUtil.cpp
@@ -444,6 +444,8 @@ FileType ActorUtil::GetFileType( const CString &sPath )
 		sExt=="bmp" )		return FT_Bitmap;
 	else if( 
 		sExt=="avi" || 
+		sExt=="mkv" ||
+		sExt=="mp4" ||
 		sExt=="mpeg" || 
 		sExt=="mpg" )		return FT_Movie;
 	else if( 

--- a/src/RageTextureManager.cpp
+++ b/src/RageTextureManager.cpp
@@ -37,6 +37,7 @@
 #include "RageLog.h"
 #include "RageDisplay.h"
 #include "Foreach.h"
+#include "ActorUtil.h"
 
 RageTextureManager*		TEXTUREMAN		= NULL;
 
@@ -123,7 +124,7 @@ RageTexture* RageTextureManager::LoadTextureInternal( RageTextureID ID )
 	sExt.MakeLower();
 
 	RageTexture* pTexture;
-	if( sExt == "avi" || sExt == "mpg" || sExt == "mpeg" )
+	if( ActorUtil::GetFileType( ID.filename ) == FT_Movie )
 		pTexture = RageMovieTexture::Create( ID );
 	else
 		pTexture = new RageBitmapTexture( ID );


### PR DESCRIPTION
Tested on windows with VS 2015 and the new ffmpeg libs.

If ffmpeg cant play the file it will simply ignore it and show a black background.

The crash happens when there are unmapped file types used as backgrounds in songs.