### PR TITLE
Update windows build documentation

### DIFF
--- a/README-Windows-build.md
+++ b/README-Windows-build.md
@@ -1,6 +1,8 @@
 =====================================
-Rough instructions for a VS2015 build
+Windows Dependancy Build Instructions
 =====================================
+
+Note for VS 2010, 2013, and 2015 these are already made for you. Nothing more need be done.
 
 ------------------
 Build requirements
@@ -13,20 +15,19 @@ Build requirements
 ------------------
 Build instructions
 ------------------
-1. from the Visual Studio command prompt
+1. From the Visual Studio command prompt
     * Unzip libpng at lpng1256/: `unzip lpng1256.zip`
     * `set INCLUDE=%INCLUDE%;Z:\path\to\openitg\src\zlib`
     * from the lpng1256 dir, run: `nmake /f .\scripts\makefile.vcwin32`
-2. from the repository root in a mingw-w32 shell (`.\msys2_shell.cmd -mingw32 -full-path`)
+2. From the repository root in a mingw-w32 shell (`.\msys2_shell.cmd -mingw32 -full-path`)
     * Install build dependencies: `pacman -S unzip diffutils yasm make mingw32/mingw-w64-i686-gcc`
     * Untar ffmpeg at ffmpeg-3.0.3/ and cd into it: `tar -zxvf ffmpeg-3.0.3.tar.gz; cd ffmpeg-3.0.3`
-    * run `./configure --prefix=../ffmpeg-build --enable-shared --toolchain=msvc`, wait forever
+    * run `./configure --prefix=../ffmpeg-build --enable-shared --toolchain=msvc --cpu=opteron`, wait forever (Note --cpu=opteron is used to work around incorrect detection of processors having FAST_CLZ)
     * `make && make install`
     * `cp ../ffmpeg-build/bin/*.dll ../Program`
-3. from Visual Studio 2015
-    * Open src/OpenITG-vs2015.sln
-    * Build the Debug and Release build configurations
-4. to build the installer, from cmd or powershell
+3. Move compiled libs to proper location in extern folder
+4. Follow Directions on building windows release from the normal readme
+5. To build the installer, from cmd or powershell
     * `assets\win32-installer\setup-installer-dir.bat`
     * `cd inst-tmp`
     * `makensis /nocd ..\assets\win32-installer\OpenITG.nsi`

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ TODO: Similar process to arcade, but create 32-bit chroot of modern debian
 
 ## How to build for home on windows:
 
-TODO: Need someone to describe how to build in Visual Studio and produce
-releases.
+1. Open visual studio (2010, 2013, and 2015 have been tested)
+2. Select "File -> Open Project" and pick src\Stepmania-net2010.sln
+3. 5 Projects will load in the solution explorer. Right click each and select properties.
+4. For each of the project properties, under the configurations drop-down, select "All Configurations" and under Configuration "Options->General" select the appropriate platform toolset for your VS Version.
+5. If you use Visual Studio 2013, depending on your edition of it, there is a bug, you will need to add the /FS flag to Additional Options under "C/C++ -> Command Line", or you can simply build twice the first time you build.
+6. To compile the release, select the appropriate profile (usually the SSE2 build), then select "Build -> Rebuild Solution".
 


### PR DESCRIPTION
Documentation on building for windows in the readme, and how to build the dependencies in the windows specific readme. Includes google-sanctioned workaround for modern ffmpeg FAST_CLZ detection.