### PR TITLE
fix confusing and/or erroneous syntax in gen-arcade-patch and gen-patch-zip

### DIFF
--- a/gen-arcade-patch.sh
+++ b/gen-arcade-patch.sh
@@ -116,9 +116,9 @@ TEMP_SIG_FILE="$TMP_DIR/.sig"
 rm -f "$PATCH_OUTPUT_FILE"
 
 CWD="`pwd`"
-cd "$TMP_DIR"
+pushd "$TMP_DIR"
 zip -r "$CWD/$PATCH_OUTPUT_FILE" * &> /dev/null
-cd - &> /dev/null
+popd
 
 echo "Signing and appending signature..."
 

--- a/gen-patch-zip.sh
+++ b/gen-patch-zip.sh
@@ -46,10 +46,10 @@ CWD=`pwd`
 # mild hack: wipe that CWD if we're using an absolute path
 if [ ${PATCH_FILE:0:1} == "/" ]; then CWD=""; fi
 
-cd "$PATCH_DIR"
+pushd "$PATCH_DIR"
 echo "Zipping files into $PATCH_FILE..."
 zip -rq "$CWD/$PATCH_FILE" ./*/
-cd - 0&> /dev/null
+popd
 
 echo "Encrypting patch data..."
 encrypt-patch "$PATCH_FILE"


### PR DESCRIPTION
this is hindering creating machine revisions, and failing silently at that with the stdout redirection.

i'm not even sure what those lines in gen-patch-zip.sh are trying to accomplish past cd'ing into and out of a directory. if there's more to this syntax than I see feel free to school me, but bash is properly equipped to handle such situations more elegantly. that last sentence was some sick accidental poetry.  mom's spaghetti.

such changes were applied to gen-arcade-patch.sh as well.

testing done:
```
$ ls artifacts
'ITG 2 OpenITG-0.9rc1.itg'
$ unzip -l artifacts/*
Archive:  artifacts/ITG 2 OpenITG-0.9rc1.itg
  Length      Date    Time    Name
---------  ---------- -----   ----
      271  2016-04-15 22:07   install-patch.sh
        0  2017-03-30 20:13   modules/
    31594  2017-03-30 20:13   modules/ehci-hcd.ko
   157793  2016-04-15 22:07   modules/usbcore.ko
    25231  2016-04-15 22:07   modules/ub.ko
    12632  2016-04-15 22:07   modules/nvram.ko
  9372576  2017-04-03 01:37   openitg
      196  2017-04-03 01:37   patch.xml
  1471482  2017-04-03 01:37   patch.zip
     1113  2017-03-30 20:13   start-2.sh
      925  2016-04-15 22:07   start-3.sh
     2406  2016-04-15 22:07   XF86Config-cab
     2699  2016-04-15 22:07   XF86Config-kit
     2431  2016-04-15 22:07   XF86Config-school
---------                     -------
 11081349                     14 files
```