### PR TITLE
exclude .git folder and related files from source distribution

### DIFF
--- a/build/build-source-package.sh
+++ b/build/build-source-package.sh
@@ -41,7 +41,7 @@ cd $TEMP_WORK_DIR/openitg-$OPENITG_VERSION
 
 cd ..
 
-tar -Jcf $TEMP_WORK_DIR/openitg-$OPENITG_VERSION.tar.xz openitg-$OPENITG_VERSION
+tar --exclude='.git*' -Jcf $TEMP_WORK_DIR/openitg-$OPENITG_VERSION.tar.xz openitg-$OPENITG_VERSION
 
 popd
 mv $TEMP_WORK_DIR/openitg-$OPENITG_VERSION.tar.xz $OUTPUT_DIR/


### PR DESCRIPTION
this just ensures the .git folder or .gitignore files don't end up in the source package.

testing done (note: the 0.9rc1 tag doesn't exist yet remotely, it's created on my end for testing):
```
$ tar -Jtf artifacts/openitg-0.9rc1+1+g8df595fd.tar.xz | grep '\.git'
$ git checkout master
$ ./build-source-package.sh ./artifacts
...
$ tar -Jtf artifacts/openitg-0.9rc1.tar.xz | grep '\.git'
openitg-0.9rc1/src/libtommath/.gitignore
openitg-0.9rc1/.gitignore
...
openitg-0.9rc1/.git/objects/for/years
...
$
```