### PR TITLE
Machine revision verification failure

### DIFF
--- a/build/build-arcade-machine-revision.sh
+++ b/build/build-arcade-machine-revision.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 PRIVATE_RSA="$1"
+PATCH_RSA="$2"
 
 # exit immediately on nonzero exit code
 set -e
@@ -15,13 +16,14 @@ fi
 
 function print_usage
 {
-	echo "Usage: $0 [private RSA key]"
+	echo "Usage: $0 [private RSA key] [public RSA key]"
 	exit 0
 }
 
-if ! [ -f "$PRIVATE_RSA" ]; then print_usage; fi
+if ! [ -f "$PRIVATE_RSA" ] || ! [ -f "$PATCH_RSA" ]; then print_usage; fi
 
 PRIVATE_RSA=$(abspath $PRIVATE_RSA)
+PATCH_RSA=$(abspath $PATCH_RSA)
 
 # Calculate reasonable number of make jobs
 HAS_NPROC=1
@@ -56,7 +58,7 @@ make
 popd
 
 # Generate a machine revision package
-./gen-arcade-patch.sh $PRIVATE_RSA
+./gen-arcade-patch.sh $PRIVATE_RSA $PATCH_RSA
 
 mv ITG*.itg build/artifacts/
 cd build


### PR DESCRIPTION
Testing on an actual dedicab with the help of Rodent we ran into a problem where after installing the machine revision you would get a verification failure of subsequent revisions signed with the same key.
It turns out the official openitg path.rsa is checked into the repo.
To fix this the new build scripts will require both the private and the public key when signing a machine revision. Makes sure machine revisions from the same source can be installed without copying a new Patch.rsa to the machine every time.