### PR TITLE
Performance and Network enhancements

### DIFF
--- a/README-Windows-build.md
+++ b/README-Windows-build.md
@@ -1,6 +1,8 @@
 =====================================
-Rough instructions for a VS2015 build
+Windows Dependancy Build Instructions
 =====================================
+
+Note for VS 2010, 2013, and 2015 these are already made for you. Nothing more need be done.
 
 ------------------
 Build requirements
@@ -13,20 +15,19 @@ Build requirements
 ------------------
 Build instructions
 ------------------
-1. from the Visual Studio command prompt
+1. From the Visual Studio command prompt
     * Unzip libpng at lpng1256/: `unzip lpng1256.zip`
     * `set INCLUDE=%INCLUDE%;Z:\path\to\openitg\src\zlib`
     * from the lpng1256 dir, run: `nmake /f .\scripts\makefile.vcwin32`
-2. from the repository root in a mingw-w32 shell (`.\msys2_shell.cmd -mingw32 -full-path`)
+2. From the repository root in a mingw-w32 shell (`.\msys2_shell.cmd -mingw32 -full-path`)
     * Install build dependencies: `pacman -S unzip diffutils yasm make mingw32/mingw-w64-i686-gcc`
     * Untar ffmpeg at ffmpeg-3.0.3/ and cd into it: `tar -zxvf ffmpeg-3.0.3.tar.gz; cd ffmpeg-3.0.3`
-    * run `./configure --prefix=../ffmpeg-build --enable-shared --toolchain=msvc`, wait forever
+    * run `./configure --prefix=../ffmpeg-build --enable-shared --toolchain=msvc --cpu=opteron`, wait forever (Note --cpu=opteron is used to work around incorrect detection of processors having FAST_CLZ)
     * `make && make install`
     * `cp ../ffmpeg-build/bin/*.dll ../Program`
-3. from Visual Studio 2015
-    * Open src/OpenITG-vs2015.sln
-    * Build the Debug and Release build configurations
-4. to build the installer, from cmd or powershell
+3. Move compiled libs to proper location in extern folder
+4. Follow Directions on building windows release from the normal readme
+5. To build the installer, from cmd or powershell
     * `assets\win32-installer\setup-installer-dir.bat`
     * `cd inst-tmp`
     * `makensis /nocd ..\assets\win32-installer\OpenITG.nsi`

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ TODO: Similar process to arcade, but create 32-bit chroot of modern debian
 
 ## How to build for home on windows:
 
-TODO: Need someone to describe how to build in Visual Studio and produce
-releases.
+1. Open visual studio (2010, 2013, and 2015 have been tested)
+2. Select "File -> Open Project" and pick src\Stepmania-net2010.sln
+3. 5 Projects will load in the solution explorer. Right click each and select properties.
+4. For each of the project properties, under the configurations drop-down, select "All Configurations" and under Configuration "Options->General" select the appropriate platform toolset for your VS Version.
+5. If you use Visual Studio 2013, depending on your edition of it, there is a bug, you will need to add the /FS flag to Additional Options under "C/C++ -> Command Line", or you can simply build twice the first time you build.
+6. To compile the release, select the appropriate profile (usually the SSE2 build), then select "Build -> Rebuild Solution".
 

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -38,58 +38,58 @@ static Preference<CString> pSongBroadcastURL("SongBroadcastURL", "");
 #define CHARACTERS_DIR "Characters/"
 #define NAME_BLACKLIST_FILE "Data/NamesBlacklist.dat"
 
-ThemeMetric<bool> USE_NAME_BLACKLIST("GameState", "UseNameBlacklist");
+ThemeMetric<bool> USE_NAME_BLACKLIST("GameState","UseNameBlacklist");
 
-ThemeMetric<CString> DEFAULT_SORT("GameState", "DefaultSort");
+ThemeMetric<CString> DEFAULT_SORT	("GameState","DefaultSort");
 SortOrder GetDefaultSort()
 {
-	return StringToSortOrder(DEFAULT_SORT);
+	return StringToSortOrder( DEFAULT_SORT );
 }
-ThemeMetric<CString> DEFAULT_SONG("GameState", "DefaultSong");
+ThemeMetric<CString> DEFAULT_SONG	("GameState","DefaultSong");
 Song* GetDefaultSong()
 {
 	SongID sid;
-	sid.LoadFromDir(DEFAULT_SONG);
+	sid.LoadFromDir( DEFAULT_SONG );
 	return sid.ToSong();
 }
 
 static int GetNumStagesForCurrentSong()
 {
 	int iNumStagesOfThisSong = 1; // default
-	if (GAMESTATE->m_pCurSong)
-		iNumStagesOfThisSong = SongManager::GetNumStagesForSong(GAMESTATE->m_pCurSong);
+	if( GAMESTATE->m_pCurSong )
+		iNumStagesOfThisSong = SongManager::GetNumStagesForSong( GAMESTATE->m_pCurSong );
 	else
 		return iNumStagesOfThisSong;
 
-	ASSERT(iNumStagesOfThisSong >= 1 && iNumStagesOfThisSong <= 3);
+	ASSERT( iNumStagesOfThisSong >= 1 && iNumStagesOfThisSong <= 3 );
 
 	/* Never increment more than one past final stage.  That is, if the current
-	* stage is the final stage, and we picked a stage that takes two songs, it
-	* only counts as one stage (so it doesn't bump us all the way to Ex2).
-	* One case where this happens is a long/marathon extra stage.  Another is
-	* if a long/marathon song is selected explicitly in the theme with a GameCommand,
-	* and PREFSMAN->m_iNumArcadeStages is less than the number of stages that
-	* song takes. */
+	 * stage is the final stage, and we picked a stage that takes two songs, it
+	 * only counts as one stage (so it doesn't bump us all the way to Ex2).
+	 * One case where this happens is a long/marathon extra stage.  Another is
+	 * if a long/marathon song is selected explicitly in the theme with a GameCommand,
+	 * and PREFSMAN->m_iNumArcadeStages is less than the number of stages that
+	 * song takes. */
 	int iNumStagesLeft = PREFSMAN->m_iSongsPerPlay - GAMESTATE->m_iCurrentStageIndex;
-	iNumStagesOfThisSong = min(iNumStagesOfThisSong, iNumStagesLeft);
-	iNumStagesOfThisSong = max(iNumStagesOfThisSong, 1);
+	iNumStagesOfThisSong = min( iNumStagesOfThisSong, iNumStagesLeft );
+	iNumStagesOfThisSong = max( iNumStagesOfThisSong, 1 );
 
 	return iNumStagesOfThisSong;
 }
 
 GameState::GameState() :
-m_pCurStyle(MESSAGE_CURRENT_STYLE_CHANGED),
-m_PreferredCourseDifficulty(MESSAGE_EDIT_PREFERRED_COURSE_DIFFICULTY_P1_CHANGED),
-m_PreferredDifficulty(MESSAGE_EDIT_PREFERRED_DIFFICULTY_P1_CHANGED),
-m_pCurSong(MESSAGE_CURRENT_SONG_CHANGED),
-m_pCurSteps(MESSAGE_CURRENT_STEPS_P1_CHANGED),
-m_pCurCourse(MESSAGE_CURRENT_COURSE_CHANGED),
-m_pCurTrail(MESSAGE_CURRENT_TRAIL_P1_CHANGED),
-m_stEdit(MESSAGE_EDIT_STEPS_TYPE_CHANGED),
-m_pEditSourceSteps(MESSAGE_EDIT_SOURCE_STEPS_CHANGED),
-m_stEditSource(MESSAGE_EDIT_SOURCE_STEPS_TYPE_CHANGED)
+    m_pCurStyle(			MESSAGE_CURRENT_STYLE_CHANGED ),
+    m_PreferredCourseDifficulty( MESSAGE_EDIT_PREFERRED_COURSE_DIFFICULTY_P1_CHANGED ),
+    m_PreferredDifficulty(	MESSAGE_EDIT_PREFERRED_DIFFICULTY_P1_CHANGED ),
+    m_pCurSong(				MESSAGE_CURRENT_SONG_CHANGED ),
+	m_pCurSteps(			MESSAGE_CURRENT_STEPS_P1_CHANGED ),
+    m_pCurCourse(			MESSAGE_CURRENT_COURSE_CHANGED ),
+	m_pCurTrail(			MESSAGE_CURRENT_TRAIL_P1_CHANGED ),
+	m_stEdit(				MESSAGE_EDIT_STEPS_TYPE_CHANGED ),
+    m_pEditSourceSteps(		MESSAGE_EDIT_SOURCE_STEPS_CHANGED ),
+	m_stEditSource(			MESSAGE_EDIT_SOURCE_STEPS_TYPE_CHANGED )
 {
-	m_pCurStyle.Set(NULL);
+	m_pCurStyle.Set( NULL );
 
 	m_pCurGame = NULL;
 	m_iCoins = 0;
@@ -104,10 +104,10 @@ m_stEditSource(MESSAGE_EDIT_SOURCE_STEPS_TYPE_CHANGED)
 	m_iStageSeed = m_iGameSeed = 0;
 
 	m_PlayMode = PLAY_MODE_INVALID; // used by IsPlayerEnabled before the first screen
-	FOREACH_PlayerNumber(p)
+	FOREACH_PlayerNumber( p )
 		m_bSideIsJoined[p] = false; // used by GetNumSidesJoined before the first screen
 
-	FOREACH_PlayerNumber(p)
+	FOREACH_PlayerNumber( p )
 	{
 		m_pPlayerState[p] = new PlayerState;
 		m_pPlayerState[p]->m_PlayerNumber = p;
@@ -116,96 +116,96 @@ m_stEditSource(MESSAGE_EDIT_SOURCE_STEPS_TYPE_CHANGED)
 	m_Environment = new LuaTable;
 
 	m_pTimingDataOriginal = new TimingData;
-
+	
 	//DUMB but if I don't do it this way, it crashes. Gotta have a private member instead of a preference	
 	m_sSongBroadcastURL.assign(pSongBroadcastURL.Get().c_str());
-
+	
 	//allocate networking variables
-#if !defined(WITHOUT_NETWORKING)
-	m_SongBroadcastHTTP = new HTTPHelper();
-#endif
+	#if !defined(WITHOUT_NETWORKING)
+		m_SongBroadcastHTTP = new HTTPHelper();
+	#endif
 
 	/* Don't reset yet; let the first screen do it, so we can
-	* use PREFSMAN and THEME. */
-	//	Reset();
+	 * use PREFSMAN and THEME. */
+//	Reset();
 }
 
 GameState::~GameState()
 {
-	for (unsigned i = 0; i<m_pCharacters.size(); i++)
-		SAFE_DELETE(m_pCharacters[i]);
+	for( unsigned i=0; i<m_pCharacters.size(); i++ )
+		SAFE_DELETE( m_pCharacters[i] );
 
-	FOREACH_PlayerNumber(p)
-		SAFE_DELETE(m_pPlayerState[p]);
+	FOREACH_PlayerNumber( p )
+		SAFE_DELETE( m_pPlayerState[p] );
 
-	SAFE_DELETE(m_Environment);
+	SAFE_DELETE( m_Environment );
 
-	SAFE_DELETE(m_pTimingDataOriginal);
-
+	SAFE_DELETE( m_pTimingDataOriginal );
+	
 	//destroy network variables
-#if !defined(WITHOUT_NETWORKING)
+	#if !defined(WITHOUT_NETWORKING)
 
 
-	m_SongBroadcastHTTP->GetThreadedResult(); //waits for last call to finish or timeout before destroying object
-	SAFE_DELETE(m_SongBroadcastHTTP);
-#endif
+		m_SongBroadcastHTTP->GetThreadedResult(); //waits for last call to finish or timeout before destroying object
+		SAFE_DELETE( m_SongBroadcastHTTP );
+	#endif
 }
 
-void GameState::ApplyGameCommand(const CString &sCommand, PlayerNumber pn)
+void GameState::ApplyGameCommand( const CString &sCommand, PlayerNumber pn )
 {
 	GameCommand m;
-	m.Load(0, ParseCommands(sCommand));
+	m.Load( 0, ParseCommands(sCommand) );
 
 	CString sWhy;
-	if (!m.IsPlayable(&sWhy))
-		RageException::Throw("Can't apply mode \"%s\": %s", sCommand.c_str(), sWhy.c_str());
+	if( !m.IsPlayable(&sWhy) )
+		RageException::Throw( "Can't apply mode \"%s\": %s", sCommand.c_str(), sWhy.c_str() );
 
-	if (pn == PLAYER_INVALID)
+	if( pn == PLAYER_INVALID )
 		m.ApplyToAllPlayers();
 	else
-		m.Apply(pn);
+		m.Apply( pn );
 }
 
 void GameState::ApplyCmdline()
 {
 	/* We need to join players before we can set the style. */
 	CString sPlayer;
-	for (int i = 0; GetCommandlineArgument("player", &sPlayer, i); ++i)
+	for( int i = 0; GetCommandlineArgument( "player", &sPlayer, i ); ++i )
 	{
-		int pn = atoi(sPlayer) - 1;
-		if (!IsAnInt(sPlayer) || pn < 0 || pn >= NUM_PLAYERS)
-			RageException::Throw("Invalid argument \"--player=%s\"", sPlayer.c_str());
+		int pn = atoi( sPlayer )-1;
+		if( !IsAnInt( sPlayer ) || pn < 0 || pn >= NUM_PLAYERS )
+			RageException::Throw( "Invalid argument \"--player=%s\"", sPlayer.c_str() );
 
-		this->JoinPlayer((PlayerNumber)pn);
+		this->JoinPlayer( (PlayerNumber) pn );
 	}
 
 	CString sMode;
-	for (int i = 0; GetCommandlineArgument("mode", &sMode, i); ++i)
+	for( int i = 0; GetCommandlineArgument( "mode", &sMode, i ); ++i )
 	{
-		ApplyGameCommand(sMode);
+		ApplyGameCommand( sMode );
 	}
 }
 
 void GameState::Reset()
 {
 	EndGame();
-
-	ASSERT(THEME);
+	
+	ASSERT( THEME );
 
 	m_timeGameStarted.SetZero();
-	m_pCurStyle.Set(NULL);
-	FOREACH_PlayerNumber(p)
+	m_pCurStyle.Set( NULL );
+	FOREACH_PlayerNumber( p )
 		m_bSideIsJoined[p] = false;
 	MEMCARDMAN->UnlockCards();
-	//	m_iCoins = 0;	// don't reset coin count!
+//	m_iCoins = 0;	// don't reset coin count!
 	m_MasterPlayerNumber = PLAYER_INVALID;
 	m_mapEnv.clear();
-	m_sPreferredSongGroup = GROUP_ALL_MUSIC;
+	m_sPreferredSongGroup	= GROUP_ALL_MUSIC;
 	m_bChangedFailTypeOnScreenSongOptions = false;
-	FOREACH_PlayerNumber(p)
+	FOREACH_PlayerNumber( p )
 	{
-		m_PreferredDifficulty[p].Set(DIFFICULTY_INVALID);
-		m_PreferredCourseDifficulty[p].Set(DIFFICULTY_MEDIUM);
+		m_PreferredDifficulty[p].Set( DIFFICULTY_INVALID );
+		m_PreferredCourseDifficulty[p].Set( DIFFICULTY_MEDIUM );
 	}
 	m_SortOrder = SORT_INVALID;
 	m_PreferredSortOrder = GetDefaultSort();
@@ -218,40 +218,40 @@ void GameState::Reset()
 	m_BeatToNoteSkinRev = 0;
 	m_iNumStagesOfThisSong = 0;
 
-	NOTESKIN->RefreshNoteSkinData(this->m_pCurGame);
+	NOTESKIN->RefreshNoteSkinData( this->m_pCurGame );
 
 	m_iGameSeed = rand();
 	m_iStageSeed = rand();
 
-	m_pCurSong.Set(GetDefaultSong());
+	m_pCurSong.Set( GetDefaultSong() );
 	m_pPreferredSong = NULL;
-	FOREACH_PlayerNumber(p)
-		m_pCurSteps[p].Set(NULL);
-	m_pCurCourse.Set(NULL);
+	FOREACH_PlayerNumber( p )
+		m_pCurSteps[p].Set( NULL );
+	m_pCurCourse.Set( NULL );
 	m_pPreferredCourse = NULL;
-	FOREACH_PlayerNumber(p)
-		m_pCurTrail[p].Set(NULL);
+	FOREACH_PlayerNumber( p )
+		m_pCurTrail[p].Set( NULL );
 
-	FOREACH_PlayerNumber(p)
+	FOREACH_PlayerNumber( p )
 		m_pPlayerState[p]->Reset();
 
 	ResetMusicStatistics();
 	ResetStageStatistics();
 
-	FOREACH_PlayerNumber(pn)
-		PROFILEMAN->UnloadProfile(pn);
+	FOREACH_PlayerNumber( pn )
+		PROFILEMAN->UnloadProfile( pn );
 
 	SONGMAN->UpdateBest();
 	SONGMAN->UpdateShuffled();
 
 	/* We may have cached trails from before everything was loaded (eg. from before
-	* SongManager::UpdateBest could be called).  Erase the cache. */
+	 * SongManager::UpdateBest could be called).  Erase the cache. */
 	SONGMAN->RegenerateNonFixedCourses();
 
 	STATSMAN->Reset();
 
 	m_SongOptions.Init();
-
+	
 	FOREACH_PlayerNumber(p)
 	{
 		// I can't think of a good reason to have both game-specific
@@ -261,43 +261,43 @@ void GameState::Reset()
 		// The theme setting is for eg. BM being reverse by default.  (This
 		// could be done in the title menu GameCommand, but then it wouldn't
 		// affect demo, and other non-gameplay things ...) -glenn
-		ApplyModifiers(p, DEFAULT_MODIFIERS);
-		ApplyModifiers(p, PREFSMAN->m_sDefaultModifiers);
+		ApplyModifiers( p, DEFAULT_MODIFIERS );
+		ApplyModifiers( p, PREFSMAN->m_sDefaultModifiers );
 	}
 
 	FOREACH_PlayerNumber(p)
 	{
-		if (PREFSMAN->m_ShowDancingCharacters == PrefsManager::CO_RANDOM)
+		if( PREFSMAN->m_ShowDancingCharacters == PrefsManager::CO_RANDOM)
 			m_pCurCharacters[p] = GetRandomCharacter();
 		else
 			m_pCurCharacters[p] = GetDefaultCharacter();
-		ASSERT(m_pCurCharacters[p]);
+		ASSERT( m_pCurCharacters[p] );
 	}
 
 	m_bTemporaryEventMode = false;
 	m_bStatsCommitted = false;
 
-	LIGHTSMAN->SetLightsMode(LIGHTSMODE_ATTRACT);
-
-	m_stEdit.Set(STEPS_TYPE_INVALID);
-	m_pEditSourceSteps.Set(NULL);
-	m_stEditSource.Set(STEPS_TYPE_INVALID);
+	LIGHTSMAN->SetLightsMode( LIGHTSMODE_ATTRACT );
+	
+	m_stEdit.Set( STEPS_TYPE_INVALID );
+	m_pEditSourceSteps.Set( NULL );
+	m_stEditSource.Set( STEPS_TYPE_INVALID );
 
 	SONGMAN->FreeAllLoadedPlayerSongs();
 
 	ApplyCmdline();
 }
 
-void GameState::JoinPlayer(PlayerNumber pn)
+void GameState::JoinPlayer( PlayerNumber pn )
 {
 	this->m_bSideIsJoined[pn] = true;
-	MESSAGEMAN->Broadcast((Message)(MESSAGE_SIDE_JOINED_P1 + pn));
+	MESSAGEMAN->Broadcast( (Message)(MESSAGE_SIDE_JOINED_P1+pn) );
 
-	if (this->m_MasterPlayerNumber == PLAYER_INVALID)
+	if( this->m_MasterPlayerNumber == PLAYER_INVALID )
 		this->m_MasterPlayerNumber = pn;
 
 	// if first player to join, set start time
-	if (this->GetNumSidesJoined() == 1)
+	if( this->GetNumSidesJoined() == 1 )
 		this->BeginGame();
 }
 
@@ -305,34 +305,34 @@ int GameState::GetCoinsNeededToJoin() const
 {
 	int iCoinsToCharge = 0;
 
-	if (GAMESTATE->GetCoinMode() == COIN_MODE_PAY)
+	if( GAMESTATE->GetCoinMode() == COIN_MODE_PAY )
 		iCoinsToCharge = PREFSMAN->m_iCoinsPerCredit;
 
 	// If joint premium don't take away a credit for the 2nd join.
-	if (GAMESTATE->GetPremium() == PREMIUM_JOINT  &&
-		GAMESTATE->GetNumSidesJoined() == 1)
+	if( GAMESTATE->GetPremium() == PREMIUM_JOINT  &&  
+		GAMESTATE->GetNumSidesJoined() == 1 )
 		iCoinsToCharge = 0;
 
 	return iCoinsToCharge;
 }
 
-void GameState::SetSongInProgress(const CString &sWriteOut)
+void GameState::SetSongInProgress( const CString &sWriteOut )
 {
 	CString sLockFile = "Data/songinprogress";
 	LOG->Debug("GameState::SetSongInProgress( %s )", sWriteOut.c_str());
 	RageFile f;
 	f.Open(sLockFile, RageFile::WRITE);
-	f.Write(sWriteOut);
+	f.Write( sWriteOut );
 	f.Close();
 
 
 }
 
-void GameState::HTTPBroadcastSongInProgress(const CString &sWriteOut)
+void GameState::HTTPBroadcastSongInProgress( const CString &sWriteOut )
 {
 
 	//if we have networking
-#if !defined(WITHOUT_NETWORKING)
+	#if !defined(WITHOUT_NETWORKING)
 	//and we have a broadcast URL...
 	if (m_sSongBroadcastURL.length()>3)
 	{
@@ -342,30 +342,30 @@ void GameState::HTTPBroadcastSongInProgress(const CString &sWriteOut)
 	{
 		//LOG->Debug("GameState::SetSongInProgress m_sSongBroadcastURL ( %s ) length is less than 3! Skipping broadcast!", m_sSongBroadcastURL.c_str());
 	}
-#endif
+	#endif
 }
 
 /*
-* Game flow:
-*
-* BeginGame() - the first player has joined; the game is starting.
-*
-* PlayersFinalized() - no more players may join (because the style is set)
-*
-* BeginStage() - gameplay is beginning
-*
-* optional: CancelStage() - gameplay aborted (Back pressed), undo BeginStage and back up
-*
-* CommitStageStats() - gameplay is finished
-*   Saves STATSMAN->m_CurStageStats to the profiles, so profile information
-*   is up-to-date for Evaluation.
-*
-* FinishStage() - gameplay and evaluation is finished
-*   Clears data which was stored by CommitStageStats.
-*
-* EndGame() - the game is finished
-*
-*/
+ * Game flow:
+ *
+ * BeginGame() - the first player has joined; the game is starting.
+ *
+ * PlayersFinalized() - no more players may join (because the style is set)
+ *
+ * BeginStage() - gameplay is beginning
+ *
+ * optional: CancelStage() - gameplay aborted (Back pressed), undo BeginStage and back up
+ *
+ * CommitStageStats() - gameplay is finished
+ *   Saves STATSMAN->m_CurStageStats to the profiles, so profile information
+ *   is up-to-date for Evaluation.
+ *
+ * FinishStage() - gameplay and evaluation is finished
+ *   Clears data which was stored by CommitStageStats.
+ *
+ * EndGame() - the game is finished
+ *
+ */
 void GameState::BeginGame()
 {
 	m_timeGameStarted.Touch();
@@ -381,83 +381,83 @@ void GameState::BeginGame()
 
 void GameState::PlayersFinalized()
 {
-	if (MEMCARDMAN->GetCardsLocked())
+	if( MEMCARDMAN->GetCardsLocked() )
 		return;
 
 	SONGMAN->FreeAllLoadedPlayerSongs(); // avoid duplicates
 	SONGMAN->FreeAllLoadedPlayerCourses();
 
-	MESSAGEMAN->Broadcast(MESSAGE_PLAYERS_FINALIZED);
+	MESSAGEMAN->Broadcast( MESSAGE_PLAYERS_FINALIZED );
 
 	MEMCARDMAN->LockCards();
 
-	FOREACH_HumanPlayer(pn)
+	FOREACH_HumanPlayer( pn )
 	{
-		MEMCARDMAN->MountCard(pn, 600);
-		PROFILEMAN->LoadFirstAvailableProfile(pn);	// load full profile
+		MEMCARDMAN->MountCard( pn, 600 );
+		PROFILEMAN->LoadFirstAvailableProfile( pn );	// load full profile
 	}
 
 	// apply saved default modifiers if any
-	FOREACH_HumanPlayer(pn)
+	FOREACH_HumanPlayer( pn )
 	{
 		if (PREFSMAN->m_bCustomSongs && !GAMESTATE->IsCourseMode())
 		{
-			SONGMAN->LoadPlayerSongs(pn);		// load custom songs, if any
+			SONGMAN->LoadPlayerSongs( pn );		// load custom songs, if any
 		}
 		else if (PREFSMAN->m_bCustomCourses && GAMESTATE->IsCourseMode())
 		{
 			// XXX LoadPlayerSongs(): should we be loading courses first to a temporary queue or something?
-			SONGMAN->LoadPlayerSongs(pn);
-			SONGMAN->LoadPlayerCourses(pn);
+			SONGMAN->LoadPlayerSongs( pn );
+			SONGMAN->LoadPlayerCourses( pn );
 		}
 
-		MEMCARDMAN->UnmountCard(pn);
+		MEMCARDMAN->UnmountCard( pn );
 	}
 
-	FOREACH_HumanPlayer(pn)
+	FOREACH_HumanPlayer( pn )
 	{
-		if (!PROFILEMAN->IsPersistentProfile(pn))
+		if( !PROFILEMAN->IsPersistentProfile(pn) )
 			continue;	// skip
 
 		Profile* pProfile = PROFILEMAN->GetProfile(pn);
 
 		CString sModifiers;
-		if (pProfile->GetDefaultModifiers(this->m_pCurGame, sModifiers))
+		if( pProfile->GetDefaultModifiers( this->m_pCurGame, sModifiers ) )
 		{
 			/* We don't save negative preferences (eg. "no reverse").  If the theme
-			* sets a default of "reverse", and the player turns it off, we should
-			* set it off.  However, don't reset modifiers that aren't saved by the
-			* profile, so we don't ignore unsaved modifiers when a profile is in use. */
+			 * sets a default of "reverse", and the player turns it off, we should
+			 * set it off.  However, don't reset modifiers that aren't saved by the
+			 * profile, so we don't ignore unsaved modifiers when a profile is in use. */
 			GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions.ResetSavedPrefs();
-			GAMESTATE->ApplyModifiers(pn, sModifiers);
+			GAMESTATE->ApplyModifiers( pn, sModifiers );
 		}
 		// Only set the sort order if it wasn't already set by a GameCommand (or by an earlier profile)
-		if (m_PreferredSortOrder == SORT_INVALID && pProfile->m_SortOrder != SORT_INVALID)
+		if( m_PreferredSortOrder == SORT_INVALID && pProfile->m_SortOrder != SORT_INVALID )
 			m_PreferredSortOrder = pProfile->m_SortOrder;
-		if (pProfile->m_LastDifficulty != DIFFICULTY_INVALID)
-			m_PreferredDifficulty[pn].Set(pProfile->m_LastDifficulty);
-		if (pProfile->m_LastCourseDifficulty != DIFFICULTY_INVALID)
-			m_PreferredCourseDifficulty[pn].Set(pProfile->m_LastCourseDifficulty);
-		if (m_pPreferredSong == NULL)
+		if( pProfile->m_LastDifficulty != DIFFICULTY_INVALID )
+			m_PreferredDifficulty[pn].Set( pProfile->m_LastDifficulty );
+		if( pProfile->m_LastCourseDifficulty != DIFFICULTY_INVALID )
+			m_PreferredCourseDifficulty[pn].Set( pProfile->m_LastCourseDifficulty );
+		if( m_pPreferredSong == NULL )
 			m_pPreferredSong = pProfile->m_lastSong.ToSong();
-		if (m_pPreferredCourse == NULL)
+		if( m_pPreferredCourse == NULL )
 			m_pPreferredCourse = pProfile->m_lastCourse.ToCourse();
 	}
 
-	FOREACH_PlayerNumber(pn)
+	FOREACH_PlayerNumber( pn )
 	{
-		if (!IsHumanPlayer(pn))
-			ApplyModifiers(pn, DEFAULT_CPU_MODIFIERS);
+		if( !IsHumanPlayer(pn) )
+			ApplyModifiers( pn, DEFAULT_CPU_MODIFIERS );
 	}
 }
 
 void GameState::EndGame()
 {
-	LOG->Trace("GameState::EndGame");
+	LOG->Trace( "GameState::EndGame" );
 
-	if (m_bDemonstrationOrJukebox)
+	if( m_bDemonstrationOrJukebox )
 		return;
-	if (m_timeGameStarted.IsZero() || !STATSMAN->m_vPlayedStageStats.size())	// we were in the middle of a game and played at least one song
+	if( m_timeGameStarted.IsZero() || !STATSMAN->m_vPlayedStageStats.size() )	// we were in the middle of a game and played at least one song
 		return;
 
 	/* Finish the final stage. */
@@ -465,16 +465,16 @@ void GameState::EndGame()
 
 
 	// Update totalPlaySeconds stat
-	int iPlaySeconds = max(0, (int)m_timeGameStarted.PeekDeltaTime());
+	int iPlaySeconds = max( 0, (int) m_timeGameStarted.PeekDeltaTime() );
 
 	Profile* pMachineProfile = PROFILEMAN->GetMachineProfile();
 	pMachineProfile->m_iTotalPlaySeconds += iPlaySeconds;
 	pMachineProfile->m_iTotalPlays++;
 
-	FOREACH_HumanPlayer(p)
+	FOREACH_HumanPlayer( p )
 	{
-		Profile* pPlayerProfile = PROFILEMAN->GetProfile(p);
-		if (pPlayerProfile)
+		Profile* pPlayerProfile = PROFILEMAN->GetProfile( p );
+		if( pPlayerProfile )
 		{
 			pPlayerProfile->m_iTotalPlaySeconds += iPlaySeconds;
 			pPlayerProfile->m_iTotalPlays++;
@@ -483,26 +483,26 @@ void GameState::EndGame()
 
 	BOOKKEEPER->WriteToDisk();
 
-	FOREACH_HumanPlayer(pn)
+	FOREACH_HumanPlayer( pn )
 	{
-		if (!PROFILEMAN->IsPersistentProfile(pn))
+		if( !PROFILEMAN->IsPersistentProfile(pn) )
 			continue;
 
 		bool bWasMemoryCard = PROFILEMAN->ProfileWasLoadedFromMemoryCard(pn);
-		if (bWasMemoryCard)
-			MEMCARDMAN->MountCard(pn);
-		PROFILEMAN->SaveProfile(pn);
-		if (bWasMemoryCard)
-			MEMCARDMAN->UnmountCard(pn);
+		if( bWasMemoryCard )
+			MEMCARDMAN->MountCard( pn );
+		PROFILEMAN->SaveProfile( pn );
+		if( bWasMemoryCard )
+			MEMCARDMAN->UnmountCard( pn );
 
-		PROFILEMAN->UnloadProfile(pn);
+		PROFILEMAN->UnloadProfile( pn );
 	}
 
 	PROFILEMAN->SaveMachineProfile();
 
 	// Reset the USB storage device numbers -after- saving
 	CHECKPOINT;
-	//	MEMCARDMAN->FlushAndReset();
+//	MEMCARDMAN->FlushAndReset();
 	CHECKPOINT;
 
 	// get rid of our custom songs
@@ -516,21 +516,21 @@ void GameState::EndGame()
 /* Called by ScreenGameplay.  Set the length of the current song. */
 void GameState::BeginStage()
 {
-	if (m_bDemonstrationOrJukebox)
+	if( m_bDemonstrationOrJukebox )
 		return;
 
 	/* This should only be called once per stage. */
-	if (m_iNumStagesOfThisSong != 0)
-		LOG->Warn("XXX: m_iNumStagesOfThisSong == %i?", m_iNumStagesOfThisSong);
+	if( m_iNumStagesOfThisSong != 0 )
+		LOG->Warn( "XXX: m_iNumStagesOfThisSong == %i?", m_iNumStagesOfThisSong );
 
 	/* Finish the last stage (if any), if we havn't already.  (For example, we might
-	* have, for some reason, gone from gameplay to evaluation straight back to gameplay.) */
+	 * have, for some reason, gone from gameplay to evaluation straight back to gameplay.) */
 	FinishStage();
 
 	GAMESTATE->ResetStageStatistics();
 
 	m_iNumStagesOfThisSong = GetNumStagesForCurrentSong();
-	ASSERT(m_iNumStagesOfThisSong != -1);
+	ASSERT( m_iNumStagesOfThisSong != -1 );
 }
 
 void GameState::CancelStage()
@@ -541,7 +541,7 @@ void GameState::CancelStage()
 void GameState::CommitStageStats()
 {
 	/* Don't commit stats twice. */
-	if (m_bStatsCommitted || m_bDemonstrationOrJukebox)
+	if( m_bStatsCommitted || m_bDemonstrationOrJukebox )
 		return;
 	m_bStatsCommitted = true;
 
@@ -549,12 +549,12 @@ void GameState::CommitStageStats()
 }
 
 /* Called by ScreenSelectMusic (etc).  Increment the stage counter if we just played a
-* song.  Might be called more than once. */
+ * song.  Might be called more than once. */
 void GameState::FinishStage()
 {
 	/* If m_iNumStagesOfThisSong is 0, we've been called more than once before calling
-	* BeginStage.  This can happen when backing out of the player options screen. */
-	if (m_iNumStagesOfThisSong == 0)
+	 * BeginStage.  This can happen when backing out of the player options screen. */
+	if( m_iNumStagesOfThisSong == 0 )
 		return;
 
 	/* If we havn't committed stats yet, do so. */
@@ -563,53 +563,53 @@ void GameState::FinishStage()
 	m_bStatsCommitted = false;
 
 	// Increment the stage counter.
-	ASSERT(m_iNumStagesOfThisSong >= 1 && m_iNumStagesOfThisSong <= 3);
+	ASSERT( m_iNumStagesOfThisSong >= 1 && m_iNumStagesOfThisSong <= 3 );
 	const int iOldStageIndex = m_iCurrentStageIndex;
 	m_iCurrentStageIndex += m_iNumStagesOfThisSong;
 
 	m_iNumStagesOfThisSong = 0;
 
-	if (m_bDemonstrationOrJukebox)
+	if( m_bDemonstrationOrJukebox )
 		return;
 
-	if (GAMESTATE->IsEventMode())
+	if( GAMESTATE->IsEventMode() )
 	{
 		const int iSaveProfileEvery = 3;
-		if (iOldStageIndex / iSaveProfileEvery < m_iCurrentStageIndex / iSaveProfileEvery)
+		if( iOldStageIndex/iSaveProfileEvery < m_iCurrentStageIndex/iSaveProfileEvery )
 		{
-			LOG->Trace("Played %i stages; saving profiles ...", iSaveProfileEvery);
+			LOG->Trace( "Played %i stages; saving profiles ...", iSaveProfileEvery );
 			PROFILEMAN->SaveAllProfiles();
 		}
 	}
 }
 
-void GameState::SaveCurrentSettingsToProfile(PlayerNumber pn)
+void GameState::SaveCurrentSettingsToProfile( PlayerNumber pn )
 {
-	if (!PROFILEMAN->IsPersistentProfile(pn))
+	if( !PROFILEMAN->IsPersistentProfile(pn) )
 		return;
-	if (m_bDemonstrationOrJukebox)
+	if( m_bDemonstrationOrJukebox )
 		return;
 
 	Profile* pProfile = PROFILEMAN->GetProfile(pn);
 
-	pProfile->SetDefaultModifiers(this->m_pCurGame, m_pPlayerState[pn]->m_PlayerOptions.GetSavedPrefsString());
-	if (IsSongSort(m_PreferredSortOrder))
+	pProfile->SetDefaultModifiers( this->m_pCurGame, m_pPlayerState[pn]->m_PlayerOptions.GetSavedPrefsString() );
+	if( IsSongSort(m_PreferredSortOrder) )
 		pProfile->m_SortOrder = m_PreferredSortOrder;
-	if (m_PreferredDifficulty[pn] != DIFFICULTY_INVALID)
+	if( m_PreferredDifficulty[pn] != DIFFICULTY_INVALID )
 		pProfile->m_LastDifficulty = m_PreferredDifficulty[pn];
-	if (m_PreferredCourseDifficulty[pn] != DIFFICULTY_INVALID)
+	if( m_PreferredCourseDifficulty[pn] != DIFFICULTY_INVALID )
 		pProfile->m_LastCourseDifficulty = m_PreferredCourseDifficulty[pn];
-	if (m_pPreferredSong)
-		pProfile->m_lastSong.FromSong(m_pPreferredSong);
-	if (m_pPreferredCourse)
-		pProfile->m_lastCourse.FromCourse(m_pPreferredCourse);
+	if( m_pPreferredSong )
+		pProfile->m_lastSong.FromSong( m_pPreferredSong );
+	if( m_pPreferredCourse )
+		pProfile->m_lastCourse.FromCourse( m_pPreferredCourse );
 }
 
-void GameState::Update(float fDelta)
+void GameState::Update( float fDelta )
 {
-	FOREACH_PlayerNumber(p)
+	FOREACH_PlayerNumber( p )
 	{
-		m_pPlayerState[p]->Update(fDelta);
+		m_pPlayerState[p]->Update( fDelta );
 
 		// TRICKY: GAMESTATE->Update is run before any of the Screen update's,
 		// so we'll clear these flags here and let them get turned on later
@@ -619,26 +619,26 @@ void GameState::Update(float fDelta)
 		bool bRebuildPlayerOptions = false;
 
 		/* See if any delayed attacks are starting or ending. */
-		for (unsigned s = 0; s<m_pPlayerState[p]->m_ActiveAttacks.size(); s++)
+		for( unsigned s=0; s<m_pPlayerState[p]->m_ActiveAttacks.size(); s++ )
 		{
 			Attack &attack = m_pPlayerState[p]->m_ActiveAttacks[s];
-
+			
 			// -1 is the "starts now" sentinel value.  You must add the attack
 			// by calling GameState::LaunchAttack, or else the -1 won't be 
 			// converted into the current music time.  
-			ASSERT(attack.fStartSecond != -1);
+			ASSERT( attack.fStartSecond != -1 );
 
 			bool bCurrentlyEnabled =
 				attack.bGlobal ||
-				(attack.fStartSecond < this->m_fMusicSeconds &&
-				m_fMusicSeconds < attack.fStartSecond + attack.fSecsRemaining);
+				( attack.fStartSecond < this->m_fMusicSeconds &&
+				m_fMusicSeconds < attack.fStartSecond+attack.fSecsRemaining );
 
-			if (m_pPlayerState[p]->m_ActiveAttacks[s].bOn == bCurrentlyEnabled)
+			if( m_pPlayerState[p]->m_ActiveAttacks[s].bOn == bCurrentlyEnabled )
 				continue; /* OK */
 
-			if (m_pPlayerState[p]->m_ActiveAttacks[s].bOn && !bCurrentlyEnabled)
+			if( m_pPlayerState[p]->m_ActiveAttacks[s].bOn && !bCurrentlyEnabled )
 				m_pPlayerState[p]->m_bAttackEndedThisUpdate = true;
-			else if (!m_pPlayerState[p]->m_ActiveAttacks[s].bOn && bCurrentlyEnabled)
+			else if( !m_pPlayerState[p]->m_ActiveAttacks[s].bOn && bCurrentlyEnabled )
 				m_pPlayerState[p]->m_bAttackBeganThisUpdate = true;
 
 			bRebuildPlayerOptions = true;
@@ -646,67 +646,67 @@ void GameState::Update(float fDelta)
 			m_pPlayerState[p]->m_ActiveAttacks[s].bOn = bCurrentlyEnabled;
 		}
 
-		if (bRebuildPlayerOptions)
-			RebuildPlayerOptionsFromActiveAttacks(p);
+		if( bRebuildPlayerOptions )
+			RebuildPlayerOptionsFromActiveAttacks( p );
 
-		if (m_pPlayerState[p]->m_fSecondsUntilAttacksPhasedOut > 0)
-			m_pPlayerState[p]->m_fSecondsUntilAttacksPhasedOut = max(0, m_pPlayerState[p]->m_fSecondsUntilAttacksPhasedOut - fDelta);
+		if( m_pPlayerState[p]->m_fSecondsUntilAttacksPhasedOut > 0 )
+			m_pPlayerState[p]->m_fSecondsUntilAttacksPhasedOut = max( 0, m_pPlayerState[p]->m_fSecondsUntilAttacksPhasedOut - fDelta );
 
-		if (!m_bGoalComplete[p] && IsGoalComplete(p))
+		if( !m_bGoalComplete[p] && IsGoalComplete(p) )
 		{
 			m_bGoalComplete[p] = true;
-			MESSAGEMAN->Broadcast((Message)(MESSAGE_GOAL_COMPLETE_P1 + p));
+			MESSAGEMAN->Broadcast( (Message)(MESSAGE_GOAL_COMPLETE_P1+p) );
 		}
 	}
 
 	// apply any delayed game commands that were issued
-	if (!m_sDelayedGameCommand.empty())
+	if( !m_sDelayedGameCommand.empty() )
 	{
-		this->ApplyGameCommand(m_sDelayedGameCommand);
+		this->ApplyGameCommand( m_sDelayedGameCommand );
 		m_sDelayedGameCommand.clear();
 	}
 }
 
 void GameState::ReloadCharacters()
 {
-	for (unsigned i = 0; i<m_pCharacters.size(); i++)
-		SAFE_DELETE(m_pCharacters[i]);
+	for( unsigned i=0; i<m_pCharacters.size(); i++ )
+		SAFE_DELETE( m_pCharacters[i] );
 	m_pCharacters.clear();
 
-	FOREACH_PlayerNumber(p)
+	FOREACH_PlayerNumber( p )
 		m_pCurCharacters[p] = NULL;
 
 	CStringArray as;
-	GetDirListing(CHARACTERS_DIR "*", as, true, true);
+	GetDirListing( CHARACTERS_DIR "*", as, true, true );
 	bool FoundDefault = false;
-	for (unsigned i = 0; i<as.size(); i++)
+	for( unsigned i=0; i<as.size(); i++ )
 	{
 		CString sCharName, sDummy;
 		splitpath(as[i], sDummy, sCharName, sDummy);
 		sCharName.MakeLower();
 
-		if (sCharName.CompareNoCase("default") == 0)
+		if( sCharName.CompareNoCase("default")==0 )
 			FoundDefault = true;
 
 		Character* pChar = new Character;
-		if (pChar->Load(as[i]))
-			m_pCharacters.push_back(pChar);
+		if( pChar->Load( as[i] ) )
+			m_pCharacters.push_back( pChar );
 		else
 			delete pChar;
 	}
-
-	if (!FoundDefault)
-		RageException::Throw("'Characters/default' is missing.");
+	
+	if( !FoundDefault )
+		RageException::Throw( "'Characters/default' is missing." );
 
 	// If FoundDefault, then we're not empty. -Chris
-	//	if( m_pCharacters.empty() )
-	//		RageException::Throw( "Couldn't find any character definitions" );
+//	if( m_pCharacters.empty() )
+//		RageException::Throw( "Couldn't find any character definitions" );
 }
 
 const float GameState::MUSIC_SECONDS_INVALID = -5000.0f;
 
 void GameState::ResetMusicStatistics()
-{
+{	
 	m_fMusicSeconds = 0; // MUSIC_SECONDS_INVALID;
 	m_fSongBeat = 0;
 	m_fMusicSecondsVisible = 0;
@@ -714,18 +714,18 @@ void GameState::ResetMusicStatistics()
 	m_fCurBPS = 10;
 	m_bFreeze = false;
 	m_bPastHereWeGo = false;
-	Actor::SetBGMTime(0, 0);
+	Actor::SetBGMTime( 0, 0 );
 }
 
 void GameState::ResetStageStatistics()
 {
 	StageStats OldStats = STATSMAN->m_CurStageStats;
 	STATSMAN->m_CurStageStats = StageStats();
-	if (PREFSMAN->m_bComboContinuesBetweenSongs)
+	if( PREFSMAN->m_bComboContinuesBetweenSongs )
 	{
-		if (GetStageIndex() == 0)
+		if( GetStageIndex() == 0 )
 		{
-			FOREACH_PlayerNumber(p)
+			FOREACH_PlayerNumber( p )
 			{
 				Profile* pProfile = PROFILEMAN->GetProfile(p);
 				STATSMAN->m_CurStageStats.m_player[p].iCurCombo = pProfile->m_iCurrentCombo;
@@ -733,7 +733,7 @@ void GameState::ResetStageStatistics()
 		}
 		else	// GetStageIndex() > 0
 		{
-			FOREACH_PlayerNumber(p)
+			FOREACH_PlayerNumber( p )
 			{
 				STATSMAN->m_CurStageStats.m_player[p].iCurCombo = OldStats.m_player[p].iCurCombo;
 			}
@@ -744,7 +744,7 @@ void GameState::ResetStageStatistics()
 	RemoveAllInventory();
 	m_fOpponentHealthPercent = 1;
 	m_fTugLifePercentP1 = 0.5f;
-	FOREACH_PlayerNumber(p)
+	FOREACH_PlayerNumber( p )
 	{
 		m_pPlayerState[p]->m_fSuperMeter = 0;
 		m_pPlayerState[p]->m_HealthState = PlayerState::ALIVE;
@@ -756,7 +756,7 @@ void GameState::ResetStageStatistics()
 	}
 
 
-	FOREACH_PlayerNumber(p)
+	FOREACH_PlayerNumber( p )
 	{
 		m_vLastPerDifficultyAwards[p].clear();
 		m_vLastPeakComboAwards[p].clear();
@@ -769,28 +769,28 @@ void GameState::ResetStageStatistics()
 	ResetOriginalSyncData();
 }
 
-void GameState::UpdateSongPosition(float fPositionSeconds, const TimingData &timing, const RageTimer &timestamp)
+void GameState::UpdateSongPosition( float fPositionSeconds, const TimingData &timing, const RageTimer &timestamp )
 {
-	if (!timestamp.IsZero())
+	if( !timestamp.IsZero() )
 		m_LastBeatUpdate = timestamp;
 	else
 		m_LastBeatUpdate.Touch();
-	timing.GetBeatAndBPSFromElapsedTime(fPositionSeconds, m_fSongBeat, m_fCurBPS, m_bFreeze);
-	ASSERT_M(m_fSongBeat > -2000, ssprintf("%f %f", m_fSongBeat, fPositionSeconds));
+	timing.GetBeatAndBPSFromElapsedTime( fPositionSeconds, m_fSongBeat, m_fCurBPS, m_bFreeze );
+	ASSERT_M( m_fSongBeat > -2000, ssprintf("%f %f", m_fSongBeat, fPositionSeconds) );
 
 	m_fMusicSeconds = fPositionSeconds;
-	m_fLightSongBeat = timing.GetBeatFromElapsedTime(fPositionSeconds + g_fLightsAheadSeconds);
+	m_fLightSongBeat = timing.GetBeatFromElapsedTime( fPositionSeconds + g_fLightsAheadSeconds );
 
 	/* update the Visible values based on the delay */
 	m_fMusicSecondsVisible = fPositionSeconds - PREFSMAN->m_fVisualDelaySeconds;
 
 	float fThrowAway; bool bThrowAway;
-	timing.GetBeatAndBPSFromElapsedTime(m_fMusicSecondsVisible, m_fSongBeatVisible, fThrowAway, bThrowAway);
+	timing.GetBeatAndBPSFromElapsedTime( m_fMusicSecondsVisible, m_fSongBeatVisible, fThrowAway, bThrowAway );
 
-	Actor::SetBGMTime(m_fMusicSecondsVisible, m_fSongBeatVisible);
+	Actor::SetBGMTime( m_fMusicSecondsVisible, m_fSongBeatVisible );
 }
 
-float GameState::GetSongPercent(float beat) const
+float GameState::GetSongPercent( float beat ) const
 {
 	/* 0 = first step; 1 = last step */
 	return (beat - m_pCurSong->m_fFirstBeat) / m_pCurSong->m_fLastBeat;
@@ -803,80 +803,80 @@ int GameState::GetStageIndex() const
 
 int GameState::GetNumStagesLeft() const
 {
-	if (IsExtraStage() || IsExtraStage2())
+	if( IsExtraStage() || IsExtraStage2() )
 		return 1;
-	if (GAMESTATE->IsEventMode())
+	if( GAMESTATE->IsEventMode() )
 		return 999;
 	return PREFSMAN->m_iSongsPerPlay - m_iCurrentStageIndex;
 }
 
 bool GameState::IsFinalStage() const
 {
-	if (GAMESTATE->IsEventMode())
+	if( GAMESTATE->IsEventMode() )
 		return false;
 
-	if (this->IsCourseMode())
+	if( this->IsCourseMode() )
 		return true;
 
 	/* This changes dynamically on ScreenSelectMusic as the wheel turns. */
 	int iPredictedStageForCurSong = GetNumStagesForCurrentSong();
-	if (iPredictedStageForCurSong == -1)
+	if( iPredictedStageForCurSong == -1 )
 		iPredictedStageForCurSong = 1;
 	return m_iCurrentStageIndex + iPredictedStageForCurSong == PREFSMAN->m_iSongsPerPlay;
 }
 
 bool GameState::IsExtraStage() const
 {
-	if (GAMESTATE->IsEventMode())
+	if( GAMESTATE->IsEventMode() )
 		return false;
 	return m_iCurrentStageIndex == PREFSMAN->m_iSongsPerPlay;
 }
 
 bool GameState::IsExtraStage2() const
 {
-	if (GAMESTATE->IsEventMode())
+	if( GAMESTATE->IsEventMode() )
 		return false;
-	return m_iCurrentStageIndex == PREFSMAN->m_iSongsPerPlay + 1;
+	return m_iCurrentStageIndex == PREFSMAN->m_iSongsPerPlay+1;
 }
 
 Stage GameState::GetCurrentStage() const
 {
-	if (m_bDemonstrationOrJukebox)				return STAGE_DEMO;
+	if( m_bDemonstrationOrJukebox )				return STAGE_DEMO;
 	// "event" has precedence
-	else if (GAMESTATE->IsEventMode())			return STAGE_EVENT;
-	else if (m_PlayMode == PLAY_MODE_ONI)		return STAGE_ONI;
-	else if (m_PlayMode == PLAY_MODE_NONSTOP)	return STAGE_NONSTOP;
-	else if (m_PlayMode == PLAY_MODE_ENDLESS)	return STAGE_ENDLESS;
-	else if (IsFinalStage())					return STAGE_FINAL;
-	else if (IsExtraStage())					return STAGE_EXTRA1;
-	else if (IsExtraStage2())					return STAGE_EXTRA2;
-	else										return (Stage)(STAGE_1 + m_iCurrentStageIndex);
+	else if( GAMESTATE->IsEventMode() )			return STAGE_EVENT;
+	else if( m_PlayMode == PLAY_MODE_ONI )		return STAGE_ONI;
+	else if( m_PlayMode == PLAY_MODE_NONSTOP )	return STAGE_NONSTOP;
+	else if( m_PlayMode == PLAY_MODE_ENDLESS )	return STAGE_ENDLESS;
+	else if( IsFinalStage() )					return STAGE_FINAL;
+	else if( IsExtraStage() )					return STAGE_EXTRA1;
+	else if( IsExtraStage2() )					return STAGE_EXTRA2;
+	else										return (Stage)(STAGE_1+m_iCurrentStageIndex);
 }
 
-void GameState::GetPossibleStages(vector<Stage> &out) const
+void GameState::GetPossibleStages( vector<Stage> &out ) const
 {
 	// Optimze me so that we don't load graphics that can't possibly be shown
 	out.clear();
-	FOREACH_Stage(s)
-		out.push_back(s);
+	FOREACH_Stage( s )
+		out.push_back( s );
 }
 
 int GameState::GetCourseSongIndex() const
 {
 	int iSongIndex = 0;
 	/* iSongsPlayed includes the current song, so it's 1-based; subtract one. */
-	FOREACH_EnabledPlayer(pn)
-		iSongIndex = max(iSongIndex, STATSMAN->m_CurStageStats.m_player[pn].iSongsPlayed - 1);
+	FOREACH_EnabledPlayer( pn )
+		iSongIndex = max( iSongIndex, STATSMAN->m_CurStageStats.m_player[pn].iSongsPlayed-1 );
 	return iSongIndex;
 }
 
-CString GameState::GetPlayerDisplayName(PlayerNumber pn) const
+CString GameState::GetPlayerDisplayName( PlayerNumber pn ) const
 {
-	ASSERT(IsPlayerEnabled(pn));
+	ASSERT( IsPlayerEnabled(pn) );
 	const CString defaultnames[] = { "Player 1", "Player 2" };
-	if (IsHumanPlayer(pn))
+	if( IsHumanPlayer(pn) )
 	{
-		if (!PROFILEMAN->GetPlayerName(pn).empty())
+		if( !PROFILEMAN->GetPlayerName(pn).empty() )
 			return PROFILEMAN->GetPlayerName(pn);
 		else
 			return defaultnames[pn];
@@ -893,17 +893,17 @@ bool GameState::PlayersCanJoin() const
 }
 
 int GameState::GetNumSidesJoined() const
-{
+{ 
 	int iNumSidesJoined = 0;
-	for (int c = 0; c<NUM_PLAYERS; c++)
-		if (m_bSideIsJoined[c])
+	for( int c=0; c<NUM_PLAYERS; c++ )
+		if( m_bSideIsJoined[c] )
 			iNumSidesJoined++;	// left side, and right side
 	return iNumSidesJoined;
 }
 
 const Game* GameState::GetCurrentGame()
 {
-	ASSERT(m_pCurGame != NULL);	// the game must be set before calling this
+	ASSERT( m_pCurGame != NULL );	// the game must be set before calling this
 	return m_pCurGame;
 }
 
@@ -913,44 +913,44 @@ const Style* GameState::GetCurrentStyle() const
 }
 
 
-bool GameState::IsPlayerEnabled(PlayerNumber pn) const
+bool GameState::IsPlayerEnabled( PlayerNumber pn ) const
 {
 	// In rave, all players are present.  Non-human players are CPU controlled.
-	switch (m_PlayMode)
+	switch( m_PlayMode )
 	{
 	case PLAY_MODE_BATTLE:
 	case PLAY_MODE_RAVE:
 		return true;
 	}
 
-	return IsHumanPlayer(pn);
+	return IsHumanPlayer( pn );
 }
 
 int	GameState::GetNumPlayersEnabled() const
 {
 	int count = 0;
-	FOREACH_EnabledPlayer(pn)
+	FOREACH_EnabledPlayer( pn )
 		count++;
 	return count;
 }
 
 bool GameState::PlayerUsingBothSides() const
 {
-	ASSERT(this->GetCurrentStyle() != NULL);
+	ASSERT( this->GetCurrentStyle() != NULL );
 	return this->GetCurrentStyle()->m_StyleType == ONE_PLAYER_TWO_SIDES;
 }
 
-bool GameState::IsHumanPlayer(PlayerNumber pn) const
+bool GameState::IsHumanPlayer( PlayerNumber pn ) const
 {
-	if (m_pCurStyle == NULL)	// no style chosen
+	if( m_pCurStyle == NULL )	// no style chosen
 	{
-		if (this->PlayersCanJoin())
+		if( this->PlayersCanJoin() )	
 			return m_bSideIsJoined[pn];	// only allow input from sides that have already joined
 		else
 			return true;	// if we can't join, then we're on a screen like MusicScroll or GameOver
 	}
 
-	switch (GetCurrentStyle()->m_StyleType)
+	switch( GetCurrentStyle()->m_StyleType )
 	{
 	case TWO_PLAYERS_TWO_SIDES:
 		return true;
@@ -966,14 +966,14 @@ bool GameState::IsHumanPlayer(PlayerNumber pn) const
 int GameState::GetNumHumanPlayers() const
 {
 	int count = 0;
-	FOREACH_HumanPlayer(pn)
+	FOREACH_HumanPlayer( pn )
 		count++;
 	return count;
 }
 
 PlayerNumber GameState::GetFirstHumanPlayer() const
 {
-	FOREACH_HumanPlayer(pn)
+	FOREACH_HumanPlayer( pn )
 		return pn;
 	ASSERT(0);	// there must be at least 1 human player
 	return PLAYER_INVALID;
@@ -981,20 +981,20 @@ PlayerNumber GameState::GetFirstHumanPlayer() const
 
 PlayerNumber GameState::GetFirstDisabledPlayer() const
 {
-	FOREACH_PlayerNumber(pn)
-		if (!IsPlayerEnabled(pn))
+	FOREACH_PlayerNumber( pn )
+		if( !IsPlayerEnabled(pn) )
 			return pn;
 	return PLAYER_INVALID;
 }
 
-bool GameState::IsCpuPlayer(PlayerNumber pn) const
+bool GameState::IsCpuPlayer( PlayerNumber pn ) const
 {
 	return IsPlayerEnabled(pn) && !IsHumanPlayer(pn);
 }
 
 bool GameState::AnyPlayersAreCpu() const
-{
-	FOREACH_CpuPlayer(pn)
+{ 
+	FOREACH_CpuPlayer( pn )
 		return true;
 	return false;
 }
@@ -1002,7 +1002,7 @@ bool GameState::AnyPlayersAreCpu() const
 
 bool GameState::IsCourseMode() const
 {
-	switch (m_PlayMode)
+	switch(m_PlayMode)
 	{
 	case PLAY_MODE_ONI:
 	case PLAY_MODE_NONSTOP:
@@ -1015,7 +1015,7 @@ bool GameState::IsCourseMode() const
 
 bool GameState::IsBattleMode() const
 {
-	switch (this->m_PlayMode)
+	switch( this->m_PlayMode )
 	{
 	case PLAY_MODE_BATTLE:
 		return true;
@@ -1026,30 +1026,30 @@ bool GameState::IsBattleMode() const
 
 bool GameState::HasEarnedExtraStage() const
 {
-	if (GAMESTATE->IsEventMode())
+	if( GAMESTATE->IsEventMode() )
 		return false;
 
-	if (!PREFSMAN->m_bAllowExtraStage)
+	if( !PREFSMAN->m_bAllowExtraStage )
 		return false;
 
-	if (this->m_PlayMode != PLAY_MODE_REGULAR)
+	if( this->m_PlayMode != PLAY_MODE_REGULAR )
 		return false;
 
-	if ((this->IsFinalStage() || this->IsExtraStage()))
+	if( (this->IsFinalStage() || this->IsExtraStage()) )
 	{
-		FOREACH_EnabledPlayer(pn)
+		FOREACH_EnabledPlayer( pn )
 		{
-			if (this->m_pCurSteps[pn]->GetDifficulty() != DIFFICULTY_HARD &&
-				this->m_pCurSteps[pn]->GetDifficulty() != DIFFICULTY_CHALLENGE)
+			if( this->m_pCurSteps[pn]->GetDifficulty() != DIFFICULTY_HARD && 
+				this->m_pCurSteps[pn]->GetDifficulty() != DIFFICULTY_CHALLENGE )
 				continue; /* not hard enough! */
 
 			/* If "choose EX" is enabled, then we should only grant EX2 if the chosen
-			* stage was the EX we would have chosen (m_bAllow2ndExtraStage is true). */
-			//			if( PREFSMAN->m_bPickExtraStage && this->IsExtraStage() && !this->m_bAllow2ndExtraStage )
-			if (this->IsExtraStage() && !this->m_bAllow2ndExtraStage)
+			 * stage was the EX we would have chosen (m_bAllow2ndExtraStage is true). */
+//			if( PREFSMAN->m_bPickExtraStage && this->IsExtraStage() && !this->m_bAllow2ndExtraStage )
+			if( this->IsExtraStage() && !this->m_bAllow2ndExtraStage )
 				continue;
 
-			if (STATSMAN->m_CurStageStats.m_player[pn].GetGrade() <= GRADE_TIER03)
+			if( STATSMAN->m_CurStageStats.m_player[pn].GetGrade() <= GRADE_TIER03 )
 				return true;
 		}
 	}
@@ -1058,40 +1058,40 @@ bool GameState::HasEarnedExtraStage() const
 
 PlayerNumber GameState::GetBestPlayer() const
 {
-	FOREACH_PlayerNumber(pn)
-		if (GetStageResult(pn) == RESULT_WIN)
+	FOREACH_PlayerNumber( pn )
+		if( GetStageResult(pn) == RESULT_WIN )
 			return pn;
 	return PLAYER_INVALID;	// draw
 }
 
-StageResult GameState::GetStageResult(PlayerNumber pn) const
+StageResult GameState::GetStageResult( PlayerNumber pn ) const
 {
-	switch (this->m_PlayMode)
+	switch( this->m_PlayMode )
 	{
 	case PLAY_MODE_BATTLE:
 	case PLAY_MODE_RAVE:
-		if (fabsf(m_fTugLifePercentP1 - 0.5f) < 0.0001f)
+		if( fabsf(m_fTugLifePercentP1 - 0.5f) < 0.0001f )
 			return RESULT_DRAW;
-		switch (pn)
+		switch( pn )
 		{
-		case PLAYER_1:	return (m_fTugLifePercentP1 >= 0.5f) ? RESULT_WIN : RESULT_LOSE;
-		case PLAYER_2:	return (m_fTugLifePercentP1<0.5f) ? RESULT_WIN : RESULT_LOSE;
+		case PLAYER_1:	return (m_fTugLifePercentP1>=0.5f)?RESULT_WIN:RESULT_LOSE;
+		case PLAYER_2:	return (m_fTugLifePercentP1<0.5f)?RESULT_WIN:RESULT_LOSE;
 		default:	ASSERT(0); return RESULT_LOSE;
 		}
 	}
 
 	StageResult win = RESULT_WIN;
-	FOREACH_PlayerNumber(p)
+	FOREACH_PlayerNumber( p )
 	{
-		if (p == pn)
+		if( p == pn )
 			continue;
 
 		/* If anyone did just as well, at best it's a draw. */
-		if (STATSMAN->m_CurStageStats.m_player[p].iActualDancePoints == STATSMAN->m_CurStageStats.m_player[pn].iActualDancePoints)
+		if( STATSMAN->m_CurStageStats.m_player[p].iActualDancePoints == STATSMAN->m_CurStageStats.m_player[pn].iActualDancePoints )
 			win = RESULT_DRAW;
 
 		/* If anyone did better, we lost. */
-		if (STATSMAN->m_CurStageStats.m_player[p].iActualDancePoints > STATSMAN->m_CurStageStats.m_player[pn].iActualDancePoints)
+		if( STATSMAN->m_CurStageStats.m_player[p].iActualDancePoints > STATSMAN->m_CurStageStats.m_player[pn].iActualDancePoints )
 			return RESULT_LOSE;
 	}
 	return win;
@@ -1099,126 +1099,126 @@ StageResult GameState::GetStageResult(PlayerNumber pn) const
 
 
 
-void GameState::ApplyModifiers(PlayerNumber pn, CString sModifiers)
+void GameState::ApplyModifiers( PlayerNumber pn, CString sModifiers )
 {
-	m_pPlayerState[pn]->m_PlayerOptions.FromString(sModifiers);
-	m_SongOptions.FromString(sModifiers);
+	m_pPlayerState[pn]->m_PlayerOptions.FromString( sModifiers );
+	m_SongOptions.FromString( sModifiers );
 }
 
 /* Store the player's preferred options.  This is called at the very beginning
-* of gameplay. */
+ * of gameplay. */
 void GameState::StoreSelectedOptions()
 {
-	FOREACH_PlayerNumber(pn)
+	FOREACH_PlayerNumber( pn )
 		m_pPlayerState[pn]->m_StoredPlayerOptions = m_pPlayerState[pn]->m_PlayerOptions;
 	m_StoredSongOptions = m_SongOptions;
 }
 
 /* Restore the preferred options.  This is called after a song ends, before
-* setting new course options, so options from one song don't carry into the
-* next and we default back to the preferred options.  This is also called
-* at the end of gameplay to restore options. */
+ * setting new course options, so options from one song don't carry into the
+ * next and we default back to the preferred options.  This is also called
+ * at the end of gameplay to restore options. */
 void GameState::RestoreSelectedOptions()
 {
-	FOREACH_PlayerNumber(pn)
+	FOREACH_PlayerNumber( pn )
 		m_pPlayerState[pn]->m_PlayerOptions = m_pPlayerState[pn]->m_StoredPlayerOptions;
 	m_SongOptions = m_StoredSongOptions;
 }
 
 void GameState::ResetCurrentOptions()
 {
-	FOREACH_PlayerNumber(p)
+	FOREACH_PlayerNumber( p )
 	{
 		m_pPlayerState[p]->m_PlayerOptions.Init();
-		m_pPlayerState[p]->m_PlayerOptions.FromString(PREFSMAN->m_sDefaultModifiers);
+		m_pPlayerState[p]->m_PlayerOptions.FromString( PREFSMAN->m_sDefaultModifiers );
 	}
 	m_SongOptions.Init();
-	m_SongOptions.FromString(PREFSMAN->m_sDefaultModifiers);
+	m_SongOptions.FromString( PREFSMAN->m_sDefaultModifiers );
 }
 
-bool GameState::IsDisqualified(PlayerNumber pn)
+bool GameState::IsDisqualified( PlayerNumber pn )
 {
-	if (!IsPlayerEnabled(pn))
+	if( !IsPlayerEnabled(pn) )
 		return false;
 
-	if (!PREFSMAN->m_bDisqualification)
+	if( !PREFSMAN->m_bDisqualification )
 		return false;
 
-	if (GAMESTATE->m_SongOptions.m_fMusicRate < 1.0f)
+	if( GAMESTATE->m_SongOptions.m_fMusicRate < 1.0f )
 		return true;
 
-	if (GAMESTATE->IsCourseMode())
+	if( GAMESTATE->IsCourseMode() )
 	{
-		return GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions.IsEasierForCourseAndTrail(
-			GAMESTATE->m_pCurCourse,
-			GAMESTATE->m_pCurTrail[pn]);
+		return GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions.IsEasierForCourseAndTrail( 
+			GAMESTATE->m_pCurCourse, 
+			GAMESTATE->m_pCurTrail[pn] );
 	}
 	else
 	{
-		return GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions.IsEasierForSongAndSteps(
-			GAMESTATE->m_pCurSong,
-			GAMESTATE->m_pCurSteps[pn]);
+		return GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions.IsEasierForSongAndSteps( 
+			GAMESTATE->m_pCurSong, 
+			GAMESTATE->m_pCurSteps[pn] );
 	}
 }
 
 void GameState::ResetNoteSkins()
 {
-	FOREACH_PlayerNumber(pn)
-		ResetNoteSkinsForPlayer(pn);
+	FOREACH_PlayerNumber( pn )
+		ResetNoteSkinsForPlayer(  pn );
 
 	++m_BeatToNoteSkinRev;
 }
 
-void GameState::ResetNoteSkinsForPlayer(PlayerNumber pn)
+void GameState::ResetNoteSkinsForPlayer( PlayerNumber pn )
 {
 	m_pPlayerState[pn]->ResetNoteSkins();
 
 	++m_BeatToNoteSkinRev;
 }
 
-void GameState::GetAllUsedNoteSkins(vector<CString> &out) const
+void GameState::GetAllUsedNoteSkins( vector<CString> &out ) const
 {
-	FOREACH_EnabledPlayer(pn)
+	FOREACH_EnabledPlayer( pn )
 	{
-		out.push_back(m_pPlayerState[pn]->m_PlayerOptions.m_sNoteSkin);
+		out.push_back( m_pPlayerState[pn]->m_PlayerOptions.m_sNoteSkin );
 
-		switch (this->m_PlayMode)
+		switch( this->m_PlayMode )
 		{
 		case PLAY_MODE_BATTLE:
 		case PLAY_MODE_RAVE:
-			for (int al = 0; al<NUM_ATTACK_LEVELS; al++)
+			for( int al=0; al<NUM_ATTACK_LEVELS; al++ )
 			{
 				const Character *ch = this->m_pCurCharacters[pn];
-				ASSERT(ch);
+				ASSERT( ch );
 				const CString* asAttacks = ch->m_sAttacks[al];
-				for (int att = 0; att < NUM_ATTACKS_PER_LEVEL; ++att)
+				for( int att = 0; att < NUM_ATTACKS_PER_LEVEL; ++att )
 				{
 					PlayerOptions po;
-					po.FromString(asAttacks[att]);
-					out.push_back(po.m_sNoteSkin);
+					po.FromString( asAttacks[att] );
+					out.push_back( po.m_sNoteSkin );
 				}
 			}
 		}
 
 		/* Add note skins that are used in courses. */
-		if (this->IsCourseMode())
+		if( this->IsCourseMode() )
 		{
 			FOREACH_EnabledPlayer(pn)
 			{
 				const Trail *pTrail = this->m_pCurTrail[pn];
-				ASSERT(pTrail);
+				ASSERT( pTrail );
 
-				FOREACH_CONST(TrailEntry, pTrail->m_vEntries, e)
+				FOREACH_CONST( TrailEntry, pTrail->m_vEntries, e )
 				{
 					AttackArray a;
-					e->GetAttackArray(a);
+					e->GetAttackArray( a );
 
-					for (unsigned j = 0; j<a.size(); j++)
+					for( unsigned j=0; j<a.size(); j++ )
 					{
 						const Attack &mod = a[j];
 						PlayerOptions po;
-						po.FromString(mod.sModifiers);
-						out.push_back(po.m_sNoteSkin);
+						po.FromString( mod.sModifiers );
+						out.push_back( po.m_sNoteSkin );
 					}
 				}
 			}
@@ -1226,16 +1226,16 @@ void GameState::GetAllUsedNoteSkins(vector<CString> &out) const
 	}
 
 	/* Remove duplicates. */
-	sort(out.begin(), out.end());
-	out.erase(unique(out.begin(), out.end()), out.end());
+	sort( out.begin(), out.end() );
+	out.erase( unique( out.begin(), out.end() ), out.end() );
 
 	/* Hack: NoteSkin "default" is never applied as an attack, so don't
-	* waste memory preloading it. */
-	for (unsigned i = 0; i < out.size(); ++i)
+	 * waste memory preloading it. */
+	for( unsigned i = 0; i < out.size(); ++i )
 	{
-		if (!out[i].CompareNoCase("default") || out[i] == "")
+		if( !out[i].CompareNoCase("default") || out[i] == "" )
 		{
-			out.erase(out.begin() + i, out.begin() + i + 1);
+			out.erase( out.begin()+i, out.begin()+i+1 );
 			--i;
 		}
 	}
@@ -1243,27 +1243,27 @@ void GameState::GetAllUsedNoteSkins(vector<CString> &out) const
 
 /* From NoteField: */
 
-void GameState::GetUndisplayedBeats(const PlayerState* pPlayerState, float TotalSeconds, float &StartBeat, float &EndBeat) const
+void GameState::GetUndisplayedBeats( const PlayerState* pPlayerState, float TotalSeconds, float &StartBeat, float &EndBeat ) const
 {
 	/* If reasonable, push the attack forward so notes on screen don't change suddenly. */
-	StartBeat = min(m_fSongBeat + BEATS_PER_MEASURE * 2, pPlayerState->m_fLastDrawnBeat);
-	StartBeat = truncf(StartBeat) + 1;
+	StartBeat = min( m_fSongBeat+BEATS_PER_MEASURE*2, pPlayerState->m_fLastDrawnBeat );
+	StartBeat = truncf(StartBeat)+1;
 
-	const float StartSecond = this->m_pCurSong->GetElapsedTimeFromBeat(StartBeat);
+	const float StartSecond = this->m_pCurSong->GetElapsedTimeFromBeat( StartBeat );
 	const float EndSecond = StartSecond + TotalSeconds;
-	EndBeat = this->m_pCurSong->GetBeatFromElapsedTime(EndSecond);
-	EndBeat = truncf(EndBeat) + 1;
+	EndBeat = this->m_pCurSong->GetBeatFromElapsedTime( EndSecond );
+	EndBeat = truncf(EndBeat)+1;
 }
 
 
-void GameState::SetNoteSkinForBeatRange(PlayerState* pPlayerState, const CString& sNoteSkin, float StartBeat, float EndBeat)
+void GameState::SetNoteSkinForBeatRange( PlayerState* pPlayerState, const CString& sNoteSkin, float StartBeat, float EndBeat )
 {
-	map<float, CString> &BeatToNoteSkin = pPlayerState->m_BeatToNoteSkin;
+	map<float,CString> &BeatToNoteSkin = pPlayerState->m_BeatToNoteSkin;
 
 	/* Erase any other note skin settings in this range. */
-	map<float, CString>::iterator begin = BeatToNoteSkin.lower_bound(StartBeat);
-	map<float, CString>::iterator end = BeatToNoteSkin.upper_bound(EndBeat);
-	BeatToNoteSkin.erase(begin, end);
+	map<float,CString>::iterator begin = BeatToNoteSkin.lower_bound( StartBeat );
+	map<float,CString>::iterator end = BeatToNoteSkin.upper_bound( EndBeat );
+	BeatToNoteSkin.erase( begin, end );
 
 	/* Add the skin to m_BeatToNoteSkin.  */
 	BeatToNoteSkin[StartBeat] = sNoteSkin;
@@ -1275,48 +1275,48 @@ void GameState::SetNoteSkinForBeatRange(PlayerState* pPlayerState, const CString
 }
 
 /* This is called to launch an attack, or to queue an attack if a.fStartSecond
-* is set.  This is also called by GameState::Update when activating a queued attack. */
-void GameState::LaunchAttack(PlayerNumber target, const Attack& a)
+ * is set.  This is also called by GameState::Update when activating a queued attack. */
+void GameState::LaunchAttack( PlayerNumber target, const Attack& a )
 {
-	LOG->Trace("Launch attack '%s' against P%d at %f", a.sModifiers.c_str(), target + 1, a.fStartSecond);
+	LOG->Trace( "Launch attack '%s' against P%d at %f", a.sModifiers.c_str(), target+1, a.fStartSecond );
 
 	Attack attack = a;
 
 	/* If fStartSecond is -1, it means "launch as soon as possible".  For m_ActiveAttacks,
-	* mark the real time it's starting (now), so Update() can know when the attack started
-	* so it can be removed later.  For m_ModsToApply, leave the -1 in, so Player::Update
-	* knows to apply attack transforms correctly.  (yuck) */
-	m_pPlayerState[target]->m_ModsToApply.push_back(attack);
-	if (attack.fStartSecond == -1)
+	 * mark the real time it's starting (now), so Update() can know when the attack started
+	 * so it can be removed later.  For m_ModsToApply, leave the -1 in, so Player::Update
+	 * knows to apply attack transforms correctly.  (yuck) */
+	m_pPlayerState[target]->m_ModsToApply.push_back( attack );
+	if( attack.fStartSecond == -1 )
 		attack.fStartSecond = this->m_fMusicSeconds;
-	m_pPlayerState[target]->m_ActiveAttacks.push_back(attack);
+	m_pPlayerState[target]->m_ActiveAttacks.push_back( attack );
 
-	this->RebuildPlayerOptionsFromActiveAttacks(target);
+	this->RebuildPlayerOptionsFromActiveAttacks( target );
 }
 
-void GameState::RemoveActiveAttacksForPlayer(PlayerNumber pn, AttackLevel al)
+void GameState::RemoveActiveAttacksForPlayer( PlayerNumber pn, AttackLevel al )
 {
-	for (unsigned s = 0; s<m_pPlayerState[pn]->m_ActiveAttacks.size(); s++)
+	for( unsigned s=0; s<m_pPlayerState[pn]->m_ActiveAttacks.size(); s++ )
 	{
-		if (al != NUM_ATTACK_LEVELS && al != m_pPlayerState[pn]->m_ActiveAttacks[s].level)
+		if( al != NUM_ATTACK_LEVELS && al != m_pPlayerState[pn]->m_ActiveAttacks[s].level )
 			continue;
-		m_pPlayerState[pn]->m_ActiveAttacks.erase(m_pPlayerState[pn]->m_ActiveAttacks.begin() + s, m_pPlayerState[pn]->m_ActiveAttacks.begin() + s + 1);
+		m_pPlayerState[pn]->m_ActiveAttacks.erase( m_pPlayerState[pn]->m_ActiveAttacks.begin()+s, m_pPlayerState[pn]->m_ActiveAttacks.begin()+s+1 );
 		--s;
 	}
-	RebuildPlayerOptionsFromActiveAttacks(pn);
+	RebuildPlayerOptionsFromActiveAttacks( pn );
 }
 
-void GameState::EndActiveAttacksForPlayer(PlayerNumber pn)
+void GameState::EndActiveAttacksForPlayer( PlayerNumber pn )
 {
-	FOREACH(Attack, m_pPlayerState[pn]->m_ActiveAttacks, a)
+	FOREACH( Attack, m_pPlayerState[pn]->m_ActiveAttacks, a )
 		a->fSecsRemaining = 0;
 }
 
 void GameState::RemoveAllInventory()
 {
-	FOREACH_PlayerNumber(p)
+	FOREACH_PlayerNumber( p )
 	{
-		for (int s = 0; s<NUM_INVENTORY_SLOTS; s++)
+		for( int s=0; s<NUM_INVENTORY_SLOTS; s++ )
 		{
 			m_pPlayerState[p]->m_Inventory[s].fSecsRemaining = 0;
 			m_pPlayerState[p]->m_Inventory[s].sModifiers = "";
@@ -1324,21 +1324,21 @@ void GameState::RemoveAllInventory()
 	}
 }
 
-void GameState::RebuildPlayerOptionsFromActiveAttacks(PlayerNumber pn)
+void GameState::RebuildPlayerOptionsFromActiveAttacks( PlayerNumber pn )
 {
 	// rebuild player options
 	PlayerOptions po = m_pPlayerState[pn]->m_StoredPlayerOptions;
-	for (unsigned s = 0; s<m_pPlayerState[pn]->m_ActiveAttacks.size(); s++)
+	for( unsigned s=0; s<m_pPlayerState[pn]->m_ActiveAttacks.size(); s++ )
 	{
-		if (!m_pPlayerState[pn]->m_ActiveAttacks[s].bOn)
+		if( !m_pPlayerState[pn]->m_ActiveAttacks[s].bOn )
 			continue; /* hasn't started yet */
-		po.FromString(m_pPlayerState[pn]->m_ActiveAttacks[s].sModifiers);
+		po.FromString( m_pPlayerState[pn]->m_ActiveAttacks[s].sModifiers );
 	}
 	m_pPlayerState[pn]->m_PlayerOptions = po;
 
 
-	int iSumOfAttackLevels = GetSumOfActiveAttackLevels(pn);
-	if (iSumOfAttackLevels > 0)
+	int iSumOfAttackLevels = GetSumOfActiveAttackLevels( pn );
+	if( iSumOfAttackLevels > 0 )
 	{
 		m_pPlayerState[pn]->m_iLastPositiveSumOfAttackLevels = iSumOfAttackLevels;
 		m_pPlayerState[pn]->m_fSecondsUntilAttacksPhasedOut = 10000;	// any positive number that won't run out before the attacks
@@ -1352,68 +1352,68 @@ void GameState::RebuildPlayerOptionsFromActiveAttacks(PlayerNumber pn)
 
 void GameState::RemoveAllActiveAttacks()	// called on end of song
 {
-	FOREACH_PlayerNumber(p)
-		RemoveActiveAttacksForPlayer(p);
+	FOREACH_PlayerNumber( p )
+		RemoveActiveAttacksForPlayer( p );
 }
 
-int GameState::GetSumOfActiveAttackLevels(PlayerNumber pn) const
+int GameState::GetSumOfActiveAttackLevels( PlayerNumber pn ) const
 {
 	int iSum = 0;
 
-	for (unsigned s = 0; s<m_pPlayerState[pn]->m_ActiveAttacks.size(); s++)
-		if (m_pPlayerState[pn]->m_ActiveAttacks[s].fSecsRemaining > 0 && m_pPlayerState[pn]->m_ActiveAttacks[s].level != NUM_ATTACK_LEVELS)
+	for( unsigned s=0; s<m_pPlayerState[pn]->m_ActiveAttacks.size(); s++ )
+		if( m_pPlayerState[pn]->m_ActiveAttacks[s].fSecsRemaining > 0 && m_pPlayerState[pn]->m_ActiveAttacks[s].level != NUM_ATTACK_LEVELS )
 			iSum += m_pPlayerState[pn]->m_ActiveAttacks[s].level;
 
 	return iSum;
 }
 
 template<class T>
-void setmin(T &a, const T &b)
+void setmin( T &a, const T &b )
 {
 	a = min(a, b);
 }
 
 template<class T>
-void setmax(T &a, const T &b)
+void setmax( T &a, const T &b )
 {
 	a = max(a, b);
 }
 
-SongOptions::FailType GameState::GetPlayerFailType(PlayerNumber pn) const
+SongOptions::FailType GameState::GetPlayerFailType( PlayerNumber pn ) const
 {
 	SongOptions::FailType ft = m_SongOptions.m_FailType;
 
 	/* If the player changed the fail mode explicitly, leave it alone. */
-	if (this->m_bChangedFailTypeOnScreenSongOptions)
+	if( this->m_bChangedFailTypeOnScreenSongOptions )
 		return ft;
 
-	if (GAMESTATE->IsCourseMode())
+	if( GAMESTATE->IsCourseMode() )
 	{
-		if (PREFSMAN->m_bMinimum1FullSongInCourses && GAMESTATE->GetCourseSongIndex() == 0)
-			ft = max(ft, SongOptions::FAIL_END_OF_SONG);	// take the least harsh of the two FailTypes
+		if( PREFSMAN->m_bMinimum1FullSongInCourses && GAMESTATE->GetCourseSongIndex()==0 )
+			ft = max( ft, SongOptions::FAIL_END_OF_SONG );	// take the least harsh of the two FailTypes
 	}
 	else
 	{
 		Difficulty dc = DIFFICULTY_INVALID;
-		if (m_pCurSteps[pn])
+		if( m_pCurSteps[pn] )
 			dc = m_pCurSteps[pn]->GetDifficulty();
 
 		bool bFirstStage = !GAMESTATE->IsEventMode() && m_iCurrentStageIndex == 0;
 
 		/* Easy and beginner are never harder than FAIL_END_OF_SONG. */
-		if (dc <= DIFFICULTY_EASY)
-			setmax(ft, SongOptions::FAIL_END_OF_SONG);
+		if( dc <= DIFFICULTY_EASY )
+			setmax( ft, SongOptions::FAIL_END_OF_SONG );
 
-		if (dc <= DIFFICULTY_EASY && bFirstStage && PREFSMAN->m_bFailOffForFirstStageEasy)
-			setmax(ft, SongOptions::FAIL_OFF);
+		if( dc <= DIFFICULTY_EASY && bFirstStage && PREFSMAN->m_bFailOffForFirstStageEasy )
+			setmax( ft, SongOptions::FAIL_OFF );
 
 		/* If beginner's steps were chosen, and this is the first stage,
-		* turn off failure completely. */
-		if (dc == DIFFICULTY_BEGINNER && bFirstStage)
-			setmax(ft, SongOptions::FAIL_OFF);
+		 * turn off failure completely. */
+		if( dc == DIFFICULTY_BEGINNER && bFirstStage )
+			setmax( ft, SongOptions::FAIL_OFF );
 
-		if (dc == DIFFICULTY_BEGINNER && PREFSMAN->m_bFailOffInBeginner)
-			setmax(ft, SongOptions::FAIL_OFF);
+		if( dc == DIFFICULTY_BEGINNER && PREFSMAN->m_bFailOffInBeginner )
+			setmax( ft, SongOptions::FAIL_OFF );
 	}
 
 	return ft;
@@ -1421,7 +1421,7 @@ SongOptions::FailType GameState::GetPlayerFailType(PlayerNumber pn) const
 
 bool GameState::ShowMarvelous() const
 {
-	switch (PREFSMAN->m_MarvelousTiming)
+	switch( PREFSMAN->m_MarvelousTiming )
 	{
 	case PrefsManager::MARVELOUS_NEVER:			return false;
 	case PrefsManager::MARVELOUS_COURSES_ONLY:	return IsCourseMode();
@@ -1430,28 +1430,28 @@ bool GameState::ShowMarvelous() const
 	}
 }
 
-void GameState::GetCharacters(vector<Character*> &apCharactersOut)
+void GameState::GetCharacters( vector<Character*> &apCharactersOut )
 {
-	for (unsigned i = 0; i<m_pCharacters.size(); i++)
-		if (m_pCharacters[i]->m_sName.CompareNoCase("default") != 0)
-			apCharactersOut.push_back(m_pCharacters[i]);
+	for( unsigned i=0; i<m_pCharacters.size(); i++ )
+		if( m_pCharacters[i]->m_sName.CompareNoCase("default")!=0 )
+			apCharactersOut.push_back( m_pCharacters[i] );
 }
 
 Character* GameState::GetRandomCharacter()
 {
 	vector<Character*> apCharacters;
-	GetCharacters(apCharacters);
-	if (apCharacters.size())
-		return apCharacters[rand() % apCharacters.size()];
+	GetCharacters( apCharacters );
+	if( apCharacters.size() )
+		return apCharacters[rand()%apCharacters.size()];
 	else
 		return GetDefaultCharacter();
 }
 
 Character* GameState::GetDefaultCharacter()
 {
-	for (unsigned i = 0; i<m_pCharacters.size(); i++)
+	for( unsigned i=0; i<m_pCharacters.size(); i++ )
 	{
-		if (m_pCharacters[i]->m_sName.CompareNoCase("default") == 0)
+		if( m_pCharacters[i]->m_sName.CompareNoCase("default")==0 )
 			return m_pCharacters[i];
 	}
 
@@ -1464,231 +1464,231 @@ struct SongAndSteps
 {
 	Song* pSong;
 	Steps* pSteps;
-	bool operator==(const SongAndSteps& other) const { return pSong == other.pSong && pSteps == other.pSteps; }
-	bool operator<(const SongAndSteps& other) const { return pSong <= other.pSong && pSteps <= other.pSteps; }
+	bool operator==( const SongAndSteps& other ) const { return pSong==other.pSong && pSteps==other.pSteps; }
+	bool operator<( const SongAndSteps& other ) const { return pSong<=other.pSong && pSteps<=other.pSteps; }
 };
 
-void GameState::GetRankingFeats(PlayerNumber pn, vector<RankingFeat> &asFeatsOut) const
+void GameState::GetRankingFeats( PlayerNumber pn, vector<RankingFeat> &asFeatsOut ) const
 {
-	if (!IsHumanPlayer(pn))
+	if( !IsHumanPlayer(pn) )
 		return;
 
 	Profile *pProf = PROFILEMAN->GetProfile(pn);
 
-	CHECKPOINT_M(ssprintf("PlayMode %i", this->m_PlayMode));
-	switch (this->m_PlayMode)
+	CHECKPOINT_M(ssprintf("PlayMode %i",this->m_PlayMode));
+	switch( this->m_PlayMode )
 	{
 	case PLAY_MODE_REGULAR:
-	{
-		CHECKPOINT;
-
-		StepsType st = this->GetCurrentStyle()->m_StepsType;
-
-		//
-		// Find unique Song and Steps combinations that were played.
-		// We must keep only the unique combination or else we'll double-count
-		// high score markers.
-		//
-		vector<SongAndSteps> vSongAndSteps;
-
-		for (unsigned i = 0; i<STATSMAN->m_vPlayedStageStats.size(); i++)
 		{
-			CHECKPOINT_M(ssprintf("%u/%i", i, (int)STATSMAN->m_vPlayedStageStats.size()));
-			SongAndSteps sas;
-			sas.pSong = STATSMAN->m_vPlayedStageStats[i].vpPlayedSongs[0];
-			ASSERT(sas.pSong);
-			sas.pSteps = STATSMAN->m_vPlayedStageStats[i].m_player[pn].vpPlayedSteps[0];
-			ASSERT(sas.pSteps);
-			vSongAndSteps.push_back(sas);
-		}
-		CHECKPOINT;
+			CHECKPOINT;
 
-		sort(vSongAndSteps.begin(), vSongAndSteps.end());
+			StepsType st = this->GetCurrentStyle()->m_StepsType;
 
-		vector<SongAndSteps>::iterator toDelete = unique(vSongAndSteps.begin(), vSongAndSteps.end());
-		vSongAndSteps.erase(toDelete, vSongAndSteps.end());
+			//
+			// Find unique Song and Steps combinations that were played.
+			// We must keep only the unique combination or else we'll double-count
+			// high score markers.
+			//
+			vector<SongAndSteps> vSongAndSteps;
 
-		CHECKPOINT;
-		for (unsigned i = 0; i<vSongAndSteps.size(); i++)
-		{
-			Song* pSong = vSongAndSteps[i].pSong;
-			Steps* pSteps = vSongAndSteps[i].pSteps;
-
-			// Find Machine Records
+			for( unsigned i=0; i<STATSMAN->m_vPlayedStageStats.size(); i++ )
 			{
-				HighScoreList &hsl = PROFILEMAN->GetMachineProfile()->GetStepsHighScoreList(pSong, pSteps);
-				for (unsigned j = 0; j<hsl.vHighScores.size(); j++)
+				CHECKPOINT_M( ssprintf("%u/%i", i, (int)STATSMAN->m_vPlayedStageStats.size() ) );
+				SongAndSteps sas;
+				sas.pSong = STATSMAN->m_vPlayedStageStats[i].vpPlayedSongs[0];
+				ASSERT( sas.pSong );
+				sas.pSteps = STATSMAN->m_vPlayedStageStats[i].m_player[pn].vpPlayedSteps[0];
+				ASSERT( sas.pSteps );
+				vSongAndSteps.push_back( sas );
+			}
+			CHECKPOINT;
+
+			sort( vSongAndSteps.begin(), vSongAndSteps.end() );
+
+			vector<SongAndSteps>::iterator toDelete = unique( vSongAndSteps.begin(), vSongAndSteps.end() );
+			vSongAndSteps.erase(toDelete, vSongAndSteps.end());
+
+			CHECKPOINT;
+			for( unsigned i=0; i<vSongAndSteps.size(); i++ )
+			{
+				Song* pSong = vSongAndSteps[i].pSong;
+				Steps* pSteps = vSongAndSteps[i].pSteps;
+
+				// Find Machine Records
 				{
-					HighScore &hs = hsl.vHighScores[j];
+					HighScoreList &hsl = PROFILEMAN->GetMachineProfile()->GetStepsHighScoreList(pSong,pSteps);
+					for( unsigned j=0; j<hsl.vHighScores.size(); j++ )
+					{
+						HighScore &hs = hsl.vHighScores[j];
 
-					if (hs.sName != RANKING_TO_FILL_IN_MARKER[pn])
-						continue;
+						if( hs.sName != RANKING_TO_FILL_IN_MARKER[pn] )
+							continue;
 
-					RankingFeat feat;
-					feat.Type = RankingFeat::SONG;
-					feat.pSong = pSong;
-					feat.pSteps = pSteps;
-					feat.Feat = ssprintf("MR #%d in %s %s", j + 1, pSong->GetTranslitMainTitle().c_str(), DifficultyToString(pSteps->GetDifficulty()).c_str());
-					feat.pStringToFill = &hs.sName;
-					feat.grade = hs.grade;
-					feat.fPercentDP = hs.fPercentDP;
-					feat.iScore = hs.iScore;
+						RankingFeat feat;
+						feat.Type = RankingFeat::SONG;
+						feat.pSong = pSong;
+						feat.pSteps = pSteps;
+						feat.Feat = ssprintf("MR #%d in %s %s", j+1, pSong->GetTranslitMainTitle().c_str(), DifficultyToString(pSteps->GetDifficulty()).c_str() );
+						feat.pStringToFill = &hs.sName;
+						feat.grade = hs.grade;
+						feat.fPercentDP = hs.fPercentDP;
+						feat.iScore = hs.iScore;
 
-					if (pSong->HasBanner())
-						feat.Banner = pSong->GetBannerPath();
+						if( pSong->HasBanner() )
+							feat.Banner = pSong->GetBannerPath();
 
-					asFeatsOut.push_back(feat);
+						asFeatsOut.push_back( feat );
+					}
+				}
+		
+				// Find Personal Records
+				if( pProf )
+				{
+					HighScoreList &hsl = pProf->GetStepsHighScoreList(pSong,pSteps);
+					for( unsigned j=0; j<hsl.vHighScores.size(); j++ )
+					{
+						HighScore &hs = hsl.vHighScores[j];
+
+						if( hs.sName != RANKING_TO_FILL_IN_MARKER[pn] )
+							continue;
+
+						RankingFeat feat;
+						feat.pSong = pSong;
+						feat.pSteps = pSteps;
+						feat.Type = RankingFeat::SONG;
+						feat.Feat = ssprintf("PR #%d in %s %s", j+1, pSong->GetTranslitMainTitle().c_str(), DifficultyToString(pSteps->GetDifficulty()).c_str() );
+						feat.pStringToFill = &hs.sName;
+						feat.grade = hs.grade;
+						feat.fPercentDP = hs.fPercentDP;
+						feat.iScore = hs.iScore;
+
+						// XXX: temporary hack
+						if( pSong->HasBackground() )
+							feat.Banner = pSong->GetBackgroundPath();
+		//					if( pSong->HasBanner() )
+		//						feat.Banner = pSong->GetBannerPath();
+
+						asFeatsOut.push_back( feat );
+					}
 				}
 			}
 
-			// Find Personal Records
-			if (pProf)
+			CHECKPOINT;
+			StageStats stats;
+			STATSMAN->GetFinalEvalStageStats( stats );
+
+
+			// Find Machine Category Records
+			FOREACH_RankingCategory( rc )
 			{
-				HighScoreList &hsl = pProf->GetStepsHighScoreList(pSong, pSteps);
-				for (unsigned j = 0; j<hsl.vHighScores.size(); j++)
+				HighScoreList &hsl = PROFILEMAN->GetMachineProfile()->GetCategoryHighScoreList( st, rc );
+				for( unsigned j=0; j<hsl.vHighScores.size(); j++ )
 				{
 					HighScore &hs = hsl.vHighScores[j];
-
-					if (hs.sName != RANKING_TO_FILL_IN_MARKER[pn])
-						continue;
-
-					RankingFeat feat;
-					feat.pSong = pSong;
-					feat.pSteps = pSteps;
-					feat.Type = RankingFeat::SONG;
-					feat.Feat = ssprintf("PR #%d in %s %s", j + 1, pSong->GetTranslitMainTitle().c_str(), DifficultyToString(pSteps->GetDifficulty()).c_str());
-					feat.pStringToFill = &hs.sName;
-					feat.grade = hs.grade;
-					feat.fPercentDP = hs.fPercentDP;
-					feat.iScore = hs.iScore;
-
-					// XXX: temporary hack
-					if (pSong->HasBackground())
-						feat.Banner = pSong->GetBackgroundPath();
-					//					if( pSong->HasBanner() )
-					//						feat.Banner = pSong->GetBannerPath();
-
-					asFeatsOut.push_back(feat);
-				}
-			}
-		}
-
-		CHECKPOINT;
-		StageStats stats;
-		STATSMAN->GetFinalEvalStageStats(stats);
-
-
-		// Find Machine Category Records
-		FOREACH_RankingCategory(rc)
-		{
-			HighScoreList &hsl = PROFILEMAN->GetMachineProfile()->GetCategoryHighScoreList(st, rc);
-			for (unsigned j = 0; j<hsl.vHighScores.size(); j++)
-			{
-				HighScore &hs = hsl.vHighScores[j];
-				if (hs.sName != RANKING_TO_FILL_IN_MARKER[pn])
-					continue;
-
-				RankingFeat feat;
-				feat.Type = RankingFeat::CATEGORY;
-				feat.Feat = ssprintf("MR #%d in Type %c (%d)", j + 1, 'A' + rc, stats.GetAverageMeter(pn));
-				feat.pStringToFill = &hs.sName;
-				feat.grade = GRADE_NO_DATA;
-				feat.iScore = hs.iScore;
-				feat.fPercentDP = hs.fPercentDP;
-				asFeatsOut.push_back(feat);
-			}
-		}
-
-		// Find Personal Category Records
-		FOREACH_RankingCategory(rc)
-		{
-			if (pProf)
-			{
-				HighScoreList &hsl = pProf->GetCategoryHighScoreList(st, rc);
-				for (unsigned j = 0; j<hsl.vHighScores.size(); j++)
-				{
-					HighScore &hs = hsl.vHighScores[j];
-					if (hs.sName != RANKING_TO_FILL_IN_MARKER[pn])
+					if( hs.sName != RANKING_TO_FILL_IN_MARKER[pn] )
 						continue;
 
 					RankingFeat feat;
 					feat.Type = RankingFeat::CATEGORY;
-					feat.Feat = ssprintf("PR #%d in Type %c (%d)", j + 1, 'A' + rc, stats.GetAverageMeter(pn));
+					feat.Feat = ssprintf("MR #%d in Type %c (%d)", j+1, 'A'+rc, stats.GetAverageMeter(pn) );
 					feat.pStringToFill = &hs.sName;
 					feat.grade = GRADE_NO_DATA;
 					feat.iScore = hs.iScore;
 					feat.fPercentDP = hs.fPercentDP;
-					asFeatsOut.push_back(feat);
+					asFeatsOut.push_back( feat );
+				}
+			}
+
+			// Find Personal Category Records
+			FOREACH_RankingCategory( rc )
+			{
+				if( pProf )
+				{
+					HighScoreList &hsl = pProf->GetCategoryHighScoreList( st, rc );
+					for( unsigned j=0; j<hsl.vHighScores.size(); j++ )
+					{
+						HighScore &hs = hsl.vHighScores[j];
+						if( hs.sName != RANKING_TO_FILL_IN_MARKER[pn] )
+							continue;
+
+						RankingFeat feat;
+						feat.Type = RankingFeat::CATEGORY;
+						feat.Feat = ssprintf("PR #%d in Type %c (%d)", j+1, 'A'+rc, stats.GetAverageMeter(pn) );
+						feat.pStringToFill = &hs.sName;
+						feat.grade = GRADE_NO_DATA;
+						feat.iScore = hs.iScore;
+						feat.fPercentDP = hs.fPercentDP;
+						asFeatsOut.push_back( feat );
+					}
 				}
 			}
 		}
-	}
-	break;
+		break;
 	case PLAY_MODE_BATTLE:
 	case PLAY_MODE_RAVE:
 		break;
 	case PLAY_MODE_NONSTOP:
 	case PLAY_MODE_ONI:
 	case PLAY_MODE_ENDLESS:
-	{
-		CHECKPOINT;
-		Course* pCourse = m_pCurCourse;
-		ASSERT(pCourse);
-		Trail *pTrail = m_pCurTrail[pn];
-		ASSERT(pTrail);
-		CourseDifficulty cd = pTrail->m_CourseDifficulty;
-
-		// Find Machine Records
 		{
-			Profile* pProfile = PROFILEMAN->GetMachineProfile();
-			HighScoreList &hsl = pProfile->GetCourseHighScoreList(pCourse, pTrail);
-			for (unsigned i = 0; i<hsl.vHighScores.size(); i++)
-			{
-				HighScore &hs = hsl.vHighScores[i];
-				if (hs.sName != RANKING_TO_FILL_IN_MARKER[pn])
-					continue;
+			CHECKPOINT;
+			Course* pCourse = m_pCurCourse;
+			ASSERT( pCourse );
+			Trail *pTrail = m_pCurTrail[pn];
+			ASSERT( pTrail );
+			CourseDifficulty cd = pTrail->m_CourseDifficulty;
 
-				RankingFeat feat;
-				feat.Type = RankingFeat::COURSE;
-				feat.pCourse = pCourse;
-				feat.Feat = ssprintf("MR #%d in %s", i + 1, pCourse->GetDisplayFullTitle().c_str());
-				if (cd != DIFFICULTY_MEDIUM)
-					feat.Feat += " " + CourseDifficultyToThemedString(cd);
-				feat.pStringToFill = &hs.sName;
-				feat.grade = GRADE_NO_DATA;
-				feat.iScore = hs.iScore;
-				feat.fPercentDP = hs.fPercentDP;
-				if (pCourse->HasBanner())
-					feat.Banner = pCourse->m_sBannerPath;
-				asFeatsOut.push_back(feat);
+			// Find Machine Records
+			{
+				Profile* pProfile = PROFILEMAN->GetMachineProfile();
+				HighScoreList &hsl = pProfile->GetCourseHighScoreList( pCourse, pTrail );
+				for( unsigned i=0; i<hsl.vHighScores.size(); i++ )
+				{
+					HighScore &hs = hsl.vHighScores[i];
+					if( hs.sName != RANKING_TO_FILL_IN_MARKER[pn] )
+							continue;
+
+					RankingFeat feat;
+					feat.Type = RankingFeat::COURSE;
+					feat.pCourse = pCourse;
+					feat.Feat = ssprintf("MR #%d in %s", i+1, pCourse->GetDisplayFullTitle().c_str() );
+					if( cd != DIFFICULTY_MEDIUM )
+						feat.Feat += " " + CourseDifficultyToThemedString(cd);
+					feat.pStringToFill = &hs.sName;
+					feat.grade = GRADE_NO_DATA;
+					feat.iScore = hs.iScore;
+					feat.fPercentDP = hs.fPercentDP;
+					if( pCourse->HasBanner() )
+						feat.Banner = pCourse->m_sBannerPath;
+					asFeatsOut.push_back( feat );
+				}
+			}
+
+			// Find Personal Records
+			if( PROFILEMAN->IsPersistentProfile( pn ) )
+			{
+				HighScoreList &hsl = pProf->GetCourseHighScoreList( pCourse, pTrail );
+				for( unsigned i=0; i<hsl.vHighScores.size(); i++ )
+				{
+					HighScore& hs = hsl.vHighScores[i];
+					if( hs.sName != RANKING_TO_FILL_IN_MARKER[pn] )
+							continue;
+
+					RankingFeat feat;
+					feat.Type = RankingFeat::COURSE;
+					feat.pCourse = pCourse;
+					feat.Feat = ssprintf("PR #%d in %s", i+1, pCourse->GetDisplayFullTitle().c_str() );
+					feat.pStringToFill = &hs.sName;
+					feat.grade = GRADE_NO_DATA;
+					feat.iScore = hs.iScore;
+					feat.fPercentDP = hs.fPercentDP;
+					if( pCourse->HasBanner() )
+						feat.Banner = pCourse->m_sBannerPath;
+					asFeatsOut.push_back( feat );
+				}
 			}
 		}
-
-		// Find Personal Records
-		if (PROFILEMAN->IsPersistentProfile(pn))
-		{
-			HighScoreList &hsl = pProf->GetCourseHighScoreList(pCourse, pTrail);
-			for (unsigned i = 0; i<hsl.vHighScores.size(); i++)
-			{
-				HighScore& hs = hsl.vHighScores[i];
-				if (hs.sName != RANKING_TO_FILL_IN_MARKER[pn])
-					continue;
-
-				RankingFeat feat;
-				feat.Type = RankingFeat::COURSE;
-				feat.pCourse = pCourse;
-				feat.Feat = ssprintf("PR #%d in %s", i + 1, pCourse->GetDisplayFullTitle().c_str());
-				feat.pStringToFill = &hs.sName;
-				feat.grade = GRADE_NO_DATA;
-				feat.iScore = hs.iScore;
-				feat.fPercentDP = hs.fPercentDP;
-				if (pCourse->HasBanner())
-					feat.Banner = pCourse->m_sBannerPath;
-				asFeatsOut.push_back(feat);
-			}
-		}
-	}
-	break;
+		break;
 	default:
 		ASSERT(0);
 	}
@@ -1697,10 +1697,10 @@ void GameState::GetRankingFeats(PlayerNumber pn, vector<RankingFeat> &asFeatsOut
 bool GameState::AnyPlayerHasRankingFeats() const
 {
 	vector<RankingFeat> vFeats;
-	FOREACH_PlayerNumber(p)
+	FOREACH_PlayerNumber( p )
 	{
-		GetRankingFeats(p, vFeats);
-		if (!vFeats.empty())
+		GetRankingFeats( p, vFeats );
+		if( !vFeats.empty() )
 			return true;
 	}
 	return false;
@@ -1711,29 +1711,29 @@ bool GameState::AnyPlayerHasRankingFeats() const
 
 }*/
 
-void GameState::StoreRankingName(PlayerNumber pn, CString name)
+void GameState::StoreRankingName( PlayerNumber pn, CString name )
 {
 	name.MakeUpper();
 
-	if (USE_NAME_BLACKLIST)
+	if( USE_NAME_BLACKLIST )
 	{
 		RageFile file;
-		if (file.Open(NAME_BLACKLIST_FILE))
+		if( file.Open(NAME_BLACKLIST_FILE) )
 		{
 			CString line;
-
+			
 			while (!file.AtEOF())
 			{
-				if (file.GetLine(line) == -1)
+				if( file.GetLine( line ) == -1 )
 				{
-					LOG->Warn("Error reading \"%s\": %s", NAME_BLACKLIST_FILE, file.GetError().c_str());
+					LOG->Warn( "Error reading \"%s\": %s", NAME_BLACKLIST_FILE, file.GetError().c_str() );
 					break;
 				}
 
 				line.MakeUpper();
-				if (!line.empty() && name.find(line) != CString::npos)	// name contains a bad word
+				if( !line.empty() && name.find(line) != CString::npos )	// name contains a bad word
 				{
-					LOG->Trace("entered '%s' matches blacklisted item '%s'", name.c_str(), line.c_str());
+					LOG->Trace( "entered '%s' matches blacklisted item '%s'", name.c_str(), line.c_str() );
 					name = "";
 					break;
 				}
@@ -1742,73 +1742,73 @@ void GameState::StoreRankingName(PlayerNumber pn, CString name)
 	}
 
 	vector<RankingFeat> aFeats;
-	GetRankingFeats(pn, aFeats);
+	GetRankingFeats( pn, aFeats );
 
-	for (unsigned i = 0; i<aFeats.size(); i++)
+	for( unsigned i=0; i<aFeats.size(); i++ )
 	{
 		*aFeats[i].pStringToFill = name;
 
 		// save name pointers as we fill them
-		m_vpsNamesThatWereFilled.push_back(aFeats[i].pStringToFill);
+		m_vpsNamesThatWereFilled.push_back( aFeats[i].pStringToFill );
 	}
 
 
 	Profile *pProfile = PROFILEMAN->GetMachineProfile();
 
-	if (!PREFSMAN->m_bAllowMultipleHighScoreWithSameName)
+	if( !PREFSMAN->m_bAllowMultipleHighScoreWithSameName )
 	{
 		//
 		// erase all but the highest score for each name
 		//
-		FOREACHM(SongID, Profile::HighScoresForASong, pProfile->m_SongHighScores, iter)
-			FOREACHM(StepsID, Profile::HighScoresForASteps, iter->second.m_StepsHighScores, iter2)
-			iter2->second.hsl.RemoveAllButOneOfEachName();
+		FOREACHM( SongID, Profile::HighScoresForASong, pProfile->m_SongHighScores, iter )
+			FOREACHM( StepsID, Profile::HighScoresForASteps, iter->second.m_StepsHighScores, iter2 )
+				iter2->second.hsl.RemoveAllButOneOfEachName();
 
-		FOREACHM(CourseID, Profile::HighScoresForACourse, pProfile->m_CourseHighScores, iter)
-			FOREACHM(TrailID, Profile::HighScoresForATrail, iter->second.m_TrailHighScores, iter2)
-			iter2->second.hsl.RemoveAllButOneOfEachName();
+		FOREACHM( CourseID, Profile::HighScoresForACourse, pProfile->m_CourseHighScores, iter )
+			FOREACHM( TrailID, Profile::HighScoresForATrail, iter->second.m_TrailHighScores, iter2 )
+				iter2->second.hsl.RemoveAllButOneOfEachName();
 	}
 
 	//
 	// clamp high score sizes
 	//
-	FOREACHM(SongID, Profile::HighScoresForASong, pProfile->m_SongHighScores, iter)
-		FOREACHM(StepsID, Profile::HighScoresForASteps, iter->second.m_StepsHighScores, iter2)
-		iter2->second.hsl.ClampSize(true);
+	FOREACHM( SongID, Profile::HighScoresForASong, pProfile->m_SongHighScores, iter )
+		FOREACHM( StepsID, Profile::HighScoresForASteps, iter->second.m_StepsHighScores, iter2 )
+			iter2->second.hsl.ClampSize( true );
 
-	FOREACHM(CourseID, Profile::HighScoresForACourse, pProfile->m_CourseHighScores, iter)
-		FOREACHM(TrailID, Profile::HighScoresForATrail, iter->second.m_TrailHighScores, iter2)
-		iter2->second.hsl.ClampSize(true);
+	FOREACHM( CourseID, Profile::HighScoresForACourse, pProfile->m_CourseHighScores, iter )
+		FOREACHM( TrailID, Profile::HighScoresForATrail, iter->second.m_TrailHighScores, iter2 )
+			iter2->second.hsl.ClampSize( true );
 }
 
 bool GameState::AllAreInDangerOrWorse() const
 {
-	FOREACH_EnabledPlayer(p)
-		if (m_pPlayerState[p]->m_HealthState < PlayerState::DANGER)
+	FOREACH_EnabledPlayer( p )
+		if( m_pPlayerState[p]->m_HealthState < PlayerState::DANGER )
 			return false;
 	return true;
 }
 
 bool GameState::AllAreDead() const
 {
-	FOREACH_EnabledPlayer(p)
-		if (m_pPlayerState[p]->m_HealthState < PlayerState::DEAD)
+	FOREACH_EnabledPlayer( p )
+		if( m_pPlayerState[p]->m_HealthState < PlayerState::DEAD )
 			return false;
 	return true;
 }
 
 bool GameState::AllHumanHaveComboOf30OrMoreMisses() const
 {
-	FOREACH_HumanPlayer(p)
-		if (STATSMAN->m_CurStageStats.m_player[p].iCurMissCombo < 30)
+	FOREACH_HumanPlayer( p )
+		if( STATSMAN->m_CurStageStats.m_player[p].iCurMissCombo < 30 )
 			return false;
 	return true;
 }
 
 bool GameState::OneIsHot() const
 {
-	FOREACH_EnabledPlayer(p)
-		if (m_pPlayerState[p]->m_HealthState == PlayerState::HOT)
+	FOREACH_EnabledPlayer( p )
+		if( m_pPlayerState[p]->m_HealthState == PlayerState::HOT )
 			return true;
 	return false;
 }
@@ -1820,75 +1820,75 @@ bool GameState::IsTimeToPlayAttractSounds() const
 	// Play attract sounds for this sort span of time regardless of 
 	// m_AttractSoundFrequency because it's awkward to have the machine go 
 	// silent immediately after the end of a game.
-	if (m_iNumTimesThroughAttract == -1)
+	if( m_iNumTimesThroughAttract == -1 )
 		return true;
 
-	if (PREFSMAN->m_AttractSoundFrequency == PrefsManager::ASF_NEVER)
+	if( PREFSMAN->m_AttractSoundFrequency == PrefsManager::ASF_NEVER )
 		return false;
 
 	// play attract sounds once every m_iAttractSoundFrequency times through
-	if ((m_iNumTimesThroughAttract % PREFSMAN->m_AttractSoundFrequency) == 0)
+	if( (m_iNumTimesThroughAttract % PREFSMAN->m_AttractSoundFrequency)==0 )
 		return true;
 
 	return false;
 }
 
-void GameState::VisitAttractScreen(const CString sScreenName)
+void GameState::VisitAttractScreen( const CString sScreenName )
 {
-	if (sScreenName == FIRST_ATTRACT_SCREEN.GetValue())
+	if( sScreenName == FIRST_ATTRACT_SCREEN.GetValue() )
 		m_iNumTimesThroughAttract++;
 }
 
 bool GameState::DifficultiesLocked()
 {
-	if (GAMESTATE->m_PlayMode == PLAY_MODE_RAVE)
+ 	if( GAMESTATE->m_PlayMode == PLAY_MODE_RAVE )
 		return true;
-	if (IsCourseMode())
+	if( IsCourseMode() )
 		return PREFSMAN->m_bLockCourseDifficulties;
 	return false;
 }
 
-bool GameState::ChangePreferredDifficulty(PlayerNumber pn, Difficulty dc)
+bool GameState::ChangePreferredDifficulty( PlayerNumber pn, Difficulty dc )
 {
-	m_PreferredDifficulty[pn].Set(dc);
-	if (DifficultiesLocked())
-		FOREACH_PlayerNumber(p)
-		if (p != pn)
-			m_PreferredDifficulty[p].Set(m_PreferredDifficulty[pn]);
+	m_PreferredDifficulty[pn].Set( dc );
+	if( DifficultiesLocked() )
+		FOREACH_PlayerNumber( p )
+			if( p != pn )
+				m_PreferredDifficulty[p].Set( m_PreferredDifficulty[pn] );
 
 	return true;
 }
 
-bool GameState::ChangePreferredDifficulty(PlayerNumber pn, int dir)
+bool GameState::ChangePreferredDifficulty( PlayerNumber pn, int dir )
 {
 	const vector<Difficulty> &v = DIFFICULTIES_TO_SHOW.GetValue();
 
 	Difficulty d = m_PreferredDifficulty[pn];
-	while (1)
+	while( 1 )
 	{
-		d = (Difficulty)(d + dir);
-		if (d < 0 || d >= NUM_DIFFICULTIES)
+		d = (Difficulty)(d+dir);
+		if( d < 0 || d >= NUM_DIFFICULTIES )
 			return false;
-		if (find(v.begin(), v.end(), d) != v.end())
+		if( find(v.begin(), v.end(), d) != v.end() )
 			break; // found
 	}
 
-	return ChangePreferredDifficulty(pn, d);
+	return ChangePreferredDifficulty( pn, d );
 }
 
-bool GameState::ChangePreferredCourseDifficulty(PlayerNumber pn, CourseDifficulty cd)
+bool GameState::ChangePreferredCourseDifficulty( PlayerNumber pn, CourseDifficulty cd )
 {
-	m_PreferredCourseDifficulty[pn].Set(cd);
+	m_PreferredCourseDifficulty[pn].Set( cd );
 
-	if (PREFSMAN->m_bLockCourseDifficulties)
-		FOREACH_PlayerNumber(p)
-		if (p != pn)
-			m_PreferredCourseDifficulty[p].Set(m_PreferredCourseDifficulty[pn]);
+	if( PREFSMAN->m_bLockCourseDifficulties )
+		FOREACH_PlayerNumber( p )
+			if( p != pn )
+				m_PreferredCourseDifficulty[p].Set( m_PreferredCourseDifficulty[pn] );
 
 	return true;
 }
 
-bool GameState::ChangePreferredCourseDifficulty(PlayerNumber pn, int dir)
+bool GameState::ChangePreferredCourseDifficulty( PlayerNumber pn, int dir )
 {
 	/* If we have a course selected, only choose among difficulties available in the course. */
 	const Course *pCourse = this->m_pCurCourse;
@@ -1896,21 +1896,21 @@ bool GameState::ChangePreferredCourseDifficulty(PlayerNumber pn, int dir)
 	const vector<CourseDifficulty> &v = COURSE_DIFFICULTIES_TO_SHOW.GetValue();
 
 	CourseDifficulty cd = m_PreferredCourseDifficulty[pn];
-	while (1)
+	while( 1 )
 	{
-		cd = (CourseDifficulty)(cd + dir);
-		if (cd < 0 || cd >= NUM_DIFFICULTIES)
+		cd = (CourseDifficulty)(cd+dir);
+		if( cd < 0 || cd >= NUM_DIFFICULTIES )
 			return false;
-		if (find(v.begin(), v.end(), cd) == v.end())
+		if( find(v.begin(),v.end(),cd) == v.end() )
 			continue; /* not available */
-		if (!pCourse || pCourse->GetTrail(GAMESTATE->GetCurrentStyle()->m_StepsType, cd))
+		if( !pCourse || pCourse->GetTrail( GAMESTATE->GetCurrentStyle()->m_StepsType, cd ) )
 			break;
 	}
 
-	return ChangePreferredCourseDifficulty(pn, cd);
+	return ChangePreferredCourseDifficulty( pn, cd );
 }
 
-bool GameState::IsCourseDifficultyShown(CourseDifficulty cd)
+bool GameState::IsCourseDifficultyShown( CourseDifficulty cd )
 {
 	const vector<CourseDifficulty> &v = COURSE_DIFFICULTIES_TO_SHOW.GetValue();
 	return find(v.begin(), v.end(), cd) != v.end();
@@ -1919,61 +1919,61 @@ bool GameState::IsCourseDifficultyShown(CourseDifficulty cd)
 Difficulty GameState::GetEasiestStepsDifficulty() const
 {
 	Difficulty dc = DIFFICULTY_INVALID;
-	FOREACH_HumanPlayer(p)
+	FOREACH_HumanPlayer( p )
 	{
-		if (this->m_pCurSteps[p] == NULL)
+		if( this->m_pCurSteps[p] == NULL )
 		{
-			LOG->Warn("GetEasiestStepsDifficulty called but p%i hasn't chosen notes", p + 1);
+			LOG->Warn( "GetEasiestStepsDifficulty called but p%i hasn't chosen notes", p+1 );
 			continue;
 		}
-		dc = min(dc, this->m_pCurSteps[p]->GetDifficulty());
+		dc = min( dc, this->m_pCurSteps[p]->GetDifficulty() );
 	}
 	return dc;
 }
 
 bool GameState::IsEventMode() const
 {
-	return m_bTemporaryEventMode || PREFSMAN->m_bEventMode;
+	return m_bTemporaryEventMode || PREFSMAN->m_bEventMode; 
 }
 
 CoinMode GameState::GetCoinMode()
 {
-	if (IsEventMode() && PREFSMAN->m_CoinMode == COIN_MODE_PAY)
-		return COIN_MODE_FREE;
-	else
-		return PREFSMAN->m_CoinMode;
+	if( IsEventMode() && PREFSMAN->m_CoinMode == COIN_MODE_PAY )
+		return COIN_MODE_FREE; 
+	else 
+		return PREFSMAN->m_CoinMode; 
 }
 
-Premium	GameState::GetPremium()
-{
-	if (IsEventMode())
-		return PREMIUM_NONE;
-	else
-		return PREFSMAN->m_Premium;
+Premium	GameState::GetPremium() 
+{ 
+	if( IsEventMode() ) 
+		return PREMIUM_NONE; 
+	else 
+		return PREFSMAN->m_Premium; 
 }
 
-bool GameState::IsPlayerHot(PlayerNumber pn) const
+bool GameState::IsPlayerHot( PlayerNumber pn ) const
 {
 	return GAMESTATE->m_pPlayerState[pn]->m_HealthState == PlayerState::HOT;
 }
 
-bool GameState::IsPlayerInDanger(PlayerNumber pn) const
+bool GameState::IsPlayerInDanger( PlayerNumber pn ) const
 {
-	if (GAMESTATE->GetPlayerFailType(pn) == SongOptions::FAIL_OFF)
+	if( GAMESTATE->GetPlayerFailType(pn) == SongOptions::FAIL_OFF )
 		return false;
-	if (!PREFSMAN->m_bShowDanger)
+	if( !PREFSMAN->m_bShowDanger )
 		return false;
 	return GAMESTATE->m_pPlayerState[pn]->m_HealthState == PlayerState::DANGER;
 }
 
-bool GameState::IsPlayerDead(PlayerNumber pn) const
+bool GameState::IsPlayerDead( PlayerNumber pn ) const
 {
-	if (GAMESTATE->GetPlayerFailType(pn) == SongOptions::FAIL_OFF)
+	if( GAMESTATE->GetPlayerFailType(pn) == SongOptions::FAIL_OFF )
 		return false;
 	return GAMESTATE->m_pPlayerState[pn]->m_HealthState == PlayerState::DEAD;
 }
 
-float GameState::GetGoalPercentComplete(PlayerNumber pn)
+float GameState::GetGoalPercentComplete( PlayerNumber pn )
 {
 	const Profile *pProfile = PROFILEMAN->GetProfile(pn);
 	const StageStats &ssAccum = STATSMAN->GetAccumStageStats();
@@ -1983,7 +1983,7 @@ float GameState::GetGoalPercentComplete(PlayerNumber pn)
 
 	float fActual = 0;
 	float fGoal = 0;
-	switch (pProfile->m_GoalType)
+	switch( pProfile->m_GoalType )
 	{
 	case GOAL_CALORIES:
 		fActual = pssAccum.fCaloriesBurned + pssCurrent.fCaloriesBurned;
@@ -1998,25 +1998,25 @@ float GameState::GetGoalPercentComplete(PlayerNumber pn)
 	default:
 		ASSERT(0);
 	}
-	if (fGoal == 0)
+	if( fGoal == 0 )
 		return 0;
 	else
 		return fActual / fGoal;
 }
 
-bool GameState::PlayerIsUsingModifier(PlayerNumber pn, const CString &sModifier)
+bool GameState::PlayerIsUsingModifier( PlayerNumber pn, const CString &sModifier )
 {
 	PlayerOptions po = GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions;
 	SongOptions so = GAMESTATE->m_SongOptions;
-	po.FromString(sModifier);
-	so.FromString(sModifier);
+	po.FromString( sModifier );
+	so.FromString( sModifier );
 
 	return po == GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions && so == GAMESTATE->m_SongOptions;
 }
 
 void GameState::ResetOriginalSyncData()
 {
-	if (m_pCurSong)
+	if( m_pCurSong )
 		*m_pTimingDataOriginal = m_pCurSong->m_Timing;
 	else
 		*m_pTimingDataOriginal = TimingData();
@@ -2026,12 +2026,12 @@ void GameState::ResetOriginalSyncData()
 bool GameState::IsSyncDataChanged()
 {
 	// Can't sync in course modes
-	if (IsCourseMode())
+	if( IsCourseMode() )
 		return false;
 
-	if (m_pCurSong  &&  *m_pTimingDataOriginal != m_pCurSong->m_Timing)
+	if( m_pCurSong  &&  *m_pTimingDataOriginal != m_pCurSong->m_Timing )
 		return true;
-	if (m_fGlobalOffsetSecondsOriginal != PREFSMAN->m_fGlobalOffsetSeconds)
+	if( m_fGlobalOffsetSecondsOriginal != PREFSMAN->m_fGlobalOffsetSeconds )
 		return true;
 
 	return false;
@@ -2046,7 +2046,7 @@ void GameState::SaveSyncChanges()
 
 void GameState::RevertSyncChanges()
 {
-	PREFSMAN->m_fGlobalOffsetSeconds.Set(GAMESTATE->m_fGlobalOffsetSecondsOriginal);
+	PREFSMAN->m_fGlobalOffsetSeconds.Set( GAMESTATE->m_fGlobalOffsetSecondsOriginal );
 	GAMESTATE->m_pCurSong->m_Timing = *GAMESTATE->m_pTimingDataOriginal;
 }
 
@@ -2058,187 +2058,187 @@ template<class T>
 class LunaGameState : public Luna<T>
 {
 public:
-	LunaGameState() { LUA->Register(Register); }
+	LunaGameState() { LUA->Register( Register ); }
 
-	static int IsPlayerEnabled(T* p, lua_State *L)		{ lua_pushboolean(L, p->IsPlayerEnabled((PlayerNumber)IArg(1))); return 1; }
-	static int IsHumanPlayer(T* p, lua_State *L)			{ lua_pushboolean(L, p->IsHumanPlayer((PlayerNumber)IArg(1))); return 1; }
-	static int IsDisqualified(T* p, lua_State *L)		{ lua_pushboolean(L, p->IsDisqualified((PlayerNumber)IArg(1))); return 1; }
-	static int GetPlayerDisplayName(T* p, lua_State *L)	{ lua_pushstring(L, p->GetPlayerDisplayName((PlayerNumber)IArg(1))); return 1; }
-	static int GetMasterPlayerNumber(T* p, lua_State *L)	{ lua_pushnumber(L, p->m_MasterPlayerNumber); return 1; }
-	static int ApplyGameCommand(T* p, lua_State *L)
+	static int IsPlayerEnabled( T* p, lua_State *L )		{ lua_pushboolean(L, p->IsPlayerEnabled((PlayerNumber)IArg(1)) ); return 1; }
+	static int IsHumanPlayer( T* p, lua_State *L )			{ lua_pushboolean(L, p->IsHumanPlayer((PlayerNumber)IArg(1)) ); return 1; }
+	static int IsDisqualified( T* p, lua_State *L )		{ lua_pushboolean(L, p->IsDisqualified( (PlayerNumber)IArg(1)) ); return 1; }
+	static int GetPlayerDisplayName( T* p, lua_State *L )	{ lua_pushstring(L, p->GetPlayerDisplayName((PlayerNumber)IArg(1)) ); return 1; }
+	static int GetMasterPlayerNumber( T* p, lua_State *L )	{ lua_pushnumber(L, p->m_MasterPlayerNumber ); return 1; }
+	static int ApplyGameCommand( T* p, lua_State *L )
 	{
 		PlayerNumber pn = PLAYER_INVALID;
-		if (lua_gettop(L) >= 2 && !lua_isnil(L, 2))
-			pn = (PlayerNumber)(IArg(2) - 1);
-		p->ApplyGameCommand(SArg(1), pn);
+		if( lua_gettop(L) >= 2 && !lua_isnil(L,2) )
+			pn = (PlayerNumber)(IArg(2)-1);
+		p->ApplyGameCommand(SArg(1),pn);
 		return 0;
 	}
-	static int GetCurrentSong(T* p, lua_State *L)			{ if (p->m_pCurSong) p->m_pCurSong->PushSelf(L); else lua_pushnil(L); return 1; }
-	static int SetCurrentSong(T* p, lua_State *L)
-	{
-		if (lua_isnil(L, 1)) { p->m_pCurSong.Set(NULL); }
-		else { Song *pS = Luna<Song>::check(L, 1); p->m_pCurSong.Set(pS); }
+	static int GetCurrentSong( T* p, lua_State *L )			{ if(p->m_pCurSong) p->m_pCurSong->PushSelf(L); else lua_pushnil(L); return 1; }
+	static int SetCurrentSong( T* p, lua_State *L )
+	{ 
+		if( lua_isnil(L,1) ) { p->m_pCurSong.Set( NULL ); }
+		else { Song *pS = Luna<Song>::check(L,1); p->m_pCurSong.Set( pS ); }
 		return 0;
 	}
-	static int GetCurrentSteps(T* p, lua_State *L)
+	static int GetCurrentSteps( T* p, lua_State *L )
 	{
 		PlayerNumber pn = (PlayerNumber)IArg(1);
-		Steps *pSteps = p->m_pCurSteps[pn];
-		if (pSteps) { pSteps->PushSelf(L); }
+		Steps *pSteps = p->m_pCurSteps[pn];  
+		if( pSteps ) { pSteps->PushSelf(L); }
 		else		 { lua_pushnil(L); }
 		return 1;
 	}
-	static int SetCurrentSteps(T* p, lua_State *L)
-	{
+	static int SetCurrentSteps( T* p, lua_State *L )
+	{ 
 		PlayerNumber pn = (PlayerNumber)IArg(1);
-		if (lua_isnil(L, 2))	{ p->m_pCurSteps[pn].Set(NULL); }
-		else					{ Steps *pS = Luna<Steps>::check(L, 2); p->m_pCurSteps[pn].Set(pS); }
-		MESSAGEMAN->Broadcast((Message)(MESSAGE_CURRENT_STEPS_P1_CHANGED + pn));
+		if( lua_isnil(L,2) )	{ p->m_pCurSteps[pn].Set( NULL ); }
+		else					{ Steps *pS = Luna<Steps>::check(L,2); p->m_pCurSteps[pn].Set( pS ); }
+		MESSAGEMAN->Broadcast( (Message)(MESSAGE_CURRENT_STEPS_P1_CHANGED+pn) );
 		return 0;
 	}
-	static int GetCurrentCourse(T* p, lua_State *L)		{ if (p->m_pCurCourse) p->m_pCurCourse->PushSelf(L); else lua_pushnil(L); return 1; }
-	static int SetCurrentCourse(T* p, lua_State *L)
-	{
-		if (lua_isnil(L, 1)) { p->m_pCurCourse.Set(NULL); }
-		else { Course *pC = Luna<Course>::check(L, 1); p->m_pCurCourse.Set(pC); }
+	static int GetCurrentCourse( T* p, lua_State *L )		{ if(p->m_pCurCourse) p->m_pCurCourse->PushSelf(L); else lua_pushnil(L); return 1; }
+	static int SetCurrentCourse( T* p, lua_State *L )
+	{ 
+		if( lua_isnil(L,1) ) { p->m_pCurCourse.Set( NULL ); }
+		else { Course *pC = Luna<Course>::check(L,1); p->m_pCurCourse.Set( pC ); }
 		return 0;
 	}
-	static int GetCurrentTrail(T* p, lua_State *L)
+	static int GetCurrentTrail( T* p, lua_State *L )
 	{
 		PlayerNumber pn = (PlayerNumber)IArg(1);
-		Trail *pTrail = p->m_pCurTrail[pn];
-		if (pTrail) { pTrail->PushSelf(L); }
+		Trail *pTrail = p->m_pCurTrail[pn];  
+		if( pTrail ) { pTrail->PushSelf(L); }
 		else		 { lua_pushnil(L); }
 		return 1;
 	}
-	static int GetPreferredSong(T* p, lua_State *L)		{ if (p->m_pPreferredSong) p->m_pPreferredSong->PushSelf(L); else lua_pushnil(L); return 1; }
-	static int SetPreferredSong(T* p, lua_State *L)
+	static int GetPreferredSong( T* p, lua_State *L )		{ if(p->m_pPreferredSong) p->m_pPreferredSong->PushSelf(L); else lua_pushnil(L); return 1; }
+	static int SetPreferredSong( T* p, lua_State *L )
 	{
-		if (lua_isnil(L, 1)) { p->m_pPreferredSong = NULL; }
-		else { Song *pS = Luna<Song>::check(L, 1); p->m_pPreferredSong = pS; }
+		if( lua_isnil(L,1) ) { p->m_pPreferredSong = NULL; }
+		else { Song *pS = Luna<Song>::check(L,1); p->m_pPreferredSong = pS; }
 		return 0;
 	}
-	static int SetTemporaryEventMode(T* p, lua_State *L)	{ p->m_bTemporaryEventMode = BArg(1); return 0; }
-	static int Env(T* p, lua_State *L)	{ p->m_Environment->PushSelf(L); return 1; }
-	static int SetEnv(T* p, lua_State *L)	{ p->m_mapEnv[SArg(1)] = SArg(2); return 0; }
-	static int GetEnv(T* p, lua_State *L)
+	static int SetTemporaryEventMode( T* p, lua_State *L )	{ p->m_bTemporaryEventMode = BArg(1); return 0; }
+	static int Env( T* p, lua_State *L )	{ p->m_Environment->PushSelf(L); return 1; }
+	static int SetEnv( T* p, lua_State *L )	{ p->m_mapEnv[SArg(1)] = SArg(2); return 0; }
+	static int GetEnv( T* p, lua_State *L )
 	{
-		map<CString, CString>::const_iterator iter = p->m_mapEnv.find(SArg(1));
-		if (iter != p->m_mapEnv.end())
-			lua_pushstring(L, iter->second);
+		map<CString,CString>::const_iterator iter = p->m_mapEnv.find(SArg(1));
+		if( iter != p->m_mapEnv.end() )
+			lua_pushstring(L,iter->second);
 		else
 			lua_pushnil(L);
 		return 1;
 	}
-	static int GetEditSourceSteps(T* p, lua_State *L)
+	static int GetEditSourceSteps( T* p, lua_State *L )
 	{
-		Steps *pSteps = p->m_pEditSourceSteps;
-		if (pSteps) { pSteps->PushSelf(L); }
+		Steps *pSteps = p->m_pEditSourceSteps;  
+		if( pSteps ) { pSteps->PushSelf(L); }
 		else		 { lua_pushnil(L); }
 		return 1;
 	}
-	static int GetCurrentGame(T* p, lua_State *L)			{ const_cast<Game*>(p->GetCurrentGame())->PushSelf(L); return 1; }
-	static int DelayedGameCommand(T* p, lua_State *L)		{ p->m_sDelayedGameCommand = SArg(1); return 1; }
-	static int GetPreferredDifficulty(T* p, lua_State *L)	{ lua_pushnumber(L, p->m_PreferredDifficulty[IArg(1)]); return 1; }
-	static int AnyPlayerHasRankingFeats(T* p, lua_State *L)	{ lua_pushboolean(L, p->AnyPlayerHasRankingFeats()); return 1; }
-	static int IsCourseMode(T* p, lua_State *L)			{ lua_pushboolean(L, p->IsCourseMode()); return 1; }
-	static int IsDemonstration(T* p, lua_State *L)		{ lua_pushboolean(L, p->m_bDemonstrationOrJukebox); return 1; }
-	static int GetPlayMode(T* p, lua_State *L)			{ lua_pushnumber(L, p->m_PlayMode); return 1; }
-	static int GetSortOrder(T* p, lua_State *L)			{ lua_pushnumber(L, p->m_SortOrder); return 1; }
-	static int StageIndex(T* p, lua_State *L)			{ lua_pushnumber(L, p->GetStageIndex()); return 1; }
-	static int IsGoalComplete(T* p, lua_State *L)			{ lua_pushboolean(L, p->IsGoalComplete((PlayerNumber)IArg(1))); return 1; }
-	static int PlayerIsUsingModifier(T* p, lua_State *L)	{ lua_pushboolean(L, p->PlayerIsUsingModifier((PlayerNumber)IArg(1), SArg(2))); return 1; }
-	static int GetCourseSongIndex(T* p, lua_State *L)		{ lua_pushnumber(L, p->GetCourseSongIndex()); return 1; }
-	static int IsExtraStage(T* p, lua_State *L)			{ lua_pushboolean(L, p->IsExtraStage()); return 1; }
-	static int IsExtraStage2(T* p, lua_State *L)			{ lua_pushboolean(L, p->IsExtraStage2()); return 1; }
-	static int GetEasiestStepsDifficulty(T* p, lua_State *L){ lua_pushnumber(L, p->GetEasiestStepsDifficulty()); return 1; }
-	static int IsEventMode(T* p, lua_State *L)			{ lua_pushboolean(L, p->IsEventMode()); return 1; }
-	static int GetNumPlayersEnabled(T* p, lua_State *L)	{ lua_pushnumber(L, p->GetNumPlayersEnabled()); return 1; }
-	static int GetSongBeat(T* p, lua_State *L)			{ lua_pushnumber(L, p->m_fSongBeat); return 1; }
-	static int GetSongBeatVisible(T* p, lua_State *L)		{ lua_pushnumber(L, p->m_fSongBeatVisible); return 1; }
-	static int GetCurBPS(T* p, lua_State *L)			{ lua_pushnumber(L, p->m_fCurBPS); return 1; }
-	static int PlayerUsingBothSides(T* p, lua_State *L)	{ lua_pushboolean(L, p->PlayerUsingBothSides()); return 1; }
-	static int GetCoins(T* p, lua_State *L)				{ lua_pushnumber(L, p->m_iCoins); return 1; }
-	static int IsSideJoined(T* p, lua_State *L)			{ lua_pushboolean(L, p->m_bSideIsJoined[(PlayerNumber)IArg(1)]); return 1; }
-	static int GetCoinsNeededToJoin(T* p, lua_State *L)	{ lua_pushnumber(L, p->GetCoinsNeededToJoin()); return 1; }
-	static int PlayersCanJoin(T* p, lua_State *L)			{ lua_pushboolean(L, p->PlayersCanJoin()); return 1; }
-	static int GetNumSidesJoined(T* p, lua_State *L)		{ lua_pushnumber(L, p->GetNumSidesJoined()); return 1; }
-	static int GetCoinMode(T* p, lua_State *L)			{ lua_pushnumber(L, p->GetCoinMode()); return 1; }
-	static int GetPremium(T* p, lua_State *L)				{ lua_pushnumber(L, p->GetPremium()); return 1; }
-	static int IsSyncDataChanged(T* p, lua_State *L)		{ lua_pushboolean(L, p->IsSyncDataChanged()); return 1; }
-	static int IsWinner(T* p, lua_State *L)
+	static int GetCurrentGame( T* p, lua_State *L )			{ const_cast<Game*>(p->GetCurrentGame())->PushSelf( L ); return 1; }
+	static int DelayedGameCommand( T* p, lua_State *L )		{ p->m_sDelayedGameCommand = SArg(1); return 1; }
+	static int GetPreferredDifficulty( T* p, lua_State *L )	{ lua_pushnumber(L, p->m_PreferredDifficulty[IArg(1)] ); return 1; }
+	static int AnyPlayerHasRankingFeats( T* p, lua_State *L )	{ lua_pushboolean(L, p->AnyPlayerHasRankingFeats() ); return 1; }
+	static int IsCourseMode( T* p, lua_State *L )			{ lua_pushboolean(L, p->IsCourseMode() ); return 1; }
+	static int IsDemonstration( T* p, lua_State *L )		{ lua_pushboolean(L, p->m_bDemonstrationOrJukebox ); return 1; }
+	static int GetPlayMode( T* p, lua_State *L )			{ lua_pushnumber(L, p->m_PlayMode ); return 1; }
+	static int GetSortOrder( T* p, lua_State *L )			{ lua_pushnumber(L, p->m_SortOrder ); return 1; }
+	static int StageIndex( T* p, lua_State *L )			{ lua_pushnumber(L, p->GetStageIndex() ); return 1; }
+	static int IsGoalComplete( T* p, lua_State *L )			{ lua_pushboolean(L, p->IsGoalComplete((PlayerNumber)IArg(1)) ); return 1; }
+	static int PlayerIsUsingModifier( T* p, lua_State *L )	{ lua_pushboolean(L, p->PlayerIsUsingModifier((PlayerNumber)IArg(1),SArg(2)) ); return 1; }
+	static int GetCourseSongIndex( T* p, lua_State *L )		{ lua_pushnumber(L, p->GetCourseSongIndex() ); return 1; }
+	static int IsExtraStage( T* p, lua_State *L )			{ lua_pushboolean(L, p->IsExtraStage() ); return 1; }
+	static int IsExtraStage2( T* p, lua_State *L )			{ lua_pushboolean(L, p->IsExtraStage2() ); return 1; }
+	static int GetEasiestStepsDifficulty( T* p, lua_State *L ){ lua_pushnumber(L, p->GetEasiestStepsDifficulty() ); return 1; }
+	static int IsEventMode( T* p, lua_State *L )			{ lua_pushboolean(L, p->IsEventMode() ); return 1; }
+	static int GetNumPlayersEnabled( T* p, lua_State *L )	{ lua_pushnumber(L, p->GetNumPlayersEnabled() ); return 1; }
+	static int GetSongBeat( T* p, lua_State *L )			{ lua_pushnumber(L, p->m_fSongBeat ); return 1; }
+	static int GetSongBeatVisible( T* p, lua_State *L )		{ lua_pushnumber(L, p->m_fSongBeatVisible ); return 1; }
+	static int GetCurBPS( T* p, lua_State *L )			{ lua_pushnumber(L, p->m_fCurBPS ); return 1; }
+	static int PlayerUsingBothSides( T* p, lua_State *L )	{ lua_pushboolean(L, p->PlayerUsingBothSides() ); return 1; }
+	static int GetCoins( T* p, lua_State *L )				{ lua_pushnumber(L, p->m_iCoins ); return 1; }
+	static int IsSideJoined( T* p, lua_State *L )			{ lua_pushboolean(L, p->m_bSideIsJoined[(PlayerNumber)IArg(1)] ); return 1; }
+	static int GetCoinsNeededToJoin( T* p, lua_State *L )	{ lua_pushnumber(L, p->GetCoinsNeededToJoin() ); return 1; }
+	static int PlayersCanJoin( T* p, lua_State *L )			{ lua_pushboolean(L, p->PlayersCanJoin() ); return 1; }
+	static int GetNumSidesJoined( T* p, lua_State *L )		{ lua_pushnumber(L, p->GetNumSidesJoined() ); return 1; }
+	static int GetCoinMode( T* p, lua_State *L )			{ lua_pushnumber(L, p->GetCoinMode() ); return 1; }
+	static int GetPremium( T* p, lua_State *L )				{ lua_pushnumber(L, p->GetPremium() ); return 1; }
+	static int IsSyncDataChanged( T* p, lua_State *L )		{ lua_pushboolean(L, p->IsSyncDataChanged() ); return 1; }
+	static int IsWinner( T* p, lua_State *L )
 	{
 		PlayerNumber pn = (PlayerNumber)IArg(1);
-		lua_pushboolean(L, p->GetStageResult(pn) == RESULT_WIN); return 1;
+		lua_pushboolean(L, p->GetStageResult(pn)==RESULT_WIN); return 1;
 	}
 	static void Register(lua_State *L)
 	{
-		ADD_METHOD(IsPlayerEnabled)
-			ADD_METHOD(IsHumanPlayer)
-			ADD_METHOD(IsDisqualified)
-			ADD_METHOD(GetPlayerDisplayName)
-			ADD_METHOD(GetMasterPlayerNumber)
-			ADD_METHOD(ApplyGameCommand)
-			ADD_METHOD(DelayedGameCommand)
-			ADD_METHOD(GetCurrentGame)
-			ADD_METHOD(GetCurrentSong)
-			ADD_METHOD(SetCurrentSong)
-			ADD_METHOD(GetCurrentSteps)
-			ADD_METHOD(SetCurrentSteps)
-			ADD_METHOD(GetCurrentCourse)
-			ADD_METHOD(SetCurrentCourse)
-			ADD_METHOD(GetCurrentTrail)
-			ADD_METHOD(SetPreferredSong)
-			ADD_METHOD(GetPreferredSong)
-			ADD_METHOD(SetTemporaryEventMode)
-			ADD_METHOD(Env)
-			ADD_METHOD(SetEnv)
-			ADD_METHOD(GetEnv)
-			ADD_METHOD(GetEditSourceSteps)
-			ADD_METHOD(GetPreferredDifficulty)
-			ADD_METHOD(AnyPlayerHasRankingFeats)
-			ADD_METHOD(IsCourseMode)
-			ADD_METHOD(IsDemonstration)
-			ADD_METHOD(GetPlayMode)
-			ADD_METHOD(GetSortOrder)
-			ADD_METHOD(StageIndex)
-			ADD_METHOD(IsGoalComplete)
-			ADD_METHOD(PlayerIsUsingModifier)
-			ADD_METHOD(GetCourseSongIndex)
-			ADD_METHOD(IsExtraStage)
-			ADD_METHOD(IsExtraStage2)
-			ADD_METHOD(GetEasiestStepsDifficulty)
-			ADD_METHOD(IsEventMode)
-			ADD_METHOD(GetNumPlayersEnabled)
-			ADD_METHOD(GetSongBeat)
-			ADD_METHOD(GetSongBeatVisible)
-			ADD_METHOD(GetCurBPS)
-			ADD_METHOD(PlayerUsingBothSides)
-			ADD_METHOD(GetCoins)
-			ADD_METHOD(IsSideJoined)
-			ADD_METHOD(GetCoinsNeededToJoin)
-			ADD_METHOD(PlayersCanJoin)
-			ADD_METHOD(GetNumSidesJoined)
-			ADD_METHOD(GetCoinMode)
-			ADD_METHOD(GetPremium)
-			ADD_METHOD(IsSyncDataChanged)
-			ADD_METHOD(IsWinner)
+		ADD_METHOD( IsPlayerEnabled )
+		ADD_METHOD( IsHumanPlayer )
+		ADD_METHOD( IsDisqualified )
+		ADD_METHOD( GetPlayerDisplayName )
+		ADD_METHOD( GetMasterPlayerNumber )
+		ADD_METHOD( ApplyGameCommand )
+		ADD_METHOD( DelayedGameCommand )
+		ADD_METHOD( GetCurrentGame )
+		ADD_METHOD( GetCurrentSong )
+		ADD_METHOD( SetCurrentSong )
+		ADD_METHOD( GetCurrentSteps )
+		ADD_METHOD( SetCurrentSteps )
+		ADD_METHOD( GetCurrentCourse )
+		ADD_METHOD( SetCurrentCourse )
+		ADD_METHOD( GetCurrentTrail )
+		ADD_METHOD( SetPreferredSong )
+		ADD_METHOD( GetPreferredSong )
+		ADD_METHOD( SetTemporaryEventMode )
+		ADD_METHOD( Env )
+		ADD_METHOD( SetEnv )
+		ADD_METHOD( GetEnv )
+		ADD_METHOD( GetEditSourceSteps )
+		ADD_METHOD( GetPreferredDifficulty )
+		ADD_METHOD( AnyPlayerHasRankingFeats )
+		ADD_METHOD( IsCourseMode )
+		ADD_METHOD( IsDemonstration )
+		ADD_METHOD( GetPlayMode )
+		ADD_METHOD( GetSortOrder )
+		ADD_METHOD( StageIndex )
+		ADD_METHOD( IsGoalComplete )
+		ADD_METHOD( PlayerIsUsingModifier )
+		ADD_METHOD( GetCourseSongIndex )
+		ADD_METHOD( IsExtraStage )
+		ADD_METHOD( IsExtraStage2 )
+		ADD_METHOD( GetEasiestStepsDifficulty )
+		ADD_METHOD( IsEventMode )
+		ADD_METHOD( GetNumPlayersEnabled )
+		ADD_METHOD( GetSongBeat )
+		ADD_METHOD( GetSongBeatVisible )
+		ADD_METHOD( GetCurBPS )
+		ADD_METHOD( PlayerUsingBothSides )
+		ADD_METHOD( GetCoins )
+		ADD_METHOD( IsSideJoined )
+		ADD_METHOD( GetCoinsNeededToJoin )
+		ADD_METHOD( PlayersCanJoin )
+		ADD_METHOD( GetNumSidesJoined )
+		ADD_METHOD( GetCoinMode )
+		ADD_METHOD( GetPremium )
+		ADD_METHOD( IsSyncDataChanged )
+		ADD_METHOD( IsWinner )
 
-			Luna<T>::Register(L);
+		Luna<T>::Register( L );
 
 		// Add global singleton if constructed already.  If it's not constructed yet,
 		// then we'll register it later when we reinit Lua just before 
 		// initializing the display.
-		if (GAMESTATE)
+		if( GAMESTATE )
 		{
 			lua_pushstring(L, "GAMESTATE");
-			GAMESTATE->PushSelf(L);
+			GAMESTATE->PushSelf( L );
 			lua_settable(L, LUA_GLOBALSINDEX);
 		}
 	}
 };
 
-LUA_REGISTER_CLASS(GameState)
+LUA_REGISTER_CLASS( GameState )
 // lua end
 
 
@@ -2246,46 +2246,46 @@ LUA_REGISTER_CLASS(GameState)
 
 
 #include "LuaFunctions.h"
-LuaFunction_NoArgs(NumStagesLeft, GAMESTATE->GetNumStagesLeft())
-LuaFunction_NoArgs(IsFinalStage, GAMESTATE->IsFinalStage())
-LuaFunction_NoArgs(IsExtraStage, GAMESTATE->IsExtraStage())
-LuaFunction_NoArgs(IsExtraStage2, GAMESTATE->IsExtraStage2())
-LuaFunction_NoArgs(CourseSongIndex, GAMESTATE->GetCourseSongIndex())
-LuaFunction_NoArgs(PlayModeName, PlayModeToString(GAMESTATE->m_PlayMode))
-LuaFunction_NoArgs(CurStyleName, CString(GAMESTATE->m_pCurStyle == NULL ? "none" : GAMESTATE->GetCurrentStyle()->m_szName))
-LuaFunction_NoArgs(GetNumPlayersEnabled, GAMESTATE->GetNumPlayersEnabled())
-LuaFunction_NoArgs(GetEasiestNotesDifficulty, GAMESTATE->GetEasiestStepsDifficulty())
+LuaFunction_NoArgs( NumStagesLeft,			GAMESTATE->GetNumStagesLeft() )
+LuaFunction_NoArgs( IsFinalStage,			GAMESTATE->IsFinalStage() )
+LuaFunction_NoArgs( IsExtraStage,			GAMESTATE->IsExtraStage() )
+LuaFunction_NoArgs( IsExtraStage2,			GAMESTATE->IsExtraStage2() )
+LuaFunction_NoArgs( CourseSongIndex,		GAMESTATE->GetCourseSongIndex() )
+LuaFunction_NoArgs( PlayModeName,			PlayModeToString(GAMESTATE->m_PlayMode) )
+LuaFunction_NoArgs( CurStyleName,			CString( GAMESTATE->m_pCurStyle == NULL ? "none": GAMESTATE->GetCurrentStyle()->m_szName ) )
+LuaFunction_NoArgs( GetNumPlayersEnabled,	GAMESTATE->GetNumPlayersEnabled() )
+LuaFunction_NoArgs( GetEasiestNotesDifficulty, GAMESTATE->GetEasiestStepsDifficulty() )
 
 CString GetStageText()
 {
 	// all lowercase or compatibility with scripts
-	CString s = StageToString(GAMESTATE->GetCurrentStage());
+	CString s = StageToString( GAMESTATE->GetCurrentStage() );
 	s.MakeLower();
 	return s;
 }
-LuaFunction_NoArgs(GetStageText, GetStageText())
+LuaFunction_NoArgs( GetStageText, GetStageText() )
 
 /*
-* (c) 2001-2004 Chris Danford, Glenn Maynard, Chris Gomez
-* All rights reserved.
-*
-* Permission is hereby granted, free of charge, to any person obtaining a
-* copy of this software and associated documentation files (the
-* "Software"), to deal in the Software without restriction, including
-* without limitation the rights to use, copy, modify, merge, publish,
-* distribute, and/or sell copies of the Software, and to permit persons to
-* whom the Software is furnished to do so, provided that the above
-* copyright notice(s) and this permission notice appear in all copies of
-* the Software and that both the above copyright notice(s) and this
-* permission notice appear in supporting documentation.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
-* THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
-* INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
-* OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
-* OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
-* OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-* PERFORMANCE OF THIS SOFTWARE.
-*/
+ * (c) 2001-2004 Chris Danford, Glenn Maynard, Chris Gomez
+ * All rights reserved.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, provided that the above
+ * copyright notice(s) and this permission notice appear in all copies of
+ * the Software and that both the above copyright notice(s) and this
+ * permission notice appear in supporting documentation.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+ * THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
+ * INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
+ * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -23,67 +23,73 @@
 #include "LuaReference.h"
 #include "StepMania.h"
 
+//dont include this if we dont have networking
+#if !defined(WITHOUT_NETWORKING)
+#include "HTTPHelper.h"
+#endif
+
 #include <ctime>
 #include <set>
 
 
 GameState*	GAMESTATE = NULL;	// global and accessable from anywhere in our program
+static Preference<CString> pSongBroadcastURL("SongBroadcastURL", "");
 
 #define CHARACTERS_DIR "Characters/"
 #define NAME_BLACKLIST_FILE "Data/NamesBlacklist.dat"
 
-ThemeMetric<bool> USE_NAME_BLACKLIST("GameState","UseNameBlacklist");
+ThemeMetric<bool> USE_NAME_BLACKLIST("GameState", "UseNameBlacklist");
 
-ThemeMetric<CString> DEFAULT_SORT	("GameState","DefaultSort");
+ThemeMetric<CString> DEFAULT_SORT("GameState", "DefaultSort");
 SortOrder GetDefaultSort()
 {
-	return StringToSortOrder( DEFAULT_SORT );
+	return StringToSortOrder(DEFAULT_SORT);
 }
-ThemeMetric<CString> DEFAULT_SONG	("GameState","DefaultSong");
+ThemeMetric<CString> DEFAULT_SONG("GameState", "DefaultSong");
 Song* GetDefaultSong()
 {
 	SongID sid;
-	sid.LoadFromDir( DEFAULT_SONG );
+	sid.LoadFromDir(DEFAULT_SONG);
 	return sid.ToSong();
 }
 
 static int GetNumStagesForCurrentSong()
 {
 	int iNumStagesOfThisSong = 1; // default
-	if( GAMESTATE->m_pCurSong )
-		iNumStagesOfThisSong = SongManager::GetNumStagesForSong( GAMESTATE->m_pCurSong );
+	if (GAMESTATE->m_pCurSong)
+		iNumStagesOfThisSong = SongManager::GetNumStagesForSong(GAMESTATE->m_pCurSong);
 	else
 		return iNumStagesOfThisSong;
 
-	ASSERT( iNumStagesOfThisSong >= 1 && iNumStagesOfThisSong <= 3 );
+	ASSERT(iNumStagesOfThisSong >= 1 && iNumStagesOfThisSong <= 3);
 
 	/* Never increment more than one past final stage.  That is, if the current
-	 * stage is the final stage, and we picked a stage that takes two songs, it
-	 * only counts as one stage (so it doesn't bump us all the way to Ex2).
-	 * One case where this happens is a long/marathon extra stage.  Another is
-	 * if a long/marathon song is selected explicitly in the theme with a GameCommand,
-	 * and PREFSMAN->m_iNumArcadeStages is less than the number of stages that
-	 * song takes. */
+	* stage is the final stage, and we picked a stage that takes two songs, it
+	* only counts as one stage (so it doesn't bump us all the way to Ex2).
+	* One case where this happens is a long/marathon extra stage.  Another is
+	* if a long/marathon song is selected explicitly in the theme with a GameCommand,
+	* and PREFSMAN->m_iNumArcadeStages is less than the number of stages that
+	* song takes. */
 	int iNumStagesLeft = PREFSMAN->m_iSongsPerPlay - GAMESTATE->m_iCurrentStageIndex;
-	iNumStagesOfThisSong = min( iNumStagesOfThisSong, iNumStagesLeft );
-	iNumStagesOfThisSong = max( iNumStagesOfThisSong, 1 );
+	iNumStagesOfThisSong = min(iNumStagesOfThisSong, iNumStagesLeft);
+	iNumStagesOfThisSong = max(iNumStagesOfThisSong, 1);
 
 	return iNumStagesOfThisSong;
 }
 
 GameState::GameState() :
-    m_pCurStyle(			MESSAGE_CURRENT_STYLE_CHANGED ),
-    m_PreferredCourseDifficulty( MESSAGE_EDIT_PREFERRED_COURSE_DIFFICULTY_P1_CHANGED ),
-    m_PreferredDifficulty(	MESSAGE_EDIT_PREFERRED_DIFFICULTY_P1_CHANGED ),
-    m_pCurSong(				MESSAGE_CURRENT_SONG_CHANGED ),
-	m_pCurSteps(			MESSAGE_CURRENT_STEPS_P1_CHANGED ),
-    m_pCurCourse(			MESSAGE_CURRENT_COURSE_CHANGED ),
-	m_pCurTrail(			MESSAGE_CURRENT_TRAIL_P1_CHANGED ),
-	m_stEdit(				MESSAGE_EDIT_STEPS_TYPE_CHANGED ),
-    m_pEditSourceSteps(		MESSAGE_EDIT_SOURCE_STEPS_CHANGED ),
-	m_stEditSource(			MESSAGE_EDIT_SOURCE_STEPS_TYPE_CHANGED )
+m_pCurStyle(MESSAGE_CURRENT_STYLE_CHANGED),
+m_PreferredCourseDifficulty(MESSAGE_EDIT_PREFERRED_COURSE_DIFFICULTY_P1_CHANGED),
+m_PreferredDifficulty(MESSAGE_EDIT_PREFERRED_DIFFICULTY_P1_CHANGED),
+m_pCurSong(MESSAGE_CURRENT_SONG_CHANGED),
+m_pCurSteps(MESSAGE_CURRENT_STEPS_P1_CHANGED),
+m_pCurCourse(MESSAGE_CURRENT_COURSE_CHANGED),
+m_pCurTrail(MESSAGE_CURRENT_TRAIL_P1_CHANGED),
+m_stEdit(MESSAGE_EDIT_STEPS_TYPE_CHANGED),
+m_pEditSourceSteps(MESSAGE_EDIT_SOURCE_STEPS_CHANGED),
+m_stEditSource(MESSAGE_EDIT_SOURCE_STEPS_TYPE_CHANGED)
 {
-	m_pCurStyle.Set( NULL );
+	m_pCurStyle.Set(NULL);
 
 	m_pCurGame = NULL;
 	m_iCoins = 0;
@@ -98,10 +104,10 @@ GameState::GameState() :
 	m_iStageSeed = m_iGameSeed = 0;
 
 	m_PlayMode = PLAY_MODE_INVALID; // used by IsPlayerEnabled before the first screen
-	FOREACH_PlayerNumber( p )
+	FOREACH_PlayerNumber(p)
 		m_bSideIsJoined[p] = false; // used by GetNumSidesJoined before the first screen
 
-	FOREACH_PlayerNumber( p )
+	FOREACH_PlayerNumber(p)
 	{
 		m_pPlayerState[p] = new PlayerState;
 		m_pPlayerState[p]->m_PlayerNumber = p;
@@ -111,79 +117,95 @@ GameState::GameState() :
 
 	m_pTimingDataOriginal = new TimingData;
 
+	//DUMB but if I don't do it this way, it crashes. Gotta have a private member instead of a preference	
+	m_sSongBroadcastURL.assign(pSongBroadcastURL.Get().c_str());
+
+	//allocate networking variables
+#if !defined(WITHOUT_NETWORKING)
+	m_SongBroadcastHTTP = new HTTPHelper();
+#endif
+
 	/* Don't reset yet; let the first screen do it, so we can
-	 * use PREFSMAN and THEME. */
-//	Reset();
+	* use PREFSMAN and THEME. */
+	//	Reset();
 }
 
 GameState::~GameState()
 {
-	for( unsigned i=0; i<m_pCharacters.size(); i++ )
-		SAFE_DELETE( m_pCharacters[i] );
+	for (unsigned i = 0; i<m_pCharacters.size(); i++)
+		SAFE_DELETE(m_pCharacters[i]);
 
-	FOREACH_PlayerNumber( p )
-		SAFE_DELETE( m_pPlayerState[p] );
+	FOREACH_PlayerNumber(p)
+		SAFE_DELETE(m_pPlayerState[p]);
 
-	SAFE_DELETE( m_Environment );
+	SAFE_DELETE(m_Environment);
 
-	SAFE_DELETE( m_pTimingDataOriginal );
+	SAFE_DELETE(m_pTimingDataOriginal);
+
+	//destroy network variables
+#if !defined(WITHOUT_NETWORKING)
+
+
+	m_SongBroadcastHTTP->GetThreadedResult(); //waits for last call to finish or timeout before destroying object
+	SAFE_DELETE(m_SongBroadcastHTTP);
+#endif
 }
 
-void GameState::ApplyGameCommand( const CString &sCommand, PlayerNumber pn )
+void GameState::ApplyGameCommand(const CString &sCommand, PlayerNumber pn)
 {
 	GameCommand m;
-	m.Load( 0, ParseCommands(sCommand) );
+	m.Load(0, ParseCommands(sCommand));
 
 	CString sWhy;
-	if( !m.IsPlayable(&sWhy) )
-		RageException::Throw( "Can't apply mode \"%s\": %s", sCommand.c_str(), sWhy.c_str() );
+	if (!m.IsPlayable(&sWhy))
+		RageException::Throw("Can't apply mode \"%s\": %s", sCommand.c_str(), sWhy.c_str());
 
-	if( pn == PLAYER_INVALID )
+	if (pn == PLAYER_INVALID)
 		m.ApplyToAllPlayers();
 	else
-		m.Apply( pn );
+		m.Apply(pn);
 }
 
 void GameState::ApplyCmdline()
 {
 	/* We need to join players before we can set the style. */
 	CString sPlayer;
-	for( int i = 0; GetCommandlineArgument( "player", &sPlayer, i ); ++i )
+	for (int i = 0; GetCommandlineArgument("player", &sPlayer, i); ++i)
 	{
-		int pn = atoi( sPlayer )-1;
-		if( !IsAnInt( sPlayer ) || pn < 0 || pn >= NUM_PLAYERS )
-			RageException::Throw( "Invalid argument \"--player=%s\"", sPlayer.c_str() );
+		int pn = atoi(sPlayer) - 1;
+		if (!IsAnInt(sPlayer) || pn < 0 || pn >= NUM_PLAYERS)
+			RageException::Throw("Invalid argument \"--player=%s\"", sPlayer.c_str());
 
-		this->JoinPlayer( (PlayerNumber) pn );
+		this->JoinPlayer((PlayerNumber)pn);
 	}
 
 	CString sMode;
-	for( int i = 0; GetCommandlineArgument( "mode", &sMode, i ); ++i )
+	for (int i = 0; GetCommandlineArgument("mode", &sMode, i); ++i)
 	{
-		ApplyGameCommand( sMode );
+		ApplyGameCommand(sMode);
 	}
 }
 
 void GameState::Reset()
 {
 	EndGame();
-	
-	ASSERT( THEME );
+
+	ASSERT(THEME);
 
 	m_timeGameStarted.SetZero();
-	m_pCurStyle.Set( NULL );
-	FOREACH_PlayerNumber( p )
+	m_pCurStyle.Set(NULL);
+	FOREACH_PlayerNumber(p)
 		m_bSideIsJoined[p] = false;
 	MEMCARDMAN->UnlockCards();
-//	m_iCoins = 0;	// don't reset coin count!
+	//	m_iCoins = 0;	// don't reset coin count!
 	m_MasterPlayerNumber = PLAYER_INVALID;
 	m_mapEnv.clear();
-	m_sPreferredSongGroup	= GROUP_ALL_MUSIC;
+	m_sPreferredSongGroup = GROUP_ALL_MUSIC;
 	m_bChangedFailTypeOnScreenSongOptions = false;
-	FOREACH_PlayerNumber( p )
+	FOREACH_PlayerNumber(p)
 	{
-		m_PreferredDifficulty[p].Set( DIFFICULTY_INVALID );
-		m_PreferredCourseDifficulty[p].Set( DIFFICULTY_MEDIUM );
+		m_PreferredDifficulty[p].Set(DIFFICULTY_INVALID);
+		m_PreferredCourseDifficulty[p].Set(DIFFICULTY_MEDIUM);
 	}
 	m_SortOrder = SORT_INVALID;
 	m_PreferredSortOrder = GetDefaultSort();
@@ -196,40 +218,40 @@ void GameState::Reset()
 	m_BeatToNoteSkinRev = 0;
 	m_iNumStagesOfThisSong = 0;
 
-	NOTESKIN->RefreshNoteSkinData( this->m_pCurGame );
+	NOTESKIN->RefreshNoteSkinData(this->m_pCurGame);
 
 	m_iGameSeed = rand();
 	m_iStageSeed = rand();
 
-	m_pCurSong.Set( GetDefaultSong() );
+	m_pCurSong.Set(GetDefaultSong());
 	m_pPreferredSong = NULL;
-	FOREACH_PlayerNumber( p )
-		m_pCurSteps[p].Set( NULL );
-	m_pCurCourse.Set( NULL );
+	FOREACH_PlayerNumber(p)
+		m_pCurSteps[p].Set(NULL);
+	m_pCurCourse.Set(NULL);
 	m_pPreferredCourse = NULL;
-	FOREACH_PlayerNumber( p )
-		m_pCurTrail[p].Set( NULL );
+	FOREACH_PlayerNumber(p)
+		m_pCurTrail[p].Set(NULL);
 
-	FOREACH_PlayerNumber( p )
+	FOREACH_PlayerNumber(p)
 		m_pPlayerState[p]->Reset();
 
 	ResetMusicStatistics();
 	ResetStageStatistics();
 
-	FOREACH_PlayerNumber( pn )
-		PROFILEMAN->UnloadProfile( pn );
+	FOREACH_PlayerNumber(pn)
+		PROFILEMAN->UnloadProfile(pn);
 
 	SONGMAN->UpdateBest();
 	SONGMAN->UpdateShuffled();
 
 	/* We may have cached trails from before everything was loaded (eg. from before
-	 * SongManager::UpdateBest could be called).  Erase the cache. */
+	* SongManager::UpdateBest could be called).  Erase the cache. */
 	SONGMAN->RegenerateNonFixedCourses();
 
 	STATSMAN->Reset();
 
 	m_SongOptions.Init();
-	
+
 	FOREACH_PlayerNumber(p)
 	{
 		// I can't think of a good reason to have both game-specific
@@ -239,43 +261,43 @@ void GameState::Reset()
 		// The theme setting is for eg. BM being reverse by default.  (This
 		// could be done in the title menu GameCommand, but then it wouldn't
 		// affect demo, and other non-gameplay things ...) -glenn
-		ApplyModifiers( p, DEFAULT_MODIFIERS );
-		ApplyModifiers( p, PREFSMAN->m_sDefaultModifiers );
+		ApplyModifiers(p, DEFAULT_MODIFIERS);
+		ApplyModifiers(p, PREFSMAN->m_sDefaultModifiers);
 	}
 
 	FOREACH_PlayerNumber(p)
 	{
-		if( PREFSMAN->m_ShowDancingCharacters == PrefsManager::CO_RANDOM)
+		if (PREFSMAN->m_ShowDancingCharacters == PrefsManager::CO_RANDOM)
 			m_pCurCharacters[p] = GetRandomCharacter();
 		else
 			m_pCurCharacters[p] = GetDefaultCharacter();
-		ASSERT( m_pCurCharacters[p] );
+		ASSERT(m_pCurCharacters[p]);
 	}
 
 	m_bTemporaryEventMode = false;
 	m_bStatsCommitted = false;
 
-	LIGHTSMAN->SetLightsMode( LIGHTSMODE_ATTRACT );
-	
-	m_stEdit.Set( STEPS_TYPE_INVALID );
-	m_pEditSourceSteps.Set( NULL );
-	m_stEditSource.Set( STEPS_TYPE_INVALID );
+	LIGHTSMAN->SetLightsMode(LIGHTSMODE_ATTRACT);
+
+	m_stEdit.Set(STEPS_TYPE_INVALID);
+	m_pEditSourceSteps.Set(NULL);
+	m_stEditSource.Set(STEPS_TYPE_INVALID);
 
 	SONGMAN->FreeAllLoadedPlayerSongs();
 
 	ApplyCmdline();
 }
 
-void GameState::JoinPlayer( PlayerNumber pn )
+void GameState::JoinPlayer(PlayerNumber pn)
 {
 	this->m_bSideIsJoined[pn] = true;
-	MESSAGEMAN->Broadcast( (Message)(MESSAGE_SIDE_JOINED_P1+pn) );
+	MESSAGEMAN->Broadcast((Message)(MESSAGE_SIDE_JOINED_P1 + pn));
 
-	if( this->m_MasterPlayerNumber == PLAYER_INVALID )
+	if (this->m_MasterPlayerNumber == PLAYER_INVALID)
 		this->m_MasterPlayerNumber = pn;
 
 	// if first player to join, set start time
-	if( this->GetNumSidesJoined() == 1 )
+	if (this->GetNumSidesJoined() == 1)
 		this->BeginGame();
 }
 
@@ -283,49 +305,68 @@ int GameState::GetCoinsNeededToJoin() const
 {
 	int iCoinsToCharge = 0;
 
-	if( GAMESTATE->GetCoinMode() == COIN_MODE_PAY )
+	if (GAMESTATE->GetCoinMode() == COIN_MODE_PAY)
 		iCoinsToCharge = PREFSMAN->m_iCoinsPerCredit;
 
 	// If joint premium don't take away a credit for the 2nd join.
-	if( GAMESTATE->GetPremium() == PREMIUM_JOINT  &&  
-		GAMESTATE->GetNumSidesJoined() == 1 )
+	if (GAMESTATE->GetPremium() == PREMIUM_JOINT  &&
+		GAMESTATE->GetNumSidesJoined() == 1)
 		iCoinsToCharge = 0;
 
 	return iCoinsToCharge;
 }
 
-void GameState::SetSongInProgress( const CString &sWriteOut )
+void GameState::SetSongInProgress(const CString &sWriteOut)
 {
 	CString sLockFile = "Data/songinprogress";
 	LOG->Debug("GameState::SetSongInProgress( %s )", sWriteOut.c_str());
-
 	RageFile f;
 	f.Open(sLockFile, RageFile::WRITE);
-	f.Write( sWriteOut );
+	f.Write(sWriteOut);
 	f.Close();
+
+
+}
+
+void GameState::HTTPBroadcastSongInProgress(const CString &sWriteOut)
+{
+
+	//if we have networking
+#if !defined(WITHOUT_NETWORKING)
+	//and we have a broadcast URL...
+	if (m_sSongBroadcastURL.length()>3)
+	{
+		m_SongBroadcastHTTP = new HTTPHelper();
+		m_SongBroadcastHTTP->Threaded_SubmitPostRequest(m_sSongBroadcastURL, sWriteOut);
+	}
+	else
+	{
+		//LOG->Debug("GameState::SetSongInProgress m_sSongBroadcastURL ( %s ) length is less than 3! Skipping broadcast!", m_sSongBroadcastURL.c_str());
+	}
+#endif
 }
 
 /*
- * Game flow:
- *
- * BeginGame() - the first player has joined; the game is starting.
- *
- * PlayersFinalized() - no more players may join (because the style is set)
- *
- * BeginStage() - gameplay is beginning
- *
- * optional: CancelStage() - gameplay aborted (Back pressed), undo BeginStage and back up
- *
- * CommitStageStats() - gameplay is finished
- *   Saves STATSMAN->m_CurStageStats to the profiles, so profile information
- *   is up-to-date for Evaluation.
- *
- * FinishStage() - gameplay and evaluation is finished
- *   Clears data which was stored by CommitStageStats.
- *
- * EndGame() - the game is finished
- *
- */
+* Game flow:
+*
+* BeginGame() - the first player has joined; the game is starting.
+*
+* PlayersFinalized() - no more players may join (because the style is set)
+*
+* BeginStage() - gameplay is beginning
+*
+* optional: CancelStage() - gameplay aborted (Back pressed), undo BeginStage and back up
+*
+* CommitStageStats() - gameplay is finished
+*   Saves STATSMAN->m_CurStageStats to the profiles, so profile information
+*   is up-to-date for Evaluation.
+*
+* FinishStage() - gameplay and evaluation is finished
+*   Clears data which was stored by CommitStageStats.
+*
+* EndGame() - the game is finished
+*
+*/
 void GameState::BeginGame()
 {
 	m_timeGameStarted.Touch();
@@ -341,83 +382,83 @@ void GameState::BeginGame()
 
 void GameState::PlayersFinalized()
 {
-	if( MEMCARDMAN->GetCardsLocked() )
+	if (MEMCARDMAN->GetCardsLocked())
 		return;
 
 	SONGMAN->FreeAllLoadedPlayerSongs(); // avoid duplicates
 	SONGMAN->FreeAllLoadedPlayerCourses();
 
-	MESSAGEMAN->Broadcast( MESSAGE_PLAYERS_FINALIZED );
+	MESSAGEMAN->Broadcast(MESSAGE_PLAYERS_FINALIZED);
 
 	MEMCARDMAN->LockCards();
 
-	FOREACH_HumanPlayer( pn )
+	FOREACH_HumanPlayer(pn)
 	{
-		MEMCARDMAN->MountCard( pn, 600 );
-		PROFILEMAN->LoadFirstAvailableProfile( pn );	// load full profile
+		MEMCARDMAN->MountCard(pn, 600);
+		PROFILEMAN->LoadFirstAvailableProfile(pn);	// load full profile
 	}
 
 	// apply saved default modifiers if any
-	FOREACH_HumanPlayer( pn )
+	FOREACH_HumanPlayer(pn)
 	{
 		if (PREFSMAN->m_bCustomSongs && !GAMESTATE->IsCourseMode())
 		{
-			SONGMAN->LoadPlayerSongs( pn );		// load custom songs, if any
+			SONGMAN->LoadPlayerSongs(pn);		// load custom songs, if any
 		}
 		else if (PREFSMAN->m_bCustomCourses && GAMESTATE->IsCourseMode())
 		{
 			// XXX LoadPlayerSongs(): should we be loading courses first to a temporary queue or something?
-			SONGMAN->LoadPlayerSongs( pn );
-			SONGMAN->LoadPlayerCourses( pn );
+			SONGMAN->LoadPlayerSongs(pn);
+			SONGMAN->LoadPlayerCourses(pn);
 		}
 
-		MEMCARDMAN->UnmountCard( pn );
+		MEMCARDMAN->UnmountCard(pn);
 	}
 
-	FOREACH_HumanPlayer( pn )
+	FOREACH_HumanPlayer(pn)
 	{
-		if( !PROFILEMAN->IsPersistentProfile(pn) )
+		if (!PROFILEMAN->IsPersistentProfile(pn))
 			continue;	// skip
 
 		Profile* pProfile = PROFILEMAN->GetProfile(pn);
 
 		CString sModifiers;
-		if( pProfile->GetDefaultModifiers( this->m_pCurGame, sModifiers ) )
+		if (pProfile->GetDefaultModifiers(this->m_pCurGame, sModifiers))
 		{
 			/* We don't save negative preferences (eg. "no reverse").  If the theme
-			 * sets a default of "reverse", and the player turns it off, we should
-			 * set it off.  However, don't reset modifiers that aren't saved by the
-			 * profile, so we don't ignore unsaved modifiers when a profile is in use. */
+			* sets a default of "reverse", and the player turns it off, we should
+			* set it off.  However, don't reset modifiers that aren't saved by the
+			* profile, so we don't ignore unsaved modifiers when a profile is in use. */
 			GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions.ResetSavedPrefs();
-			GAMESTATE->ApplyModifiers( pn, sModifiers );
+			GAMESTATE->ApplyModifiers(pn, sModifiers);
 		}
 		// Only set the sort order if it wasn't already set by a GameCommand (or by an earlier profile)
-		if( m_PreferredSortOrder == SORT_INVALID && pProfile->m_SortOrder != SORT_INVALID )
+		if (m_PreferredSortOrder == SORT_INVALID && pProfile->m_SortOrder != SORT_INVALID)
 			m_PreferredSortOrder = pProfile->m_SortOrder;
-		if( pProfile->m_LastDifficulty != DIFFICULTY_INVALID )
-			m_PreferredDifficulty[pn].Set( pProfile->m_LastDifficulty );
-		if( pProfile->m_LastCourseDifficulty != DIFFICULTY_INVALID )
-			m_PreferredCourseDifficulty[pn].Set( pProfile->m_LastCourseDifficulty );
-		if( m_pPreferredSong == NULL )
+		if (pProfile->m_LastDifficulty != DIFFICULTY_INVALID)
+			m_PreferredDifficulty[pn].Set(pProfile->m_LastDifficulty);
+		if (pProfile->m_LastCourseDifficulty != DIFFICULTY_INVALID)
+			m_PreferredCourseDifficulty[pn].Set(pProfile->m_LastCourseDifficulty);
+		if (m_pPreferredSong == NULL)
 			m_pPreferredSong = pProfile->m_lastSong.ToSong();
-		if( m_pPreferredCourse == NULL )
+		if (m_pPreferredCourse == NULL)
 			m_pPreferredCourse = pProfile->m_lastCourse.ToCourse();
 	}
 
-	FOREACH_PlayerNumber( pn )
+	FOREACH_PlayerNumber(pn)
 	{
-		if( !IsHumanPlayer(pn) )
-			ApplyModifiers( pn, DEFAULT_CPU_MODIFIERS );
+		if (!IsHumanPlayer(pn))
+			ApplyModifiers(pn, DEFAULT_CPU_MODIFIERS);
 	}
 }
 
 void GameState::EndGame()
 {
-	LOG->Trace( "GameState::EndGame" );
+	LOG->Trace("GameState::EndGame");
 
-	if( m_bDemonstrationOrJukebox )
+	if (m_bDemonstrationOrJukebox)
 		return;
-	if( m_timeGameStarted.IsZero() || !STATSMAN->m_vPlayedStageStats.size() )	// we were in the middle of a game and played at least one song
+	if (m_timeGameStarted.IsZero() || !STATSMAN->m_vPlayedStageStats.size())	// we were in the middle of a game and played at least one song
 		return;
 
 	/* Finish the final stage. */
@@ -425,16 +466,16 @@ void GameState::EndGame()
 
 
 	// Update totalPlaySeconds stat
-	int iPlaySeconds = max( 0, (int) m_timeGameStarted.PeekDeltaTime() );
+	int iPlaySeconds = max(0, (int)m_timeGameStarted.PeekDeltaTime());
 
 	Profile* pMachineProfile = PROFILEMAN->GetMachineProfile();
 	pMachineProfile->m_iTotalPlaySeconds += iPlaySeconds;
 	pMachineProfile->m_iTotalPlays++;
 
-	FOREACH_HumanPlayer( p )
+	FOREACH_HumanPlayer(p)
 	{
-		Profile* pPlayerProfile = PROFILEMAN->GetProfile( p );
-		if( pPlayerProfile )
+		Profile* pPlayerProfile = PROFILEMAN->GetProfile(p);
+		if (pPlayerProfile)
 		{
 			pPlayerProfile->m_iTotalPlaySeconds += iPlaySeconds;
 			pPlayerProfile->m_iTotalPlays++;
@@ -443,26 +484,26 @@ void GameState::EndGame()
 
 	BOOKKEEPER->WriteToDisk();
 
-	FOREACH_HumanPlayer( pn )
+	FOREACH_HumanPlayer(pn)
 	{
-		if( !PROFILEMAN->IsPersistentProfile(pn) )
+		if (!PROFILEMAN->IsPersistentProfile(pn))
 			continue;
 
 		bool bWasMemoryCard = PROFILEMAN->ProfileWasLoadedFromMemoryCard(pn);
-		if( bWasMemoryCard )
-			MEMCARDMAN->MountCard( pn );
-		PROFILEMAN->SaveProfile( pn );
-		if( bWasMemoryCard )
-			MEMCARDMAN->UnmountCard( pn );
+		if (bWasMemoryCard)
+			MEMCARDMAN->MountCard(pn);
+		PROFILEMAN->SaveProfile(pn);
+		if (bWasMemoryCard)
+			MEMCARDMAN->UnmountCard(pn);
 
-		PROFILEMAN->UnloadProfile( pn );
+		PROFILEMAN->UnloadProfile(pn);
 	}
 
 	PROFILEMAN->SaveMachineProfile();
 
 	// Reset the USB storage device numbers -after- saving
 	CHECKPOINT;
-//	MEMCARDMAN->FlushAndReset();
+	//	MEMCARDMAN->FlushAndReset();
 	CHECKPOINT;
 
 	// get rid of our custom songs
@@ -476,21 +517,21 @@ void GameState::EndGame()
 /* Called by ScreenGameplay.  Set the length of the current song. */
 void GameState::BeginStage()
 {
-	if( m_bDemonstrationOrJukebox )
+	if (m_bDemonstrationOrJukebox)
 		return;
 
 	/* This should only be called once per stage. */
-	if( m_iNumStagesOfThisSong != 0 )
-		LOG->Warn( "XXX: m_iNumStagesOfThisSong == %i?", m_iNumStagesOfThisSong );
+	if (m_iNumStagesOfThisSong != 0)
+		LOG->Warn("XXX: m_iNumStagesOfThisSong == %i?", m_iNumStagesOfThisSong);
 
 	/* Finish the last stage (if any), if we havn't already.  (For example, we might
-	 * have, for some reason, gone from gameplay to evaluation straight back to gameplay.) */
+	* have, for some reason, gone from gameplay to evaluation straight back to gameplay.) */
 	FinishStage();
 
 	GAMESTATE->ResetStageStatistics();
 
 	m_iNumStagesOfThisSong = GetNumStagesForCurrentSong();
-	ASSERT( m_iNumStagesOfThisSong != -1 );
+	ASSERT(m_iNumStagesOfThisSong != -1);
 }
 
 void GameState::CancelStage()
@@ -501,7 +542,7 @@ void GameState::CancelStage()
 void GameState::CommitStageStats()
 {
 	/* Don't commit stats twice. */
-	if( m_bStatsCommitted || m_bDemonstrationOrJukebox )
+	if (m_bStatsCommitted || m_bDemonstrationOrJukebox)
 		return;
 	m_bStatsCommitted = true;
 
@@ -509,12 +550,12 @@ void GameState::CommitStageStats()
 }
 
 /* Called by ScreenSelectMusic (etc).  Increment the stage counter if we just played a
- * song.  Might be called more than once. */
+* song.  Might be called more than once. */
 void GameState::FinishStage()
 {
 	/* If m_iNumStagesOfThisSong is 0, we've been called more than once before calling
-	 * BeginStage.  This can happen when backing out of the player options screen. */
-	if( m_iNumStagesOfThisSong == 0 )
+	* BeginStage.  This can happen when backing out of the player options screen. */
+	if (m_iNumStagesOfThisSong == 0)
 		return;
 
 	/* If we havn't committed stats yet, do so. */
@@ -523,53 +564,53 @@ void GameState::FinishStage()
 	m_bStatsCommitted = false;
 
 	// Increment the stage counter.
-	ASSERT( m_iNumStagesOfThisSong >= 1 && m_iNumStagesOfThisSong <= 3 );
+	ASSERT(m_iNumStagesOfThisSong >= 1 && m_iNumStagesOfThisSong <= 3);
 	const int iOldStageIndex = m_iCurrentStageIndex;
 	m_iCurrentStageIndex += m_iNumStagesOfThisSong;
 
 	m_iNumStagesOfThisSong = 0;
 
-	if( m_bDemonstrationOrJukebox )
+	if (m_bDemonstrationOrJukebox)
 		return;
 
-	if( GAMESTATE->IsEventMode() )
+	if (GAMESTATE->IsEventMode())
 	{
 		const int iSaveProfileEvery = 3;
-		if( iOldStageIndex/iSaveProfileEvery < m_iCurrentStageIndex/iSaveProfileEvery )
+		if (iOldStageIndex / iSaveProfileEvery < m_iCurrentStageIndex / iSaveProfileEvery)
 		{
-			LOG->Trace( "Played %i stages; saving profiles ...", iSaveProfileEvery );
+			LOG->Trace("Played %i stages; saving profiles ...", iSaveProfileEvery);
 			PROFILEMAN->SaveAllProfiles();
 		}
 	}
 }
 
-void GameState::SaveCurrentSettingsToProfile( PlayerNumber pn )
+void GameState::SaveCurrentSettingsToProfile(PlayerNumber pn)
 {
-	if( !PROFILEMAN->IsPersistentProfile(pn) )
+	if (!PROFILEMAN->IsPersistentProfile(pn))
 		return;
-	if( m_bDemonstrationOrJukebox )
+	if (m_bDemonstrationOrJukebox)
 		return;
 
 	Profile* pProfile = PROFILEMAN->GetProfile(pn);
 
-	pProfile->SetDefaultModifiers( this->m_pCurGame, m_pPlayerState[pn]->m_PlayerOptions.GetSavedPrefsString() );
-	if( IsSongSort(m_PreferredSortOrder) )
+	pProfile->SetDefaultModifiers(this->m_pCurGame, m_pPlayerState[pn]->m_PlayerOptions.GetSavedPrefsString());
+	if (IsSongSort(m_PreferredSortOrder))
 		pProfile->m_SortOrder = m_PreferredSortOrder;
-	if( m_PreferredDifficulty[pn] != DIFFICULTY_INVALID )
+	if (m_PreferredDifficulty[pn] != DIFFICULTY_INVALID)
 		pProfile->m_LastDifficulty = m_PreferredDifficulty[pn];
-	if( m_PreferredCourseDifficulty[pn] != DIFFICULTY_INVALID )
+	if (m_PreferredCourseDifficulty[pn] != DIFFICULTY_INVALID)
 		pProfile->m_LastCourseDifficulty = m_PreferredCourseDifficulty[pn];
-	if( m_pPreferredSong )
-		pProfile->m_lastSong.FromSong( m_pPreferredSong );
-	if( m_pPreferredCourse )
-		pProfile->m_lastCourse.FromCourse( m_pPreferredCourse );
+	if (m_pPreferredSong)
+		pProfile->m_lastSong.FromSong(m_pPreferredSong);
+	if (m_pPreferredCourse)
+		pProfile->m_lastCourse.FromCourse(m_pPreferredCourse);
 }
 
-void GameState::Update( float fDelta )
+void GameState::Update(float fDelta)
 {
-	FOREACH_PlayerNumber( p )
+	FOREACH_PlayerNumber(p)
 	{
-		m_pPlayerState[p]->Update( fDelta );
+		m_pPlayerState[p]->Update(fDelta);
 
 		// TRICKY: GAMESTATE->Update is run before any of the Screen update's,
 		// so we'll clear these flags here and let them get turned on later
@@ -579,26 +620,26 @@ void GameState::Update( float fDelta )
 		bool bRebuildPlayerOptions = false;
 
 		/* See if any delayed attacks are starting or ending. */
-		for( unsigned s=0; s<m_pPlayerState[p]->m_ActiveAttacks.size(); s++ )
+		for (unsigned s = 0; s<m_pPlayerState[p]->m_ActiveAttacks.size(); s++)
 		{
 			Attack &attack = m_pPlayerState[p]->m_ActiveAttacks[s];
-			
+
 			// -1 is the "starts now" sentinel value.  You must add the attack
 			// by calling GameState::LaunchAttack, or else the -1 won't be 
 			// converted into the current music time.  
-			ASSERT( attack.fStartSecond != -1 );
+			ASSERT(attack.fStartSecond != -1);
 
 			bool bCurrentlyEnabled =
 				attack.bGlobal ||
-				( attack.fStartSecond < this->m_fMusicSeconds &&
-				m_fMusicSeconds < attack.fStartSecond+attack.fSecsRemaining );
+				(attack.fStartSecond < this->m_fMusicSeconds &&
+				m_fMusicSeconds < attack.fStartSecond + attack.fSecsRemaining);
 
-			if( m_pPlayerState[p]->m_ActiveAttacks[s].bOn == bCurrentlyEnabled )
+			if (m_pPlayerState[p]->m_ActiveAttacks[s].bOn == bCurrentlyEnabled)
 				continue; /* OK */
 
-			if( m_pPlayerState[p]->m_ActiveAttacks[s].bOn && !bCurrentlyEnabled )
+			if (m_pPlayerState[p]->m_ActiveAttacks[s].bOn && !bCurrentlyEnabled)
 				m_pPlayerState[p]->m_bAttackEndedThisUpdate = true;
-			else if( !m_pPlayerState[p]->m_ActiveAttacks[s].bOn && bCurrentlyEnabled )
+			else if (!m_pPlayerState[p]->m_ActiveAttacks[s].bOn && bCurrentlyEnabled)
 				m_pPlayerState[p]->m_bAttackBeganThisUpdate = true;
 
 			bRebuildPlayerOptions = true;
@@ -606,67 +647,67 @@ void GameState::Update( float fDelta )
 			m_pPlayerState[p]->m_ActiveAttacks[s].bOn = bCurrentlyEnabled;
 		}
 
-		if( bRebuildPlayerOptions )
-			RebuildPlayerOptionsFromActiveAttacks( p );
+		if (bRebuildPlayerOptions)
+			RebuildPlayerOptionsFromActiveAttacks(p);
 
-		if( m_pPlayerState[p]->m_fSecondsUntilAttacksPhasedOut > 0 )
-			m_pPlayerState[p]->m_fSecondsUntilAttacksPhasedOut = max( 0, m_pPlayerState[p]->m_fSecondsUntilAttacksPhasedOut - fDelta );
+		if (m_pPlayerState[p]->m_fSecondsUntilAttacksPhasedOut > 0)
+			m_pPlayerState[p]->m_fSecondsUntilAttacksPhasedOut = max(0, m_pPlayerState[p]->m_fSecondsUntilAttacksPhasedOut - fDelta);
 
-		if( !m_bGoalComplete[p] && IsGoalComplete(p) )
+		if (!m_bGoalComplete[p] && IsGoalComplete(p))
 		{
 			m_bGoalComplete[p] = true;
-			MESSAGEMAN->Broadcast( (Message)(MESSAGE_GOAL_COMPLETE_P1+p) );
+			MESSAGEMAN->Broadcast((Message)(MESSAGE_GOAL_COMPLETE_P1 + p));
 		}
 	}
 
 	// apply any delayed game commands that were issued
-	if( !m_sDelayedGameCommand.empty() )
+	if (!m_sDelayedGameCommand.empty())
 	{
-		this->ApplyGameCommand( m_sDelayedGameCommand );
+		this->ApplyGameCommand(m_sDelayedGameCommand);
 		m_sDelayedGameCommand.clear();
 	}
 }
 
 void GameState::ReloadCharacters()
 {
-	for( unsigned i=0; i<m_pCharacters.size(); i++ )
-		SAFE_DELETE( m_pCharacters[i] );
+	for (unsigned i = 0; i<m_pCharacters.size(); i++)
+		SAFE_DELETE(m_pCharacters[i]);
 	m_pCharacters.clear();
 
-	FOREACH_PlayerNumber( p )
+	FOREACH_PlayerNumber(p)
 		m_pCurCharacters[p] = NULL;
 
 	CStringArray as;
-	GetDirListing( CHARACTERS_DIR "*", as, true, true );
+	GetDirListing(CHARACTERS_DIR "*", as, true, true);
 	bool FoundDefault = false;
-	for( unsigned i=0; i<as.size(); i++ )
+	for (unsigned i = 0; i<as.size(); i++)
 	{
 		CString sCharName, sDummy;
 		splitpath(as[i], sDummy, sCharName, sDummy);
 		sCharName.MakeLower();
 
-		if( sCharName.CompareNoCase("default")==0 )
+		if (sCharName.CompareNoCase("default") == 0)
 			FoundDefault = true;
 
 		Character* pChar = new Character;
-		if( pChar->Load( as[i] ) )
-			m_pCharacters.push_back( pChar );
+		if (pChar->Load(as[i]))
+			m_pCharacters.push_back(pChar);
 		else
 			delete pChar;
 	}
-	
-	if( !FoundDefault )
-		RageException::Throw( "'Characters/default' is missing." );
+
+	if (!FoundDefault)
+		RageException::Throw("'Characters/default' is missing.");
 
 	// If FoundDefault, then we're not empty. -Chris
-//	if( m_pCharacters.empty() )
-//		RageException::Throw( "Couldn't find any character definitions" );
+	//	if( m_pCharacters.empty() )
+	//		RageException::Throw( "Couldn't find any character definitions" );
 }
 
 const float GameState::MUSIC_SECONDS_INVALID = -5000.0f;
 
 void GameState::ResetMusicStatistics()
-{	
+{
 	m_fMusicSeconds = 0; // MUSIC_SECONDS_INVALID;
 	m_fSongBeat = 0;
 	m_fMusicSecondsVisible = 0;
@@ -674,18 +715,18 @@ void GameState::ResetMusicStatistics()
 	m_fCurBPS = 10;
 	m_bFreeze = false;
 	m_bPastHereWeGo = false;
-	Actor::SetBGMTime( 0, 0 );
+	Actor::SetBGMTime(0, 0);
 }
 
 void GameState::ResetStageStatistics()
 {
 	StageStats OldStats = STATSMAN->m_CurStageStats;
 	STATSMAN->m_CurStageStats = StageStats();
-	if( PREFSMAN->m_bComboContinuesBetweenSongs )
+	if (PREFSMAN->m_bComboContinuesBetweenSongs)
 	{
-		if( GetStageIndex() == 0 )
+		if (GetStageIndex() == 0)
 		{
-			FOREACH_PlayerNumber( p )
+			FOREACH_PlayerNumber(p)
 			{
 				Profile* pProfile = PROFILEMAN->GetProfile(p);
 				STATSMAN->m_CurStageStats.m_player[p].iCurCombo = pProfile->m_iCurrentCombo;
@@ -693,7 +734,7 @@ void GameState::ResetStageStatistics()
 		}
 		else	// GetStageIndex() > 0
 		{
-			FOREACH_PlayerNumber( p )
+			FOREACH_PlayerNumber(p)
 			{
 				STATSMAN->m_CurStageStats.m_player[p].iCurCombo = OldStats.m_player[p].iCurCombo;
 			}
@@ -704,7 +745,7 @@ void GameState::ResetStageStatistics()
 	RemoveAllInventory();
 	m_fOpponentHealthPercent = 1;
 	m_fTugLifePercentP1 = 0.5f;
-	FOREACH_PlayerNumber( p )
+	FOREACH_PlayerNumber(p)
 	{
 		m_pPlayerState[p]->m_fSuperMeter = 0;
 		m_pPlayerState[p]->m_HealthState = PlayerState::ALIVE;
@@ -716,7 +757,7 @@ void GameState::ResetStageStatistics()
 	}
 
 
-	FOREACH_PlayerNumber( p )
+	FOREACH_PlayerNumber(p)
 	{
 		m_vLastPerDifficultyAwards[p].clear();
 		m_vLastPeakComboAwards[p].clear();
@@ -729,28 +770,28 @@ void GameState::ResetStageStatistics()
 	ResetOriginalSyncData();
 }
 
-void GameState::UpdateSongPosition( float fPositionSeconds, const TimingData &timing, const RageTimer &timestamp )
+void GameState::UpdateSongPosition(float fPositionSeconds, const TimingData &timing, const RageTimer &timestamp)
 {
-	if( !timestamp.IsZero() )
+	if (!timestamp.IsZero())
 		m_LastBeatUpdate = timestamp;
 	else
 		m_LastBeatUpdate.Touch();
-	timing.GetBeatAndBPSFromElapsedTime( fPositionSeconds, m_fSongBeat, m_fCurBPS, m_bFreeze );
-	ASSERT_M( m_fSongBeat > -2000, ssprintf("%f %f", m_fSongBeat, fPositionSeconds) );
+	timing.GetBeatAndBPSFromElapsedTime(fPositionSeconds, m_fSongBeat, m_fCurBPS, m_bFreeze);
+	ASSERT_M(m_fSongBeat > -2000, ssprintf("%f %f", m_fSongBeat, fPositionSeconds));
 
 	m_fMusicSeconds = fPositionSeconds;
-	m_fLightSongBeat = timing.GetBeatFromElapsedTime( fPositionSeconds + g_fLightsAheadSeconds );
+	m_fLightSongBeat = timing.GetBeatFromElapsedTime(fPositionSeconds + g_fLightsAheadSeconds);
 
 	/* update the Visible values based on the delay */
 	m_fMusicSecondsVisible = fPositionSeconds - PREFSMAN->m_fVisualDelaySeconds;
 
 	float fThrowAway; bool bThrowAway;
-	timing.GetBeatAndBPSFromElapsedTime( m_fMusicSecondsVisible, m_fSongBeatVisible, fThrowAway, bThrowAway );
+	timing.GetBeatAndBPSFromElapsedTime(m_fMusicSecondsVisible, m_fSongBeatVisible, fThrowAway, bThrowAway);
 
-	Actor::SetBGMTime( m_fMusicSecondsVisible, m_fSongBeatVisible );
+	Actor::SetBGMTime(m_fMusicSecondsVisible, m_fSongBeatVisible);
 }
 
-float GameState::GetSongPercent( float beat ) const
+float GameState::GetSongPercent(float beat) const
 {
 	/* 0 = first step; 1 = last step */
 	return (beat - m_pCurSong->m_fFirstBeat) / m_pCurSong->m_fLastBeat;
@@ -763,80 +804,80 @@ int GameState::GetStageIndex() const
 
 int GameState::GetNumStagesLeft() const
 {
-	if( IsExtraStage() || IsExtraStage2() )
+	if (IsExtraStage() || IsExtraStage2())
 		return 1;
-	if( GAMESTATE->IsEventMode() )
+	if (GAMESTATE->IsEventMode())
 		return 999;
 	return PREFSMAN->m_iSongsPerPlay - m_iCurrentStageIndex;
 }
 
 bool GameState::IsFinalStage() const
 {
-	if( GAMESTATE->IsEventMode() )
+	if (GAMESTATE->IsEventMode())
 		return false;
 
-	if( this->IsCourseMode() )
+	if (this->IsCourseMode())
 		return true;
 
 	/* This changes dynamically on ScreenSelectMusic as the wheel turns. */
 	int iPredictedStageForCurSong = GetNumStagesForCurrentSong();
-	if( iPredictedStageForCurSong == -1 )
+	if (iPredictedStageForCurSong == -1)
 		iPredictedStageForCurSong = 1;
 	return m_iCurrentStageIndex + iPredictedStageForCurSong == PREFSMAN->m_iSongsPerPlay;
 }
 
 bool GameState::IsExtraStage() const
 {
-	if( GAMESTATE->IsEventMode() )
+	if (GAMESTATE->IsEventMode())
 		return false;
 	return m_iCurrentStageIndex == PREFSMAN->m_iSongsPerPlay;
 }
 
 bool GameState::IsExtraStage2() const
 {
-	if( GAMESTATE->IsEventMode() )
+	if (GAMESTATE->IsEventMode())
 		return false;
-	return m_iCurrentStageIndex == PREFSMAN->m_iSongsPerPlay+1;
+	return m_iCurrentStageIndex == PREFSMAN->m_iSongsPerPlay + 1;
 }
 
 Stage GameState::GetCurrentStage() const
 {
-	if( m_bDemonstrationOrJukebox )				return STAGE_DEMO;
+	if (m_bDemonstrationOrJukebox)				return STAGE_DEMO;
 	// "event" has precedence
-	else if( GAMESTATE->IsEventMode() )			return STAGE_EVENT;
-	else if( m_PlayMode == PLAY_MODE_ONI )		return STAGE_ONI;
-	else if( m_PlayMode == PLAY_MODE_NONSTOP )	return STAGE_NONSTOP;
-	else if( m_PlayMode == PLAY_MODE_ENDLESS )	return STAGE_ENDLESS;
-	else if( IsFinalStage() )					return STAGE_FINAL;
-	else if( IsExtraStage() )					return STAGE_EXTRA1;
-	else if( IsExtraStage2() )					return STAGE_EXTRA2;
-	else										return (Stage)(STAGE_1+m_iCurrentStageIndex);
+	else if (GAMESTATE->IsEventMode())			return STAGE_EVENT;
+	else if (m_PlayMode == PLAY_MODE_ONI)		return STAGE_ONI;
+	else if (m_PlayMode == PLAY_MODE_NONSTOP)	return STAGE_NONSTOP;
+	else if (m_PlayMode == PLAY_MODE_ENDLESS)	return STAGE_ENDLESS;
+	else if (IsFinalStage())					return STAGE_FINAL;
+	else if (IsExtraStage())					return STAGE_EXTRA1;
+	else if (IsExtraStage2())					return STAGE_EXTRA2;
+	else										return (Stage)(STAGE_1 + m_iCurrentStageIndex);
 }
 
-void GameState::GetPossibleStages( vector<Stage> &out ) const
+void GameState::GetPossibleStages(vector<Stage> &out) const
 {
 	// Optimze me so that we don't load graphics that can't possibly be shown
 	out.clear();
-	FOREACH_Stage( s )
-		out.push_back( s );
+	FOREACH_Stage(s)
+		out.push_back(s);
 }
 
 int GameState::GetCourseSongIndex() const
 {
 	int iSongIndex = 0;
 	/* iSongsPlayed includes the current song, so it's 1-based; subtract one. */
-	FOREACH_EnabledPlayer( pn )
-		iSongIndex = max( iSongIndex, STATSMAN->m_CurStageStats.m_player[pn].iSongsPlayed-1 );
+	FOREACH_EnabledPlayer(pn)
+		iSongIndex = max(iSongIndex, STATSMAN->m_CurStageStats.m_player[pn].iSongsPlayed - 1);
 	return iSongIndex;
 }
 
-CString GameState::GetPlayerDisplayName( PlayerNumber pn ) const
+CString GameState::GetPlayerDisplayName(PlayerNumber pn) const
 {
-	ASSERT( IsPlayerEnabled(pn) );
+	ASSERT(IsPlayerEnabled(pn));
 	const CString defaultnames[] = { "Player 1", "Player 2" };
-	if( IsHumanPlayer(pn) )
+	if (IsHumanPlayer(pn))
 	{
-		if( !PROFILEMAN->GetPlayerName(pn).empty() )
+		if (!PROFILEMAN->GetPlayerName(pn).empty())
 			return PROFILEMAN->GetPlayerName(pn);
 		else
 			return defaultnames[pn];
@@ -853,17 +894,17 @@ bool GameState::PlayersCanJoin() const
 }
 
 int GameState::GetNumSidesJoined() const
-{ 
+{
 	int iNumSidesJoined = 0;
-	for( int c=0; c<NUM_PLAYERS; c++ )
-		if( m_bSideIsJoined[c] )
+	for (int c = 0; c<NUM_PLAYERS; c++)
+		if (m_bSideIsJoined[c])
 			iNumSidesJoined++;	// left side, and right side
 	return iNumSidesJoined;
 }
 
 const Game* GameState::GetCurrentGame()
 {
-	ASSERT( m_pCurGame != NULL );	// the game must be set before calling this
+	ASSERT(m_pCurGame != NULL);	// the game must be set before calling this
 	return m_pCurGame;
 }
 
@@ -873,44 +914,44 @@ const Style* GameState::GetCurrentStyle() const
 }
 
 
-bool GameState::IsPlayerEnabled( PlayerNumber pn ) const
+bool GameState::IsPlayerEnabled(PlayerNumber pn) const
 {
 	// In rave, all players are present.  Non-human players are CPU controlled.
-	switch( m_PlayMode )
+	switch (m_PlayMode)
 	{
 	case PLAY_MODE_BATTLE:
 	case PLAY_MODE_RAVE:
 		return true;
 	}
 
-	return IsHumanPlayer( pn );
+	return IsHumanPlayer(pn);
 }
 
 int	GameState::GetNumPlayersEnabled() const
 {
 	int count = 0;
-	FOREACH_EnabledPlayer( pn )
+	FOREACH_EnabledPlayer(pn)
 		count++;
 	return count;
 }
 
 bool GameState::PlayerUsingBothSides() const
 {
-	ASSERT( this->GetCurrentStyle() != NULL );
+	ASSERT(this->GetCurrentStyle() != NULL);
 	return this->GetCurrentStyle()->m_StyleType == ONE_PLAYER_TWO_SIDES;
 }
 
-bool GameState::IsHumanPlayer( PlayerNumber pn ) const
+bool GameState::IsHumanPlayer(PlayerNumber pn) const
 {
-	if( m_pCurStyle == NULL )	// no style chosen
+	if (m_pCurStyle == NULL)	// no style chosen
 	{
-		if( this->PlayersCanJoin() )	
+		if (this->PlayersCanJoin())
 			return m_bSideIsJoined[pn];	// only allow input from sides that have already joined
 		else
 			return true;	// if we can't join, then we're on a screen like MusicScroll or GameOver
 	}
 
-	switch( GetCurrentStyle()->m_StyleType )
+	switch (GetCurrentStyle()->m_StyleType)
 	{
 	case TWO_PLAYERS_TWO_SIDES:
 		return true;
@@ -926,14 +967,14 @@ bool GameState::IsHumanPlayer( PlayerNumber pn ) const
 int GameState::GetNumHumanPlayers() const
 {
 	int count = 0;
-	FOREACH_HumanPlayer( pn )
+	FOREACH_HumanPlayer(pn)
 		count++;
 	return count;
 }
 
 PlayerNumber GameState::GetFirstHumanPlayer() const
 {
-	FOREACH_HumanPlayer( pn )
+	FOREACH_HumanPlayer(pn)
 		return pn;
 	ASSERT(0);	// there must be at least 1 human player
 	return PLAYER_INVALID;
@@ -941,20 +982,20 @@ PlayerNumber GameState::GetFirstHumanPlayer() const
 
 PlayerNumber GameState::GetFirstDisabledPlayer() const
 {
-	FOREACH_PlayerNumber( pn )
-		if( !IsPlayerEnabled(pn) )
+	FOREACH_PlayerNumber(pn)
+		if (!IsPlayerEnabled(pn))
 			return pn;
 	return PLAYER_INVALID;
 }
 
-bool GameState::IsCpuPlayer( PlayerNumber pn ) const
+bool GameState::IsCpuPlayer(PlayerNumber pn) const
 {
 	return IsPlayerEnabled(pn) && !IsHumanPlayer(pn);
 }
 
 bool GameState::AnyPlayersAreCpu() const
-{ 
-	FOREACH_CpuPlayer( pn )
+{
+	FOREACH_CpuPlayer(pn)
 		return true;
 	return false;
 }
@@ -962,7 +1003,7 @@ bool GameState::AnyPlayersAreCpu() const
 
 bool GameState::IsCourseMode() const
 {
-	switch(m_PlayMode)
+	switch (m_PlayMode)
 	{
 	case PLAY_MODE_ONI:
 	case PLAY_MODE_NONSTOP:
@@ -975,7 +1016,7 @@ bool GameState::IsCourseMode() const
 
 bool GameState::IsBattleMode() const
 {
-	switch( this->m_PlayMode )
+	switch (this->m_PlayMode)
 	{
 	case PLAY_MODE_BATTLE:
 		return true;
@@ -986,30 +1027,30 @@ bool GameState::IsBattleMode() const
 
 bool GameState::HasEarnedExtraStage() const
 {
-	if( GAMESTATE->IsEventMode() )
+	if (GAMESTATE->IsEventMode())
 		return false;
 
-	if( !PREFSMAN->m_bAllowExtraStage )
+	if (!PREFSMAN->m_bAllowExtraStage)
 		return false;
 
-	if( this->m_PlayMode != PLAY_MODE_REGULAR )
+	if (this->m_PlayMode != PLAY_MODE_REGULAR)
 		return false;
 
-	if( (this->IsFinalStage() || this->IsExtraStage()) )
+	if ((this->IsFinalStage() || this->IsExtraStage()))
 	{
-		FOREACH_EnabledPlayer( pn )
+		FOREACH_EnabledPlayer(pn)
 		{
-			if( this->m_pCurSteps[pn]->GetDifficulty() != DIFFICULTY_HARD && 
-				this->m_pCurSteps[pn]->GetDifficulty() != DIFFICULTY_CHALLENGE )
+			if (this->m_pCurSteps[pn]->GetDifficulty() != DIFFICULTY_HARD &&
+				this->m_pCurSteps[pn]->GetDifficulty() != DIFFICULTY_CHALLENGE)
 				continue; /* not hard enough! */
 
 			/* If "choose EX" is enabled, then we should only grant EX2 if the chosen
-			 * stage was the EX we would have chosen (m_bAllow2ndExtraStage is true). */
-//			if( PREFSMAN->m_bPickExtraStage && this->IsExtraStage() && !this->m_bAllow2ndExtraStage )
-			if( this->IsExtraStage() && !this->m_bAllow2ndExtraStage )
+			* stage was the EX we would have chosen (m_bAllow2ndExtraStage is true). */
+			//			if( PREFSMAN->m_bPickExtraStage && this->IsExtraStage() && !this->m_bAllow2ndExtraStage )
+			if (this->IsExtraStage() && !this->m_bAllow2ndExtraStage)
 				continue;
 
-			if( STATSMAN->m_CurStageStats.m_player[pn].GetGrade() <= GRADE_TIER03 )
+			if (STATSMAN->m_CurStageStats.m_player[pn].GetGrade() <= GRADE_TIER03)
 				return true;
 		}
 	}
@@ -1018,40 +1059,40 @@ bool GameState::HasEarnedExtraStage() const
 
 PlayerNumber GameState::GetBestPlayer() const
 {
-	FOREACH_PlayerNumber( pn )
-		if( GetStageResult(pn) == RESULT_WIN )
+	FOREACH_PlayerNumber(pn)
+		if (GetStageResult(pn) == RESULT_WIN)
 			return pn;
 	return PLAYER_INVALID;	// draw
 }
 
-StageResult GameState::GetStageResult( PlayerNumber pn ) const
+StageResult GameState::GetStageResult(PlayerNumber pn) const
 {
-	switch( this->m_PlayMode )
+	switch (this->m_PlayMode)
 	{
 	case PLAY_MODE_BATTLE:
 	case PLAY_MODE_RAVE:
-		if( fabsf(m_fTugLifePercentP1 - 0.5f) < 0.0001f )
+		if (fabsf(m_fTugLifePercentP1 - 0.5f) < 0.0001f)
 			return RESULT_DRAW;
-		switch( pn )
+		switch (pn)
 		{
-		case PLAYER_1:	return (m_fTugLifePercentP1>=0.5f)?RESULT_WIN:RESULT_LOSE;
-		case PLAYER_2:	return (m_fTugLifePercentP1<0.5f)?RESULT_WIN:RESULT_LOSE;
+		case PLAYER_1:	return (m_fTugLifePercentP1 >= 0.5f) ? RESULT_WIN : RESULT_LOSE;
+		case PLAYER_2:	return (m_fTugLifePercentP1<0.5f) ? RESULT_WIN : RESULT_LOSE;
 		default:	ASSERT(0); return RESULT_LOSE;
 		}
 	}
 
 	StageResult win = RESULT_WIN;
-	FOREACH_PlayerNumber( p )
+	FOREACH_PlayerNumber(p)
 	{
-		if( p == pn )
+		if (p == pn)
 			continue;
 
 		/* If anyone did just as well, at best it's a draw. */
-		if( STATSMAN->m_CurStageStats.m_player[p].iActualDancePoints == STATSMAN->m_CurStageStats.m_player[pn].iActualDancePoints )
+		if (STATSMAN->m_CurStageStats.m_player[p].iActualDancePoints == STATSMAN->m_CurStageStats.m_player[pn].iActualDancePoints)
 			win = RESULT_DRAW;
 
 		/* If anyone did better, we lost. */
-		if( STATSMAN->m_CurStageStats.m_player[p].iActualDancePoints > STATSMAN->m_CurStageStats.m_player[pn].iActualDancePoints )
+		if (STATSMAN->m_CurStageStats.m_player[p].iActualDancePoints > STATSMAN->m_CurStageStats.m_player[pn].iActualDancePoints)
 			return RESULT_LOSE;
 	}
 	return win;
@@ -1059,126 +1100,126 @@ StageResult GameState::GetStageResult( PlayerNumber pn ) const
 
 
 
-void GameState::ApplyModifiers( PlayerNumber pn, CString sModifiers )
+void GameState::ApplyModifiers(PlayerNumber pn, CString sModifiers)
 {
-	m_pPlayerState[pn]->m_PlayerOptions.FromString( sModifiers );
-	m_SongOptions.FromString( sModifiers );
+	m_pPlayerState[pn]->m_PlayerOptions.FromString(sModifiers);
+	m_SongOptions.FromString(sModifiers);
 }
 
 /* Store the player's preferred options.  This is called at the very beginning
- * of gameplay. */
+* of gameplay. */
 void GameState::StoreSelectedOptions()
 {
-	FOREACH_PlayerNumber( pn )
+	FOREACH_PlayerNumber(pn)
 		m_pPlayerState[pn]->m_StoredPlayerOptions = m_pPlayerState[pn]->m_PlayerOptions;
 	m_StoredSongOptions = m_SongOptions;
 }
 
 /* Restore the preferred options.  This is called after a song ends, before
- * setting new course options, so options from one song don't carry into the
- * next and we default back to the preferred options.  This is also called
- * at the end of gameplay to restore options. */
+* setting new course options, so options from one song don't carry into the
+* next and we default back to the preferred options.  This is also called
+* at the end of gameplay to restore options. */
 void GameState::RestoreSelectedOptions()
 {
-	FOREACH_PlayerNumber( pn )
+	FOREACH_PlayerNumber(pn)
 		m_pPlayerState[pn]->m_PlayerOptions = m_pPlayerState[pn]->m_StoredPlayerOptions;
 	m_SongOptions = m_StoredSongOptions;
 }
 
 void GameState::ResetCurrentOptions()
 {
-	FOREACH_PlayerNumber( p )
+	FOREACH_PlayerNumber(p)
 	{
 		m_pPlayerState[p]->m_PlayerOptions.Init();
-		m_pPlayerState[p]->m_PlayerOptions.FromString( PREFSMAN->m_sDefaultModifiers );
+		m_pPlayerState[p]->m_PlayerOptions.FromString(PREFSMAN->m_sDefaultModifiers);
 	}
 	m_SongOptions.Init();
-	m_SongOptions.FromString( PREFSMAN->m_sDefaultModifiers );
+	m_SongOptions.FromString(PREFSMAN->m_sDefaultModifiers);
 }
 
-bool GameState::IsDisqualified( PlayerNumber pn )
+bool GameState::IsDisqualified(PlayerNumber pn)
 {
-	if( !IsPlayerEnabled(pn) )
+	if (!IsPlayerEnabled(pn))
 		return false;
 
-	if( !PREFSMAN->m_bDisqualification )
+	if (!PREFSMAN->m_bDisqualification)
 		return false;
 
-	if( GAMESTATE->m_SongOptions.m_fMusicRate < 1.0f )
+	if (GAMESTATE->m_SongOptions.m_fMusicRate < 1.0f)
 		return true;
 
-	if( GAMESTATE->IsCourseMode() )
+	if (GAMESTATE->IsCourseMode())
 	{
-		return GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions.IsEasierForCourseAndTrail( 
-			GAMESTATE->m_pCurCourse, 
-			GAMESTATE->m_pCurTrail[pn] );
+		return GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions.IsEasierForCourseAndTrail(
+			GAMESTATE->m_pCurCourse,
+			GAMESTATE->m_pCurTrail[pn]);
 	}
 	else
 	{
-		return GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions.IsEasierForSongAndSteps( 
-			GAMESTATE->m_pCurSong, 
-			GAMESTATE->m_pCurSteps[pn] );
+		return GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions.IsEasierForSongAndSteps(
+			GAMESTATE->m_pCurSong,
+			GAMESTATE->m_pCurSteps[pn]);
 	}
 }
 
 void GameState::ResetNoteSkins()
 {
-	FOREACH_PlayerNumber( pn )
-		ResetNoteSkinsForPlayer(  pn );
+	FOREACH_PlayerNumber(pn)
+		ResetNoteSkinsForPlayer(pn);
 
 	++m_BeatToNoteSkinRev;
 }
 
-void GameState::ResetNoteSkinsForPlayer( PlayerNumber pn )
+void GameState::ResetNoteSkinsForPlayer(PlayerNumber pn)
 {
 	m_pPlayerState[pn]->ResetNoteSkins();
 
 	++m_BeatToNoteSkinRev;
 }
 
-void GameState::GetAllUsedNoteSkins( vector<CString> &out ) const
+void GameState::GetAllUsedNoteSkins(vector<CString> &out) const
 {
-	FOREACH_EnabledPlayer( pn )
+	FOREACH_EnabledPlayer(pn)
 	{
-		out.push_back( m_pPlayerState[pn]->m_PlayerOptions.m_sNoteSkin );
+		out.push_back(m_pPlayerState[pn]->m_PlayerOptions.m_sNoteSkin);
 
-		switch( this->m_PlayMode )
+		switch (this->m_PlayMode)
 		{
 		case PLAY_MODE_BATTLE:
 		case PLAY_MODE_RAVE:
-			for( int al=0; al<NUM_ATTACK_LEVELS; al++ )
+			for (int al = 0; al<NUM_ATTACK_LEVELS; al++)
 			{
 				const Character *ch = this->m_pCurCharacters[pn];
-				ASSERT( ch );
+				ASSERT(ch);
 				const CString* asAttacks = ch->m_sAttacks[al];
-				for( int att = 0; att < NUM_ATTACKS_PER_LEVEL; ++att )
+				for (int att = 0; att < NUM_ATTACKS_PER_LEVEL; ++att)
 				{
 					PlayerOptions po;
-					po.FromString( asAttacks[att] );
-					out.push_back( po.m_sNoteSkin );
+					po.FromString(asAttacks[att]);
+					out.push_back(po.m_sNoteSkin);
 				}
 			}
 		}
 
 		/* Add note skins that are used in courses. */
-		if( this->IsCourseMode() )
+		if (this->IsCourseMode())
 		{
 			FOREACH_EnabledPlayer(pn)
 			{
 				const Trail *pTrail = this->m_pCurTrail[pn];
-				ASSERT( pTrail );
+				ASSERT(pTrail);
 
-				FOREACH_CONST( TrailEntry, pTrail->m_vEntries, e )
+				FOREACH_CONST(TrailEntry, pTrail->m_vEntries, e)
 				{
 					AttackArray a;
-					e->GetAttackArray( a );
+					e->GetAttackArray(a);
 
-					for( unsigned j=0; j<a.size(); j++ )
+					for (unsigned j = 0; j<a.size(); j++)
 					{
 						const Attack &mod = a[j];
 						PlayerOptions po;
-						po.FromString( mod.sModifiers );
-						out.push_back( po.m_sNoteSkin );
+						po.FromString(mod.sModifiers);
+						out.push_back(po.m_sNoteSkin);
 					}
 				}
 			}
@@ -1186,16 +1227,16 @@ void GameState::GetAllUsedNoteSkins( vector<CString> &out ) const
 	}
 
 	/* Remove duplicates. */
-	sort( out.begin(), out.end() );
-	out.erase( unique( out.begin(), out.end() ), out.end() );
+	sort(out.begin(), out.end());
+	out.erase(unique(out.begin(), out.end()), out.end());
 
 	/* Hack: NoteSkin "default" is never applied as an attack, so don't
-	 * waste memory preloading it. */
-	for( unsigned i = 0; i < out.size(); ++i )
+	* waste memory preloading it. */
+	for (unsigned i = 0; i < out.size(); ++i)
 	{
-		if( !out[i].CompareNoCase("default") || out[i] == "" )
+		if (!out[i].CompareNoCase("default") || out[i] == "")
 		{
-			out.erase( out.begin()+i, out.begin()+i+1 );
+			out.erase(out.begin() + i, out.begin() + i + 1);
 			--i;
 		}
 	}
@@ -1203,27 +1244,27 @@ void GameState::GetAllUsedNoteSkins( vector<CString> &out ) const
 
 /* From NoteField: */
 
-void GameState::GetUndisplayedBeats( const PlayerState* pPlayerState, float TotalSeconds, float &StartBeat, float &EndBeat ) const
+void GameState::GetUndisplayedBeats(const PlayerState* pPlayerState, float TotalSeconds, float &StartBeat, float &EndBeat) const
 {
 	/* If reasonable, push the attack forward so notes on screen don't change suddenly. */
-	StartBeat = min( m_fSongBeat+BEATS_PER_MEASURE*2, pPlayerState->m_fLastDrawnBeat );
-	StartBeat = truncf(StartBeat)+1;
+	StartBeat = min(m_fSongBeat + BEATS_PER_MEASURE * 2, pPlayerState->m_fLastDrawnBeat);
+	StartBeat = truncf(StartBeat) + 1;
 
-	const float StartSecond = this->m_pCurSong->GetElapsedTimeFromBeat( StartBeat );
+	const float StartSecond = this->m_pCurSong->GetElapsedTimeFromBeat(StartBeat);
 	const float EndSecond = StartSecond + TotalSeconds;
-	EndBeat = this->m_pCurSong->GetBeatFromElapsedTime( EndSecond );
-	EndBeat = truncf(EndBeat)+1;
+	EndBeat = this->m_pCurSong->GetBeatFromElapsedTime(EndSecond);
+	EndBeat = truncf(EndBeat) + 1;
 }
 
 
-void GameState::SetNoteSkinForBeatRange( PlayerState* pPlayerState, const CString& sNoteSkin, float StartBeat, float EndBeat )
+void GameState::SetNoteSkinForBeatRange(PlayerState* pPlayerState, const CString& sNoteSkin, float StartBeat, float EndBeat)
 {
-	map<float,CString> &BeatToNoteSkin = pPlayerState->m_BeatToNoteSkin;
+	map<float, CString> &BeatToNoteSkin = pPlayerState->m_BeatToNoteSkin;
 
 	/* Erase any other note skin settings in this range. */
-	map<float,CString>::iterator begin = BeatToNoteSkin.lower_bound( StartBeat );
-	map<float,CString>::iterator end = BeatToNoteSkin.upper_bound( EndBeat );
-	BeatToNoteSkin.erase( begin, end );
+	map<float, CString>::iterator begin = BeatToNoteSkin.lower_bound(StartBeat);
+	map<float, CString>::iterator end = BeatToNoteSkin.upper_bound(EndBeat);
+	BeatToNoteSkin.erase(begin, end);
 
 	/* Add the skin to m_BeatToNoteSkin.  */
 	BeatToNoteSkin[StartBeat] = sNoteSkin;
@@ -1235,48 +1276,48 @@ void GameState::SetNoteSkinForBeatRange( PlayerState* pPlayerState, const CStrin
 }
 
 /* This is called to launch an attack, or to queue an attack if a.fStartSecond
- * is set.  This is also called by GameState::Update when activating a queued attack. */
-void GameState::LaunchAttack( PlayerNumber target, const Attack& a )
+* is set.  This is also called by GameState::Update when activating a queued attack. */
+void GameState::LaunchAttack(PlayerNumber target, const Attack& a)
 {
-	LOG->Trace( "Launch attack '%s' against P%d at %f", a.sModifiers.c_str(), target+1, a.fStartSecond );
+	LOG->Trace("Launch attack '%s' against P%d at %f", a.sModifiers.c_str(), target + 1, a.fStartSecond);
 
 	Attack attack = a;
 
 	/* If fStartSecond is -1, it means "launch as soon as possible".  For m_ActiveAttacks,
-	 * mark the real time it's starting (now), so Update() can know when the attack started
-	 * so it can be removed later.  For m_ModsToApply, leave the -1 in, so Player::Update
-	 * knows to apply attack transforms correctly.  (yuck) */
-	m_pPlayerState[target]->m_ModsToApply.push_back( attack );
-	if( attack.fStartSecond == -1 )
+	* mark the real time it's starting (now), so Update() can know when the attack started
+	* so it can be removed later.  For m_ModsToApply, leave the -1 in, so Player::Update
+	* knows to apply attack transforms correctly.  (yuck) */
+	m_pPlayerState[target]->m_ModsToApply.push_back(attack);
+	if (attack.fStartSecond == -1)
 		attack.fStartSecond = this->m_fMusicSeconds;
-	m_pPlayerState[target]->m_ActiveAttacks.push_back( attack );
+	m_pPlayerState[target]->m_ActiveAttacks.push_back(attack);
 
-	this->RebuildPlayerOptionsFromActiveAttacks( target );
+	this->RebuildPlayerOptionsFromActiveAttacks(target);
 }
 
-void GameState::RemoveActiveAttacksForPlayer( PlayerNumber pn, AttackLevel al )
+void GameState::RemoveActiveAttacksForPlayer(PlayerNumber pn, AttackLevel al)
 {
-	for( unsigned s=0; s<m_pPlayerState[pn]->m_ActiveAttacks.size(); s++ )
+	for (unsigned s = 0; s<m_pPlayerState[pn]->m_ActiveAttacks.size(); s++)
 	{
-		if( al != NUM_ATTACK_LEVELS && al != m_pPlayerState[pn]->m_ActiveAttacks[s].level )
+		if (al != NUM_ATTACK_LEVELS && al != m_pPlayerState[pn]->m_ActiveAttacks[s].level)
 			continue;
-		m_pPlayerState[pn]->m_ActiveAttacks.erase( m_pPlayerState[pn]->m_ActiveAttacks.begin()+s, m_pPlayerState[pn]->m_ActiveAttacks.begin()+s+1 );
+		m_pPlayerState[pn]->m_ActiveAttacks.erase(m_pPlayerState[pn]->m_ActiveAttacks.begin() + s, m_pPlayerState[pn]->m_ActiveAttacks.begin() + s + 1);
 		--s;
 	}
-	RebuildPlayerOptionsFromActiveAttacks( pn );
+	RebuildPlayerOptionsFromActiveAttacks(pn);
 }
 
-void GameState::EndActiveAttacksForPlayer( PlayerNumber pn )
+void GameState::EndActiveAttacksForPlayer(PlayerNumber pn)
 {
-	FOREACH( Attack, m_pPlayerState[pn]->m_ActiveAttacks, a )
+	FOREACH(Attack, m_pPlayerState[pn]->m_ActiveAttacks, a)
 		a->fSecsRemaining = 0;
 }
 
 void GameState::RemoveAllInventory()
 {
-	FOREACH_PlayerNumber( p )
+	FOREACH_PlayerNumber(p)
 	{
-		for( int s=0; s<NUM_INVENTORY_SLOTS; s++ )
+		for (int s = 0; s<NUM_INVENTORY_SLOTS; s++)
 		{
 			m_pPlayerState[p]->m_Inventory[s].fSecsRemaining = 0;
 			m_pPlayerState[p]->m_Inventory[s].sModifiers = "";
@@ -1284,21 +1325,21 @@ void GameState::RemoveAllInventory()
 	}
 }
 
-void GameState::RebuildPlayerOptionsFromActiveAttacks( PlayerNumber pn )
+void GameState::RebuildPlayerOptionsFromActiveAttacks(PlayerNumber pn)
 {
 	// rebuild player options
 	PlayerOptions po = m_pPlayerState[pn]->m_StoredPlayerOptions;
-	for( unsigned s=0; s<m_pPlayerState[pn]->m_ActiveAttacks.size(); s++ )
+	for (unsigned s = 0; s<m_pPlayerState[pn]->m_ActiveAttacks.size(); s++)
 	{
-		if( !m_pPlayerState[pn]->m_ActiveAttacks[s].bOn )
+		if (!m_pPlayerState[pn]->m_ActiveAttacks[s].bOn)
 			continue; /* hasn't started yet */
-		po.FromString( m_pPlayerState[pn]->m_ActiveAttacks[s].sModifiers );
+		po.FromString(m_pPlayerState[pn]->m_ActiveAttacks[s].sModifiers);
 	}
 	m_pPlayerState[pn]->m_PlayerOptions = po;
 
 
-	int iSumOfAttackLevels = GetSumOfActiveAttackLevels( pn );
-	if( iSumOfAttackLevels > 0 )
+	int iSumOfAttackLevels = GetSumOfActiveAttackLevels(pn);
+	if (iSumOfAttackLevels > 0)
 	{
 		m_pPlayerState[pn]->m_iLastPositiveSumOfAttackLevels = iSumOfAttackLevels;
 		m_pPlayerState[pn]->m_fSecondsUntilAttacksPhasedOut = 10000;	// any positive number that won't run out before the attacks
@@ -1312,68 +1353,68 @@ void GameState::RebuildPlayerOptionsFromActiveAttacks( PlayerNumber pn )
 
 void GameState::RemoveAllActiveAttacks()	// called on end of song
 {
-	FOREACH_PlayerNumber( p )
-		RemoveActiveAttacksForPlayer( p );
+	FOREACH_PlayerNumber(p)
+		RemoveActiveAttacksForPlayer(p);
 }
 
-int GameState::GetSumOfActiveAttackLevels( PlayerNumber pn ) const
+int GameState::GetSumOfActiveAttackLevels(PlayerNumber pn) const
 {
 	int iSum = 0;
 
-	for( unsigned s=0; s<m_pPlayerState[pn]->m_ActiveAttacks.size(); s++ )
-		if( m_pPlayerState[pn]->m_ActiveAttacks[s].fSecsRemaining > 0 && m_pPlayerState[pn]->m_ActiveAttacks[s].level != NUM_ATTACK_LEVELS )
+	for (unsigned s = 0; s<m_pPlayerState[pn]->m_ActiveAttacks.size(); s++)
+		if (m_pPlayerState[pn]->m_ActiveAttacks[s].fSecsRemaining > 0 && m_pPlayerState[pn]->m_ActiveAttacks[s].level != NUM_ATTACK_LEVELS)
 			iSum += m_pPlayerState[pn]->m_ActiveAttacks[s].level;
 
 	return iSum;
 }
 
 template<class T>
-void setmin( T &a, const T &b )
+void setmin(T &a, const T &b)
 {
 	a = min(a, b);
 }
 
 template<class T>
-void setmax( T &a, const T &b )
+void setmax(T &a, const T &b)
 {
 	a = max(a, b);
 }
 
-SongOptions::FailType GameState::GetPlayerFailType( PlayerNumber pn ) const
+SongOptions::FailType GameState::GetPlayerFailType(PlayerNumber pn) const
 {
 	SongOptions::FailType ft = m_SongOptions.m_FailType;
 
 	/* If the player changed the fail mode explicitly, leave it alone. */
-	if( this->m_bChangedFailTypeOnScreenSongOptions )
+	if (this->m_bChangedFailTypeOnScreenSongOptions)
 		return ft;
 
-	if( GAMESTATE->IsCourseMode() )
+	if (GAMESTATE->IsCourseMode())
 	{
-		if( PREFSMAN->m_bMinimum1FullSongInCourses && GAMESTATE->GetCourseSongIndex()==0 )
-			ft = max( ft, SongOptions::FAIL_END_OF_SONG );	// take the least harsh of the two FailTypes
+		if (PREFSMAN->m_bMinimum1FullSongInCourses && GAMESTATE->GetCourseSongIndex() == 0)
+			ft = max(ft, SongOptions::FAIL_END_OF_SONG);	// take the least harsh of the two FailTypes
 	}
 	else
 	{
 		Difficulty dc = DIFFICULTY_INVALID;
-		if( m_pCurSteps[pn] )
+		if (m_pCurSteps[pn])
 			dc = m_pCurSteps[pn]->GetDifficulty();
 
 		bool bFirstStage = !GAMESTATE->IsEventMode() && m_iCurrentStageIndex == 0;
 
 		/* Easy and beginner are never harder than FAIL_END_OF_SONG. */
-		if( dc <= DIFFICULTY_EASY )
-			setmax( ft, SongOptions::FAIL_END_OF_SONG );
+		if (dc <= DIFFICULTY_EASY)
+			setmax(ft, SongOptions::FAIL_END_OF_SONG);
 
-		if( dc <= DIFFICULTY_EASY && bFirstStage && PREFSMAN->m_bFailOffForFirstStageEasy )
-			setmax( ft, SongOptions::FAIL_OFF );
+		if (dc <= DIFFICULTY_EASY && bFirstStage && PREFSMAN->m_bFailOffForFirstStageEasy)
+			setmax(ft, SongOptions::FAIL_OFF);
 
 		/* If beginner's steps were chosen, and this is the first stage,
-		 * turn off failure completely. */
-		if( dc == DIFFICULTY_BEGINNER && bFirstStage )
-			setmax( ft, SongOptions::FAIL_OFF );
+		* turn off failure completely. */
+		if (dc == DIFFICULTY_BEGINNER && bFirstStage)
+			setmax(ft, SongOptions::FAIL_OFF);
 
-		if( dc == DIFFICULTY_BEGINNER && PREFSMAN->m_bFailOffInBeginner )
-			setmax( ft, SongOptions::FAIL_OFF );
+		if (dc == DIFFICULTY_BEGINNER && PREFSMAN->m_bFailOffInBeginner)
+			setmax(ft, SongOptions::FAIL_OFF);
 	}
 
 	return ft;
@@ -1381,7 +1422,7 @@ SongOptions::FailType GameState::GetPlayerFailType( PlayerNumber pn ) const
 
 bool GameState::ShowMarvelous() const
 {
-	switch( PREFSMAN->m_MarvelousTiming )
+	switch (PREFSMAN->m_MarvelousTiming)
 	{
 	case PrefsManager::MARVELOUS_NEVER:			return false;
 	case PrefsManager::MARVELOUS_COURSES_ONLY:	return IsCourseMode();
@@ -1390,28 +1431,28 @@ bool GameState::ShowMarvelous() const
 	}
 }
 
-void GameState::GetCharacters( vector<Character*> &apCharactersOut )
+void GameState::GetCharacters(vector<Character*> &apCharactersOut)
 {
-	for( unsigned i=0; i<m_pCharacters.size(); i++ )
-		if( m_pCharacters[i]->m_sName.CompareNoCase("default")!=0 )
-			apCharactersOut.push_back( m_pCharacters[i] );
+	for (unsigned i = 0; i<m_pCharacters.size(); i++)
+		if (m_pCharacters[i]->m_sName.CompareNoCase("default") != 0)
+			apCharactersOut.push_back(m_pCharacters[i]);
 }
 
 Character* GameState::GetRandomCharacter()
 {
 	vector<Character*> apCharacters;
-	GetCharacters( apCharacters );
-	if( apCharacters.size() )
-		return apCharacters[rand()%apCharacters.size()];
+	GetCharacters(apCharacters);
+	if (apCharacters.size())
+		return apCharacters[rand() % apCharacters.size()];
 	else
 		return GetDefaultCharacter();
 }
 
 Character* GameState::GetDefaultCharacter()
 {
-	for( unsigned i=0; i<m_pCharacters.size(); i++ )
+	for (unsigned i = 0; i<m_pCharacters.size(); i++)
 	{
-		if( m_pCharacters[i]->m_sName.CompareNoCase("default")==0 )
+		if (m_pCharacters[i]->m_sName.CompareNoCase("default") == 0)
 			return m_pCharacters[i];
 	}
 
@@ -1424,231 +1465,231 @@ struct SongAndSteps
 {
 	Song* pSong;
 	Steps* pSteps;
-	bool operator==( const SongAndSteps& other ) const { return pSong==other.pSong && pSteps==other.pSteps; }
-	bool operator<( const SongAndSteps& other ) const { return pSong<=other.pSong && pSteps<=other.pSteps; }
+	bool operator==(const SongAndSteps& other) const { return pSong == other.pSong && pSteps == other.pSteps; }
+	bool operator<(const SongAndSteps& other) const { return pSong <= other.pSong && pSteps <= other.pSteps; }
 };
 
-void GameState::GetRankingFeats( PlayerNumber pn, vector<RankingFeat> &asFeatsOut ) const
+void GameState::GetRankingFeats(PlayerNumber pn, vector<RankingFeat> &asFeatsOut) const
 {
-	if( !IsHumanPlayer(pn) )
+	if (!IsHumanPlayer(pn))
 		return;
 
 	Profile *pProf = PROFILEMAN->GetProfile(pn);
 
-	CHECKPOINT_M(ssprintf("PlayMode %i",this->m_PlayMode));
-	switch( this->m_PlayMode )
+	CHECKPOINT_M(ssprintf("PlayMode %i", this->m_PlayMode));
+	switch (this->m_PlayMode)
 	{
 	case PLAY_MODE_REGULAR:
+	{
+		CHECKPOINT;
+
+		StepsType st = this->GetCurrentStyle()->m_StepsType;
+
+		//
+		// Find unique Song and Steps combinations that were played.
+		// We must keep only the unique combination or else we'll double-count
+		// high score markers.
+		//
+		vector<SongAndSteps> vSongAndSteps;
+
+		for (unsigned i = 0; i<STATSMAN->m_vPlayedStageStats.size(); i++)
 		{
-			CHECKPOINT;
+			CHECKPOINT_M(ssprintf("%u/%i", i, (int)STATSMAN->m_vPlayedStageStats.size()));
+			SongAndSteps sas;
+			sas.pSong = STATSMAN->m_vPlayedStageStats[i].vpPlayedSongs[0];
+			ASSERT(sas.pSong);
+			sas.pSteps = STATSMAN->m_vPlayedStageStats[i].m_player[pn].vpPlayedSteps[0];
+			ASSERT(sas.pSteps);
+			vSongAndSteps.push_back(sas);
+		}
+		CHECKPOINT;
 
-			StepsType st = this->GetCurrentStyle()->m_StepsType;
+		sort(vSongAndSteps.begin(), vSongAndSteps.end());
 
-			//
-			// Find unique Song and Steps combinations that were played.
-			// We must keep only the unique combination or else we'll double-count
-			// high score markers.
-			//
-			vector<SongAndSteps> vSongAndSteps;
+		vector<SongAndSteps>::iterator toDelete = unique(vSongAndSteps.begin(), vSongAndSteps.end());
+		vSongAndSteps.erase(toDelete, vSongAndSteps.end());
 
-			for( unsigned i=0; i<STATSMAN->m_vPlayedStageStats.size(); i++ )
+		CHECKPOINT;
+		for (unsigned i = 0; i<vSongAndSteps.size(); i++)
+		{
+			Song* pSong = vSongAndSteps[i].pSong;
+			Steps* pSteps = vSongAndSteps[i].pSteps;
+
+			// Find Machine Records
 			{
-				CHECKPOINT_M( ssprintf("%u/%i", i, (int)STATSMAN->m_vPlayedStageStats.size() ) );
-				SongAndSteps sas;
-				sas.pSong = STATSMAN->m_vPlayedStageStats[i].vpPlayedSongs[0];
-				ASSERT( sas.pSong );
-				sas.pSteps = STATSMAN->m_vPlayedStageStats[i].m_player[pn].vpPlayedSteps[0];
-				ASSERT( sas.pSteps );
-				vSongAndSteps.push_back( sas );
-			}
-			CHECKPOINT;
-
-			sort( vSongAndSteps.begin(), vSongAndSteps.end() );
-
-			vector<SongAndSteps>::iterator toDelete = unique( vSongAndSteps.begin(), vSongAndSteps.end() );
-			vSongAndSteps.erase(toDelete, vSongAndSteps.end());
-
-			CHECKPOINT;
-			for( unsigned i=0; i<vSongAndSteps.size(); i++ )
-			{
-				Song* pSong = vSongAndSteps[i].pSong;
-				Steps* pSteps = vSongAndSteps[i].pSteps;
-
-				// Find Machine Records
-				{
-					HighScoreList &hsl = PROFILEMAN->GetMachineProfile()->GetStepsHighScoreList(pSong,pSteps);
-					for( unsigned j=0; j<hsl.vHighScores.size(); j++ )
-					{
-						HighScore &hs = hsl.vHighScores[j];
-
-						if( hs.sName != RANKING_TO_FILL_IN_MARKER[pn] )
-							continue;
-
-						RankingFeat feat;
-						feat.Type = RankingFeat::SONG;
-						feat.pSong = pSong;
-						feat.pSteps = pSteps;
-						feat.Feat = ssprintf("MR #%d in %s %s", j+1, pSong->GetTranslitMainTitle().c_str(), DifficultyToString(pSteps->GetDifficulty()).c_str() );
-						feat.pStringToFill = &hs.sName;
-						feat.grade = hs.grade;
-						feat.fPercentDP = hs.fPercentDP;
-						feat.iScore = hs.iScore;
-
-						if( pSong->HasBanner() )
-							feat.Banner = pSong->GetBannerPath();
-
-						asFeatsOut.push_back( feat );
-					}
-				}
-		
-				// Find Personal Records
-				if( pProf )
-				{
-					HighScoreList &hsl = pProf->GetStepsHighScoreList(pSong,pSteps);
-					for( unsigned j=0; j<hsl.vHighScores.size(); j++ )
-					{
-						HighScore &hs = hsl.vHighScores[j];
-
-						if( hs.sName != RANKING_TO_FILL_IN_MARKER[pn] )
-							continue;
-
-						RankingFeat feat;
-						feat.pSong = pSong;
-						feat.pSteps = pSteps;
-						feat.Type = RankingFeat::SONG;
-						feat.Feat = ssprintf("PR #%d in %s %s", j+1, pSong->GetTranslitMainTitle().c_str(), DifficultyToString(pSteps->GetDifficulty()).c_str() );
-						feat.pStringToFill = &hs.sName;
-						feat.grade = hs.grade;
-						feat.fPercentDP = hs.fPercentDP;
-						feat.iScore = hs.iScore;
-
-						// XXX: temporary hack
-						if( pSong->HasBackground() )
-							feat.Banner = pSong->GetBackgroundPath();
-		//					if( pSong->HasBanner() )
-		//						feat.Banner = pSong->GetBannerPath();
-
-						asFeatsOut.push_back( feat );
-					}
-				}
-			}
-
-			CHECKPOINT;
-			StageStats stats;
-			STATSMAN->GetFinalEvalStageStats( stats );
-
-
-			// Find Machine Category Records
-			FOREACH_RankingCategory( rc )
-			{
-				HighScoreList &hsl = PROFILEMAN->GetMachineProfile()->GetCategoryHighScoreList( st, rc );
-				for( unsigned j=0; j<hsl.vHighScores.size(); j++ )
+				HighScoreList &hsl = PROFILEMAN->GetMachineProfile()->GetStepsHighScoreList(pSong, pSteps);
+				for (unsigned j = 0; j<hsl.vHighScores.size(); j++)
 				{
 					HighScore &hs = hsl.vHighScores[j];
-					if( hs.sName != RANKING_TO_FILL_IN_MARKER[pn] )
+
+					if (hs.sName != RANKING_TO_FILL_IN_MARKER[pn])
+						continue;
+
+					RankingFeat feat;
+					feat.Type = RankingFeat::SONG;
+					feat.pSong = pSong;
+					feat.pSteps = pSteps;
+					feat.Feat = ssprintf("MR #%d in %s %s", j + 1, pSong->GetTranslitMainTitle().c_str(), DifficultyToString(pSteps->GetDifficulty()).c_str());
+					feat.pStringToFill = &hs.sName;
+					feat.grade = hs.grade;
+					feat.fPercentDP = hs.fPercentDP;
+					feat.iScore = hs.iScore;
+
+					if (pSong->HasBanner())
+						feat.Banner = pSong->GetBannerPath();
+
+					asFeatsOut.push_back(feat);
+				}
+			}
+
+			// Find Personal Records
+			if (pProf)
+			{
+				HighScoreList &hsl = pProf->GetStepsHighScoreList(pSong, pSteps);
+				for (unsigned j = 0; j<hsl.vHighScores.size(); j++)
+				{
+					HighScore &hs = hsl.vHighScores[j];
+
+					if (hs.sName != RANKING_TO_FILL_IN_MARKER[pn])
+						continue;
+
+					RankingFeat feat;
+					feat.pSong = pSong;
+					feat.pSteps = pSteps;
+					feat.Type = RankingFeat::SONG;
+					feat.Feat = ssprintf("PR #%d in %s %s", j + 1, pSong->GetTranslitMainTitle().c_str(), DifficultyToString(pSteps->GetDifficulty()).c_str());
+					feat.pStringToFill = &hs.sName;
+					feat.grade = hs.grade;
+					feat.fPercentDP = hs.fPercentDP;
+					feat.iScore = hs.iScore;
+
+					// XXX: temporary hack
+					if (pSong->HasBackground())
+						feat.Banner = pSong->GetBackgroundPath();
+					//					if( pSong->HasBanner() )
+					//						feat.Banner = pSong->GetBannerPath();
+
+					asFeatsOut.push_back(feat);
+				}
+			}
+		}
+
+		CHECKPOINT;
+		StageStats stats;
+		STATSMAN->GetFinalEvalStageStats(stats);
+
+
+		// Find Machine Category Records
+		FOREACH_RankingCategory(rc)
+		{
+			HighScoreList &hsl = PROFILEMAN->GetMachineProfile()->GetCategoryHighScoreList(st, rc);
+			for (unsigned j = 0; j<hsl.vHighScores.size(); j++)
+			{
+				HighScore &hs = hsl.vHighScores[j];
+				if (hs.sName != RANKING_TO_FILL_IN_MARKER[pn])
+					continue;
+
+				RankingFeat feat;
+				feat.Type = RankingFeat::CATEGORY;
+				feat.Feat = ssprintf("MR #%d in Type %c (%d)", j + 1, 'A' + rc, stats.GetAverageMeter(pn));
+				feat.pStringToFill = &hs.sName;
+				feat.grade = GRADE_NO_DATA;
+				feat.iScore = hs.iScore;
+				feat.fPercentDP = hs.fPercentDP;
+				asFeatsOut.push_back(feat);
+			}
+		}
+
+		// Find Personal Category Records
+		FOREACH_RankingCategory(rc)
+		{
+			if (pProf)
+			{
+				HighScoreList &hsl = pProf->GetCategoryHighScoreList(st, rc);
+				for (unsigned j = 0; j<hsl.vHighScores.size(); j++)
+				{
+					HighScore &hs = hsl.vHighScores[j];
+					if (hs.sName != RANKING_TO_FILL_IN_MARKER[pn])
 						continue;
 
 					RankingFeat feat;
 					feat.Type = RankingFeat::CATEGORY;
-					feat.Feat = ssprintf("MR #%d in Type %c (%d)", j+1, 'A'+rc, stats.GetAverageMeter(pn) );
+					feat.Feat = ssprintf("PR #%d in Type %c (%d)", j + 1, 'A' + rc, stats.GetAverageMeter(pn));
 					feat.pStringToFill = &hs.sName;
 					feat.grade = GRADE_NO_DATA;
 					feat.iScore = hs.iScore;
 					feat.fPercentDP = hs.fPercentDP;
-					asFeatsOut.push_back( feat );
-				}
-			}
-
-			// Find Personal Category Records
-			FOREACH_RankingCategory( rc )
-			{
-				if( pProf )
-				{
-					HighScoreList &hsl = pProf->GetCategoryHighScoreList( st, rc );
-					for( unsigned j=0; j<hsl.vHighScores.size(); j++ )
-					{
-						HighScore &hs = hsl.vHighScores[j];
-						if( hs.sName != RANKING_TO_FILL_IN_MARKER[pn] )
-							continue;
-
-						RankingFeat feat;
-						feat.Type = RankingFeat::CATEGORY;
-						feat.Feat = ssprintf("PR #%d in Type %c (%d)", j+1, 'A'+rc, stats.GetAverageMeter(pn) );
-						feat.pStringToFill = &hs.sName;
-						feat.grade = GRADE_NO_DATA;
-						feat.iScore = hs.iScore;
-						feat.fPercentDP = hs.fPercentDP;
-						asFeatsOut.push_back( feat );
-					}
+					asFeatsOut.push_back(feat);
 				}
 			}
 		}
-		break;
+	}
+	break;
 	case PLAY_MODE_BATTLE:
 	case PLAY_MODE_RAVE:
 		break;
 	case PLAY_MODE_NONSTOP:
 	case PLAY_MODE_ONI:
 	case PLAY_MODE_ENDLESS:
+	{
+		CHECKPOINT;
+		Course* pCourse = m_pCurCourse;
+		ASSERT(pCourse);
+		Trail *pTrail = m_pCurTrail[pn];
+		ASSERT(pTrail);
+		CourseDifficulty cd = pTrail->m_CourseDifficulty;
+
+		// Find Machine Records
 		{
-			CHECKPOINT;
-			Course* pCourse = m_pCurCourse;
-			ASSERT( pCourse );
-			Trail *pTrail = m_pCurTrail[pn];
-			ASSERT( pTrail );
-			CourseDifficulty cd = pTrail->m_CourseDifficulty;
-
-			// Find Machine Records
+			Profile* pProfile = PROFILEMAN->GetMachineProfile();
+			HighScoreList &hsl = pProfile->GetCourseHighScoreList(pCourse, pTrail);
+			for (unsigned i = 0; i<hsl.vHighScores.size(); i++)
 			{
-				Profile* pProfile = PROFILEMAN->GetMachineProfile();
-				HighScoreList &hsl = pProfile->GetCourseHighScoreList( pCourse, pTrail );
-				for( unsigned i=0; i<hsl.vHighScores.size(); i++ )
-				{
-					HighScore &hs = hsl.vHighScores[i];
-					if( hs.sName != RANKING_TO_FILL_IN_MARKER[pn] )
-							continue;
+				HighScore &hs = hsl.vHighScores[i];
+				if (hs.sName != RANKING_TO_FILL_IN_MARKER[pn])
+					continue;
 
-					RankingFeat feat;
-					feat.Type = RankingFeat::COURSE;
-					feat.pCourse = pCourse;
-					feat.Feat = ssprintf("MR #%d in %s", i+1, pCourse->GetDisplayFullTitle().c_str() );
-					if( cd != DIFFICULTY_MEDIUM )
-						feat.Feat += " " + CourseDifficultyToThemedString(cd);
-					feat.pStringToFill = &hs.sName;
-					feat.grade = GRADE_NO_DATA;
-					feat.iScore = hs.iScore;
-					feat.fPercentDP = hs.fPercentDP;
-					if( pCourse->HasBanner() )
-						feat.Banner = pCourse->m_sBannerPath;
-					asFeatsOut.push_back( feat );
-				}
-			}
-
-			// Find Personal Records
-			if( PROFILEMAN->IsPersistentProfile( pn ) )
-			{
-				HighScoreList &hsl = pProf->GetCourseHighScoreList( pCourse, pTrail );
-				for( unsigned i=0; i<hsl.vHighScores.size(); i++ )
-				{
-					HighScore& hs = hsl.vHighScores[i];
-					if( hs.sName != RANKING_TO_FILL_IN_MARKER[pn] )
-							continue;
-
-					RankingFeat feat;
-					feat.Type = RankingFeat::COURSE;
-					feat.pCourse = pCourse;
-					feat.Feat = ssprintf("PR #%d in %s", i+1, pCourse->GetDisplayFullTitle().c_str() );
-					feat.pStringToFill = &hs.sName;
-					feat.grade = GRADE_NO_DATA;
-					feat.iScore = hs.iScore;
-					feat.fPercentDP = hs.fPercentDP;
-					if( pCourse->HasBanner() )
-						feat.Banner = pCourse->m_sBannerPath;
-					asFeatsOut.push_back( feat );
-				}
+				RankingFeat feat;
+				feat.Type = RankingFeat::COURSE;
+				feat.pCourse = pCourse;
+				feat.Feat = ssprintf("MR #%d in %s", i + 1, pCourse->GetDisplayFullTitle().c_str());
+				if (cd != DIFFICULTY_MEDIUM)
+					feat.Feat += " " + CourseDifficultyToThemedString(cd);
+				feat.pStringToFill = &hs.sName;
+				feat.grade = GRADE_NO_DATA;
+				feat.iScore = hs.iScore;
+				feat.fPercentDP = hs.fPercentDP;
+				if (pCourse->HasBanner())
+					feat.Banner = pCourse->m_sBannerPath;
+				asFeatsOut.push_back(feat);
 			}
 		}
-		break;
+
+		// Find Personal Records
+		if (PROFILEMAN->IsPersistentProfile(pn))
+		{
+			HighScoreList &hsl = pProf->GetCourseHighScoreList(pCourse, pTrail);
+			for (unsigned i = 0; i<hsl.vHighScores.size(); i++)
+			{
+				HighScore& hs = hsl.vHighScores[i];
+				if (hs.sName != RANKING_TO_FILL_IN_MARKER[pn])
+					continue;
+
+				RankingFeat feat;
+				feat.Type = RankingFeat::COURSE;
+				feat.pCourse = pCourse;
+				feat.Feat = ssprintf("PR #%d in %s", i + 1, pCourse->GetDisplayFullTitle().c_str());
+				feat.pStringToFill = &hs.sName;
+				feat.grade = GRADE_NO_DATA;
+				feat.iScore = hs.iScore;
+				feat.fPercentDP = hs.fPercentDP;
+				if (pCourse->HasBanner())
+					feat.Banner = pCourse->m_sBannerPath;
+				asFeatsOut.push_back(feat);
+			}
+		}
+	}
+	break;
 	default:
 		ASSERT(0);
 	}
@@ -1657,10 +1698,10 @@ void GameState::GetRankingFeats( PlayerNumber pn, vector<RankingFeat> &asFeatsOu
 bool GameState::AnyPlayerHasRankingFeats() const
 {
 	vector<RankingFeat> vFeats;
-	FOREACH_PlayerNumber( p )
+	FOREACH_PlayerNumber(p)
 	{
-		GetRankingFeats( p, vFeats );
-		if( !vFeats.empty() )
+		GetRankingFeats(p, vFeats);
+		if (!vFeats.empty())
 			return true;
 	}
 	return false;
@@ -1671,29 +1712,29 @@ bool GameState::AnyPlayerHasRankingFeats() const
 
 }*/
 
-void GameState::StoreRankingName( PlayerNumber pn, CString name )
+void GameState::StoreRankingName(PlayerNumber pn, CString name)
 {
 	name.MakeUpper();
 
-	if( USE_NAME_BLACKLIST )
+	if (USE_NAME_BLACKLIST)
 	{
 		RageFile file;
-		if( file.Open(NAME_BLACKLIST_FILE) )
+		if (file.Open(NAME_BLACKLIST_FILE))
 		{
 			CString line;
-			
+
 			while (!file.AtEOF())
 			{
-				if( file.GetLine( line ) == -1 )
+				if (file.GetLine(line) == -1)
 				{
-					LOG->Warn( "Error reading \"%s\": %s", NAME_BLACKLIST_FILE, file.GetError().c_str() );
+					LOG->Warn("Error reading \"%s\": %s", NAME_BLACKLIST_FILE, file.GetError().c_str());
 					break;
 				}
 
 				line.MakeUpper();
-				if( !line.empty() && name.find(line) != CString::npos )	// name contains a bad word
+				if (!line.empty() && name.find(line) != CString::npos)	// name contains a bad word
 				{
-					LOG->Trace( "entered '%s' matches blacklisted item '%s'", name.c_str(), line.c_str() );
+					LOG->Trace("entered '%s' matches blacklisted item '%s'", name.c_str(), line.c_str());
 					name = "";
 					break;
 				}
@@ -1702,73 +1743,73 @@ void GameState::StoreRankingName( PlayerNumber pn, CString name )
 	}
 
 	vector<RankingFeat> aFeats;
-	GetRankingFeats( pn, aFeats );
+	GetRankingFeats(pn, aFeats);
 
-	for( unsigned i=0; i<aFeats.size(); i++ )
+	for (unsigned i = 0; i<aFeats.size(); i++)
 	{
 		*aFeats[i].pStringToFill = name;
 
 		// save name pointers as we fill them
-		m_vpsNamesThatWereFilled.push_back( aFeats[i].pStringToFill );
+		m_vpsNamesThatWereFilled.push_back(aFeats[i].pStringToFill);
 	}
 
 
 	Profile *pProfile = PROFILEMAN->GetMachineProfile();
 
-	if( !PREFSMAN->m_bAllowMultipleHighScoreWithSameName )
+	if (!PREFSMAN->m_bAllowMultipleHighScoreWithSameName)
 	{
 		//
 		// erase all but the highest score for each name
 		//
-		FOREACHM( SongID, Profile::HighScoresForASong, pProfile->m_SongHighScores, iter )
-			FOREACHM( StepsID, Profile::HighScoresForASteps, iter->second.m_StepsHighScores, iter2 )
-				iter2->second.hsl.RemoveAllButOneOfEachName();
+		FOREACHM(SongID, Profile::HighScoresForASong, pProfile->m_SongHighScores, iter)
+			FOREACHM(StepsID, Profile::HighScoresForASteps, iter->second.m_StepsHighScores, iter2)
+			iter2->second.hsl.RemoveAllButOneOfEachName();
 
-		FOREACHM( CourseID, Profile::HighScoresForACourse, pProfile->m_CourseHighScores, iter )
-			FOREACHM( TrailID, Profile::HighScoresForATrail, iter->second.m_TrailHighScores, iter2 )
-				iter2->second.hsl.RemoveAllButOneOfEachName();
+		FOREACHM(CourseID, Profile::HighScoresForACourse, pProfile->m_CourseHighScores, iter)
+			FOREACHM(TrailID, Profile::HighScoresForATrail, iter->second.m_TrailHighScores, iter2)
+			iter2->second.hsl.RemoveAllButOneOfEachName();
 	}
 
 	//
 	// clamp high score sizes
 	//
-	FOREACHM( SongID, Profile::HighScoresForASong, pProfile->m_SongHighScores, iter )
-		FOREACHM( StepsID, Profile::HighScoresForASteps, iter->second.m_StepsHighScores, iter2 )
-			iter2->second.hsl.ClampSize( true );
+	FOREACHM(SongID, Profile::HighScoresForASong, pProfile->m_SongHighScores, iter)
+		FOREACHM(StepsID, Profile::HighScoresForASteps, iter->second.m_StepsHighScores, iter2)
+		iter2->second.hsl.ClampSize(true);
 
-	FOREACHM( CourseID, Profile::HighScoresForACourse, pProfile->m_CourseHighScores, iter )
-		FOREACHM( TrailID, Profile::HighScoresForATrail, iter->second.m_TrailHighScores, iter2 )
-			iter2->second.hsl.ClampSize( true );
+	FOREACHM(CourseID, Profile::HighScoresForACourse, pProfile->m_CourseHighScores, iter)
+		FOREACHM(TrailID, Profile::HighScoresForATrail, iter->second.m_TrailHighScores, iter2)
+		iter2->second.hsl.ClampSize(true);
 }
 
 bool GameState::AllAreInDangerOrWorse() const
 {
-	FOREACH_EnabledPlayer( p )
-		if( m_pPlayerState[p]->m_HealthState < PlayerState::DANGER )
+	FOREACH_EnabledPlayer(p)
+		if (m_pPlayerState[p]->m_HealthState < PlayerState::DANGER)
 			return false;
 	return true;
 }
 
 bool GameState::AllAreDead() const
 {
-	FOREACH_EnabledPlayer( p )
-		if( m_pPlayerState[p]->m_HealthState < PlayerState::DEAD )
+	FOREACH_EnabledPlayer(p)
+		if (m_pPlayerState[p]->m_HealthState < PlayerState::DEAD)
 			return false;
 	return true;
 }
 
 bool GameState::AllHumanHaveComboOf30OrMoreMisses() const
 {
-	FOREACH_HumanPlayer( p )
-		if( STATSMAN->m_CurStageStats.m_player[p].iCurMissCombo < 30 )
+	FOREACH_HumanPlayer(p)
+		if (STATSMAN->m_CurStageStats.m_player[p].iCurMissCombo < 30)
 			return false;
 	return true;
 }
 
 bool GameState::OneIsHot() const
 {
-	FOREACH_EnabledPlayer( p )
-		if( m_pPlayerState[p]->m_HealthState == PlayerState::HOT )
+	FOREACH_EnabledPlayer(p)
+		if (m_pPlayerState[p]->m_HealthState == PlayerState::HOT)
 			return true;
 	return false;
 }
@@ -1780,75 +1821,75 @@ bool GameState::IsTimeToPlayAttractSounds() const
 	// Play attract sounds for this sort span of time regardless of 
 	// m_AttractSoundFrequency because it's awkward to have the machine go 
 	// silent immediately after the end of a game.
-	if( m_iNumTimesThroughAttract == -1 )
+	if (m_iNumTimesThroughAttract == -1)
 		return true;
 
-	if( PREFSMAN->m_AttractSoundFrequency == PrefsManager::ASF_NEVER )
+	if (PREFSMAN->m_AttractSoundFrequency == PrefsManager::ASF_NEVER)
 		return false;
 
 	// play attract sounds once every m_iAttractSoundFrequency times through
-	if( (m_iNumTimesThroughAttract % PREFSMAN->m_AttractSoundFrequency)==0 )
+	if ((m_iNumTimesThroughAttract % PREFSMAN->m_AttractSoundFrequency) == 0)
 		return true;
 
 	return false;
 }
 
-void GameState::VisitAttractScreen( const CString sScreenName )
+void GameState::VisitAttractScreen(const CString sScreenName)
 {
-	if( sScreenName == FIRST_ATTRACT_SCREEN.GetValue() )
+	if (sScreenName == FIRST_ATTRACT_SCREEN.GetValue())
 		m_iNumTimesThroughAttract++;
 }
 
 bool GameState::DifficultiesLocked()
 {
- 	if( GAMESTATE->m_PlayMode == PLAY_MODE_RAVE )
+	if (GAMESTATE->m_PlayMode == PLAY_MODE_RAVE)
 		return true;
-	if( IsCourseMode() )
+	if (IsCourseMode())
 		return PREFSMAN->m_bLockCourseDifficulties;
 	return false;
 }
 
-bool GameState::ChangePreferredDifficulty( PlayerNumber pn, Difficulty dc )
+bool GameState::ChangePreferredDifficulty(PlayerNumber pn, Difficulty dc)
 {
-	m_PreferredDifficulty[pn].Set( dc );
-	if( DifficultiesLocked() )
-		FOREACH_PlayerNumber( p )
-			if( p != pn )
-				m_PreferredDifficulty[p].Set( m_PreferredDifficulty[pn] );
+	m_PreferredDifficulty[pn].Set(dc);
+	if (DifficultiesLocked())
+		FOREACH_PlayerNumber(p)
+		if (p != pn)
+			m_PreferredDifficulty[p].Set(m_PreferredDifficulty[pn]);
 
 	return true;
 }
 
-bool GameState::ChangePreferredDifficulty( PlayerNumber pn, int dir )
+bool GameState::ChangePreferredDifficulty(PlayerNumber pn, int dir)
 {
 	const vector<Difficulty> &v = DIFFICULTIES_TO_SHOW.GetValue();
 
 	Difficulty d = m_PreferredDifficulty[pn];
-	while( 1 )
+	while (1)
 	{
-		d = (Difficulty)(d+dir);
-		if( d < 0 || d >= NUM_DIFFICULTIES )
+		d = (Difficulty)(d + dir);
+		if (d < 0 || d >= NUM_DIFFICULTIES)
 			return false;
-		if( find(v.begin(), v.end(), d) != v.end() )
+		if (find(v.begin(), v.end(), d) != v.end())
 			break; // found
 	}
 
-	return ChangePreferredDifficulty( pn, d );
+	return ChangePreferredDifficulty(pn, d);
 }
 
-bool GameState::ChangePreferredCourseDifficulty( PlayerNumber pn, CourseDifficulty cd )
+bool GameState::ChangePreferredCourseDifficulty(PlayerNumber pn, CourseDifficulty cd)
 {
-	m_PreferredCourseDifficulty[pn].Set( cd );
+	m_PreferredCourseDifficulty[pn].Set(cd);
 
-	if( PREFSMAN->m_bLockCourseDifficulties )
-		FOREACH_PlayerNumber( p )
-			if( p != pn )
-				m_PreferredCourseDifficulty[p].Set( m_PreferredCourseDifficulty[pn] );
+	if (PREFSMAN->m_bLockCourseDifficulties)
+		FOREACH_PlayerNumber(p)
+		if (p != pn)
+			m_PreferredCourseDifficulty[p].Set(m_PreferredCourseDifficulty[pn]);
 
 	return true;
 }
 
-bool GameState::ChangePreferredCourseDifficulty( PlayerNumber pn, int dir )
+bool GameState::ChangePreferredCourseDifficulty(PlayerNumber pn, int dir)
 {
 	/* If we have a course selected, only choose among difficulties available in the course. */
 	const Course *pCourse = this->m_pCurCourse;
@@ -1856,21 +1897,21 @@ bool GameState::ChangePreferredCourseDifficulty( PlayerNumber pn, int dir )
 	const vector<CourseDifficulty> &v = COURSE_DIFFICULTIES_TO_SHOW.GetValue();
 
 	CourseDifficulty cd = m_PreferredCourseDifficulty[pn];
-	while( 1 )
+	while (1)
 	{
-		cd = (CourseDifficulty)(cd+dir);
-		if( cd < 0 || cd >= NUM_DIFFICULTIES )
+		cd = (CourseDifficulty)(cd + dir);
+		if (cd < 0 || cd >= NUM_DIFFICULTIES)
 			return false;
-		if( find(v.begin(),v.end(),cd) == v.end() )
+		if (find(v.begin(), v.end(), cd) == v.end())
 			continue; /* not available */
-		if( !pCourse || pCourse->GetTrail( GAMESTATE->GetCurrentStyle()->m_StepsType, cd ) )
+		if (!pCourse || pCourse->GetTrail(GAMESTATE->GetCurrentStyle()->m_StepsType, cd))
 			break;
 	}
 
-	return ChangePreferredCourseDifficulty( pn, cd );
+	return ChangePreferredCourseDifficulty(pn, cd);
 }
 
-bool GameState::IsCourseDifficultyShown( CourseDifficulty cd )
+bool GameState::IsCourseDifficultyShown(CourseDifficulty cd)
 {
 	const vector<CourseDifficulty> &v = COURSE_DIFFICULTIES_TO_SHOW.GetValue();
 	return find(v.begin(), v.end(), cd) != v.end();
@@ -1879,61 +1920,61 @@ bool GameState::IsCourseDifficultyShown( CourseDifficulty cd )
 Difficulty GameState::GetEasiestStepsDifficulty() const
 {
 	Difficulty dc = DIFFICULTY_INVALID;
-	FOREACH_HumanPlayer( p )
+	FOREACH_HumanPlayer(p)
 	{
-		if( this->m_pCurSteps[p] == NULL )
+		if (this->m_pCurSteps[p] == NULL)
 		{
-			LOG->Warn( "GetEasiestStepsDifficulty called but p%i hasn't chosen notes", p+1 );
+			LOG->Warn("GetEasiestStepsDifficulty called but p%i hasn't chosen notes", p + 1);
 			continue;
 		}
-		dc = min( dc, this->m_pCurSteps[p]->GetDifficulty() );
+		dc = min(dc, this->m_pCurSteps[p]->GetDifficulty());
 	}
 	return dc;
 }
 
 bool GameState::IsEventMode() const
 {
-	return m_bTemporaryEventMode || PREFSMAN->m_bEventMode; 
+	return m_bTemporaryEventMode || PREFSMAN->m_bEventMode;
 }
 
 CoinMode GameState::GetCoinMode()
 {
-	if( IsEventMode() && PREFSMAN->m_CoinMode == COIN_MODE_PAY )
-		return COIN_MODE_FREE; 
-	else 
-		return PREFSMAN->m_CoinMode; 
+	if (IsEventMode() && PREFSMAN->m_CoinMode == COIN_MODE_PAY)
+		return COIN_MODE_FREE;
+	else
+		return PREFSMAN->m_CoinMode;
 }
 
-Premium	GameState::GetPremium() 
-{ 
-	if( IsEventMode() ) 
-		return PREMIUM_NONE; 
-	else 
-		return PREFSMAN->m_Premium; 
+Premium	GameState::GetPremium()
+{
+	if (IsEventMode())
+		return PREMIUM_NONE;
+	else
+		return PREFSMAN->m_Premium;
 }
 
-bool GameState::IsPlayerHot( PlayerNumber pn ) const
+bool GameState::IsPlayerHot(PlayerNumber pn) const
 {
 	return GAMESTATE->m_pPlayerState[pn]->m_HealthState == PlayerState::HOT;
 }
 
-bool GameState::IsPlayerInDanger( PlayerNumber pn ) const
+bool GameState::IsPlayerInDanger(PlayerNumber pn) const
 {
-	if( GAMESTATE->GetPlayerFailType(pn) == SongOptions::FAIL_OFF )
+	if (GAMESTATE->GetPlayerFailType(pn) == SongOptions::FAIL_OFF)
 		return false;
-	if( !PREFSMAN->m_bShowDanger )
+	if (!PREFSMAN->m_bShowDanger)
 		return false;
 	return GAMESTATE->m_pPlayerState[pn]->m_HealthState == PlayerState::DANGER;
 }
 
-bool GameState::IsPlayerDead( PlayerNumber pn ) const
+bool GameState::IsPlayerDead(PlayerNumber pn) const
 {
-	if( GAMESTATE->GetPlayerFailType(pn) == SongOptions::FAIL_OFF )
+	if (GAMESTATE->GetPlayerFailType(pn) == SongOptions::FAIL_OFF)
 		return false;
 	return GAMESTATE->m_pPlayerState[pn]->m_HealthState == PlayerState::DEAD;
 }
 
-float GameState::GetGoalPercentComplete( PlayerNumber pn )
+float GameState::GetGoalPercentComplete(PlayerNumber pn)
 {
 	const Profile *pProfile = PROFILEMAN->GetProfile(pn);
 	const StageStats &ssAccum = STATSMAN->GetAccumStageStats();
@@ -1943,7 +1984,7 @@ float GameState::GetGoalPercentComplete( PlayerNumber pn )
 
 	float fActual = 0;
 	float fGoal = 0;
-	switch( pProfile->m_GoalType )
+	switch (pProfile->m_GoalType)
 	{
 	case GOAL_CALORIES:
 		fActual = pssAccum.fCaloriesBurned + pssCurrent.fCaloriesBurned;
@@ -1958,25 +1999,25 @@ float GameState::GetGoalPercentComplete( PlayerNumber pn )
 	default:
 		ASSERT(0);
 	}
-	if( fGoal == 0 )
+	if (fGoal == 0)
 		return 0;
 	else
 		return fActual / fGoal;
 }
 
-bool GameState::PlayerIsUsingModifier( PlayerNumber pn, const CString &sModifier )
+bool GameState::PlayerIsUsingModifier(PlayerNumber pn, const CString &sModifier)
 {
 	PlayerOptions po = GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions;
 	SongOptions so = GAMESTATE->m_SongOptions;
-	po.FromString( sModifier );
-	so.FromString( sModifier );
+	po.FromString(sModifier);
+	so.FromString(sModifier);
 
 	return po == GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions && so == GAMESTATE->m_SongOptions;
 }
 
 void GameState::ResetOriginalSyncData()
 {
-	if( m_pCurSong )
+	if (m_pCurSong)
 		*m_pTimingDataOriginal = m_pCurSong->m_Timing;
 	else
 		*m_pTimingDataOriginal = TimingData();
@@ -1986,12 +2027,12 @@ void GameState::ResetOriginalSyncData()
 bool GameState::IsSyncDataChanged()
 {
 	// Can't sync in course modes
-	if( IsCourseMode() )
+	if (IsCourseMode())
 		return false;
 
-	if( m_pCurSong  &&  *m_pTimingDataOriginal != m_pCurSong->m_Timing )
+	if (m_pCurSong  &&  *m_pTimingDataOriginal != m_pCurSong->m_Timing)
 		return true;
-	if( m_fGlobalOffsetSecondsOriginal != PREFSMAN->m_fGlobalOffsetSeconds )
+	if (m_fGlobalOffsetSecondsOriginal != PREFSMAN->m_fGlobalOffsetSeconds)
 		return true;
 
 	return false;
@@ -2006,7 +2047,7 @@ void GameState::SaveSyncChanges()
 
 void GameState::RevertSyncChanges()
 {
-	PREFSMAN->m_fGlobalOffsetSeconds.Set( GAMESTATE->m_fGlobalOffsetSecondsOriginal );
+	PREFSMAN->m_fGlobalOffsetSeconds.Set(GAMESTATE->m_fGlobalOffsetSecondsOriginal);
 	GAMESTATE->m_pCurSong->m_Timing = *GAMESTATE->m_pTimingDataOriginal;
 }
 
@@ -2018,187 +2059,187 @@ template<class T>
 class LunaGameState : public Luna<T>
 {
 public:
-	LunaGameState() { LUA->Register( Register ); }
+	LunaGameState() { LUA->Register(Register); }
 
-	static int IsPlayerEnabled( T* p, lua_State *L )		{ lua_pushboolean(L, p->IsPlayerEnabled((PlayerNumber)IArg(1)) ); return 1; }
-	static int IsHumanPlayer( T* p, lua_State *L )			{ lua_pushboolean(L, p->IsHumanPlayer((PlayerNumber)IArg(1)) ); return 1; }
-	static int IsDisqualified( T* p, lua_State *L )		{ lua_pushboolean(L, p->IsDisqualified( (PlayerNumber)IArg(1)) ); return 1; }
-	static int GetPlayerDisplayName( T* p, lua_State *L )	{ lua_pushstring(L, p->GetPlayerDisplayName((PlayerNumber)IArg(1)) ); return 1; }
-	static int GetMasterPlayerNumber( T* p, lua_State *L )	{ lua_pushnumber(L, p->m_MasterPlayerNumber ); return 1; }
-	static int ApplyGameCommand( T* p, lua_State *L )
+	static int IsPlayerEnabled(T* p, lua_State *L)		{ lua_pushboolean(L, p->IsPlayerEnabled((PlayerNumber)IArg(1))); return 1; }
+	static int IsHumanPlayer(T* p, lua_State *L)			{ lua_pushboolean(L, p->IsHumanPlayer((PlayerNumber)IArg(1))); return 1; }
+	static int IsDisqualified(T* p, lua_State *L)		{ lua_pushboolean(L, p->IsDisqualified((PlayerNumber)IArg(1))); return 1; }
+	static int GetPlayerDisplayName(T* p, lua_State *L)	{ lua_pushstring(L, p->GetPlayerDisplayName((PlayerNumber)IArg(1))); return 1; }
+	static int GetMasterPlayerNumber(T* p, lua_State *L)	{ lua_pushnumber(L, p->m_MasterPlayerNumber); return 1; }
+	static int ApplyGameCommand(T* p, lua_State *L)
 	{
 		PlayerNumber pn = PLAYER_INVALID;
-		if( lua_gettop(L) >= 2 && !lua_isnil(L,2) )
-			pn = (PlayerNumber)(IArg(2)-1);
-		p->ApplyGameCommand(SArg(1),pn);
+		if (lua_gettop(L) >= 2 && !lua_isnil(L, 2))
+			pn = (PlayerNumber)(IArg(2) - 1);
+		p->ApplyGameCommand(SArg(1), pn);
 		return 0;
 	}
-	static int GetCurrentSong( T* p, lua_State *L )			{ if(p->m_pCurSong) p->m_pCurSong->PushSelf(L); else lua_pushnil(L); return 1; }
-	static int SetCurrentSong( T* p, lua_State *L )
-	{ 
-		if( lua_isnil(L,1) ) { p->m_pCurSong.Set( NULL ); }
-		else { Song *pS = Luna<Song>::check(L,1); p->m_pCurSong.Set( pS ); }
+	static int GetCurrentSong(T* p, lua_State *L)			{ if (p->m_pCurSong) p->m_pCurSong->PushSelf(L); else lua_pushnil(L); return 1; }
+	static int SetCurrentSong(T* p, lua_State *L)
+	{
+		if (lua_isnil(L, 1)) { p->m_pCurSong.Set(NULL); }
+		else { Song *pS = Luna<Song>::check(L, 1); p->m_pCurSong.Set(pS); }
 		return 0;
 	}
-	static int GetCurrentSteps( T* p, lua_State *L )
+	static int GetCurrentSteps(T* p, lua_State *L)
 	{
 		PlayerNumber pn = (PlayerNumber)IArg(1);
-		Steps *pSteps = p->m_pCurSteps[pn];  
-		if( pSteps ) { pSteps->PushSelf(L); }
+		Steps *pSteps = p->m_pCurSteps[pn];
+		if (pSteps) { pSteps->PushSelf(L); }
 		else		 { lua_pushnil(L); }
 		return 1;
 	}
-	static int SetCurrentSteps( T* p, lua_State *L )
-	{ 
-		PlayerNumber pn = (PlayerNumber)IArg(1);
-		if( lua_isnil(L,2) )	{ p->m_pCurSteps[pn].Set( NULL ); }
-		else					{ Steps *pS = Luna<Steps>::check(L,2); p->m_pCurSteps[pn].Set( pS ); }
-		MESSAGEMAN->Broadcast( (Message)(MESSAGE_CURRENT_STEPS_P1_CHANGED+pn) );
-		return 0;
-	}
-	static int GetCurrentCourse( T* p, lua_State *L )		{ if(p->m_pCurCourse) p->m_pCurCourse->PushSelf(L); else lua_pushnil(L); return 1; }
-	static int SetCurrentCourse( T* p, lua_State *L )
-	{ 
-		if( lua_isnil(L,1) ) { p->m_pCurCourse.Set( NULL ); }
-		else { Course *pC = Luna<Course>::check(L,1); p->m_pCurCourse.Set( pC ); }
-		return 0;
-	}
-	static int GetCurrentTrail( T* p, lua_State *L )
+	static int SetCurrentSteps(T* p, lua_State *L)
 	{
 		PlayerNumber pn = (PlayerNumber)IArg(1);
-		Trail *pTrail = p->m_pCurTrail[pn];  
-		if( pTrail ) { pTrail->PushSelf(L); }
+		if (lua_isnil(L, 2))	{ p->m_pCurSteps[pn].Set(NULL); }
+		else					{ Steps *pS = Luna<Steps>::check(L, 2); p->m_pCurSteps[pn].Set(pS); }
+		MESSAGEMAN->Broadcast((Message)(MESSAGE_CURRENT_STEPS_P1_CHANGED + pn));
+		return 0;
+	}
+	static int GetCurrentCourse(T* p, lua_State *L)		{ if (p->m_pCurCourse) p->m_pCurCourse->PushSelf(L); else lua_pushnil(L); return 1; }
+	static int SetCurrentCourse(T* p, lua_State *L)
+	{
+		if (lua_isnil(L, 1)) { p->m_pCurCourse.Set(NULL); }
+		else { Course *pC = Luna<Course>::check(L, 1); p->m_pCurCourse.Set(pC); }
+		return 0;
+	}
+	static int GetCurrentTrail(T* p, lua_State *L)
+	{
+		PlayerNumber pn = (PlayerNumber)IArg(1);
+		Trail *pTrail = p->m_pCurTrail[pn];
+		if (pTrail) { pTrail->PushSelf(L); }
 		else		 { lua_pushnil(L); }
 		return 1;
 	}
-	static int GetPreferredSong( T* p, lua_State *L )		{ if(p->m_pPreferredSong) p->m_pPreferredSong->PushSelf(L); else lua_pushnil(L); return 1; }
-	static int SetPreferredSong( T* p, lua_State *L )
+	static int GetPreferredSong(T* p, lua_State *L)		{ if (p->m_pPreferredSong) p->m_pPreferredSong->PushSelf(L); else lua_pushnil(L); return 1; }
+	static int SetPreferredSong(T* p, lua_State *L)
 	{
-		if( lua_isnil(L,1) ) { p->m_pPreferredSong = NULL; }
-		else { Song *pS = Luna<Song>::check(L,1); p->m_pPreferredSong = pS; }
+		if (lua_isnil(L, 1)) { p->m_pPreferredSong = NULL; }
+		else { Song *pS = Luna<Song>::check(L, 1); p->m_pPreferredSong = pS; }
 		return 0;
 	}
-	static int SetTemporaryEventMode( T* p, lua_State *L )	{ p->m_bTemporaryEventMode = BArg(1); return 0; }
-	static int Env( T* p, lua_State *L )	{ p->m_Environment->PushSelf(L); return 1; }
-	static int SetEnv( T* p, lua_State *L )	{ p->m_mapEnv[SArg(1)] = SArg(2); return 0; }
-	static int GetEnv( T* p, lua_State *L )
+	static int SetTemporaryEventMode(T* p, lua_State *L)	{ p->m_bTemporaryEventMode = BArg(1); return 0; }
+	static int Env(T* p, lua_State *L)	{ p->m_Environment->PushSelf(L); return 1; }
+	static int SetEnv(T* p, lua_State *L)	{ p->m_mapEnv[SArg(1)] = SArg(2); return 0; }
+	static int GetEnv(T* p, lua_State *L)
 	{
-		map<CString,CString>::const_iterator iter = p->m_mapEnv.find(SArg(1));
-		if( iter != p->m_mapEnv.end() )
-			lua_pushstring(L,iter->second);
+		map<CString, CString>::const_iterator iter = p->m_mapEnv.find(SArg(1));
+		if (iter != p->m_mapEnv.end())
+			lua_pushstring(L, iter->second);
 		else
 			lua_pushnil(L);
 		return 1;
 	}
-	static int GetEditSourceSteps( T* p, lua_State *L )
+	static int GetEditSourceSteps(T* p, lua_State *L)
 	{
-		Steps *pSteps = p->m_pEditSourceSteps;  
-		if( pSteps ) { pSteps->PushSelf(L); }
+		Steps *pSteps = p->m_pEditSourceSteps;
+		if (pSteps) { pSteps->PushSelf(L); }
 		else		 { lua_pushnil(L); }
 		return 1;
 	}
-	static int GetCurrentGame( T* p, lua_State *L )			{ const_cast<Game*>(p->GetCurrentGame())->PushSelf( L ); return 1; }
-	static int DelayedGameCommand( T* p, lua_State *L )		{ p->m_sDelayedGameCommand = SArg(1); return 1; }
-	static int GetPreferredDifficulty( T* p, lua_State *L )	{ lua_pushnumber(L, p->m_PreferredDifficulty[IArg(1)] ); return 1; }
-	static int AnyPlayerHasRankingFeats( T* p, lua_State *L )	{ lua_pushboolean(L, p->AnyPlayerHasRankingFeats() ); return 1; }
-	static int IsCourseMode( T* p, lua_State *L )			{ lua_pushboolean(L, p->IsCourseMode() ); return 1; }
-	static int IsDemonstration( T* p, lua_State *L )		{ lua_pushboolean(L, p->m_bDemonstrationOrJukebox ); return 1; }
-	static int GetPlayMode( T* p, lua_State *L )			{ lua_pushnumber(L, p->m_PlayMode ); return 1; }
-	static int GetSortOrder( T* p, lua_State *L )			{ lua_pushnumber(L, p->m_SortOrder ); return 1; }
-	static int StageIndex( T* p, lua_State *L )			{ lua_pushnumber(L, p->GetStageIndex() ); return 1; }
-	static int IsGoalComplete( T* p, lua_State *L )			{ lua_pushboolean(L, p->IsGoalComplete((PlayerNumber)IArg(1)) ); return 1; }
-	static int PlayerIsUsingModifier( T* p, lua_State *L )	{ lua_pushboolean(L, p->PlayerIsUsingModifier((PlayerNumber)IArg(1),SArg(2)) ); return 1; }
-	static int GetCourseSongIndex( T* p, lua_State *L )		{ lua_pushnumber(L, p->GetCourseSongIndex() ); return 1; }
-	static int IsExtraStage( T* p, lua_State *L )			{ lua_pushboolean(L, p->IsExtraStage() ); return 1; }
-	static int IsExtraStage2( T* p, lua_State *L )			{ lua_pushboolean(L, p->IsExtraStage2() ); return 1; }
-	static int GetEasiestStepsDifficulty( T* p, lua_State *L ){ lua_pushnumber(L, p->GetEasiestStepsDifficulty() ); return 1; }
-	static int IsEventMode( T* p, lua_State *L )			{ lua_pushboolean(L, p->IsEventMode() ); return 1; }
-	static int GetNumPlayersEnabled( T* p, lua_State *L )	{ lua_pushnumber(L, p->GetNumPlayersEnabled() ); return 1; }
-	static int GetSongBeat( T* p, lua_State *L )			{ lua_pushnumber(L, p->m_fSongBeat ); return 1; }
-	static int GetSongBeatVisible( T* p, lua_State *L )		{ lua_pushnumber(L, p->m_fSongBeatVisible ); return 1; }
-	static int GetCurBPS( T* p, lua_State *L )			{ lua_pushnumber(L, p->m_fCurBPS ); return 1; }
-	static int PlayerUsingBothSides( T* p, lua_State *L )	{ lua_pushboolean(L, p->PlayerUsingBothSides() ); return 1; }
-	static int GetCoins( T* p, lua_State *L )				{ lua_pushnumber(L, p->m_iCoins ); return 1; }
-	static int IsSideJoined( T* p, lua_State *L )			{ lua_pushboolean(L, p->m_bSideIsJoined[(PlayerNumber)IArg(1)] ); return 1; }
-	static int GetCoinsNeededToJoin( T* p, lua_State *L )	{ lua_pushnumber(L, p->GetCoinsNeededToJoin() ); return 1; }
-	static int PlayersCanJoin( T* p, lua_State *L )			{ lua_pushboolean(L, p->PlayersCanJoin() ); return 1; }
-	static int GetNumSidesJoined( T* p, lua_State *L )		{ lua_pushnumber(L, p->GetNumSidesJoined() ); return 1; }
-	static int GetCoinMode( T* p, lua_State *L )			{ lua_pushnumber(L, p->GetCoinMode() ); return 1; }
-	static int GetPremium( T* p, lua_State *L )				{ lua_pushnumber(L, p->GetPremium() ); return 1; }
-	static int IsSyncDataChanged( T* p, lua_State *L )		{ lua_pushboolean(L, p->IsSyncDataChanged() ); return 1; }
-	static int IsWinner( T* p, lua_State *L )
+	static int GetCurrentGame(T* p, lua_State *L)			{ const_cast<Game*>(p->GetCurrentGame())->PushSelf(L); return 1; }
+	static int DelayedGameCommand(T* p, lua_State *L)		{ p->m_sDelayedGameCommand = SArg(1); return 1; }
+	static int GetPreferredDifficulty(T* p, lua_State *L)	{ lua_pushnumber(L, p->m_PreferredDifficulty[IArg(1)]); return 1; }
+	static int AnyPlayerHasRankingFeats(T* p, lua_State *L)	{ lua_pushboolean(L, p->AnyPlayerHasRankingFeats()); return 1; }
+	static int IsCourseMode(T* p, lua_State *L)			{ lua_pushboolean(L, p->IsCourseMode()); return 1; }
+	static int IsDemonstration(T* p, lua_State *L)		{ lua_pushboolean(L, p->m_bDemonstrationOrJukebox); return 1; }
+	static int GetPlayMode(T* p, lua_State *L)			{ lua_pushnumber(L, p->m_PlayMode); return 1; }
+	static int GetSortOrder(T* p, lua_State *L)			{ lua_pushnumber(L, p->m_SortOrder); return 1; }
+	static int StageIndex(T* p, lua_State *L)			{ lua_pushnumber(L, p->GetStageIndex()); return 1; }
+	static int IsGoalComplete(T* p, lua_State *L)			{ lua_pushboolean(L, p->IsGoalComplete((PlayerNumber)IArg(1))); return 1; }
+	static int PlayerIsUsingModifier(T* p, lua_State *L)	{ lua_pushboolean(L, p->PlayerIsUsingModifier((PlayerNumber)IArg(1), SArg(2))); return 1; }
+	static int GetCourseSongIndex(T* p, lua_State *L)		{ lua_pushnumber(L, p->GetCourseSongIndex()); return 1; }
+	static int IsExtraStage(T* p, lua_State *L)			{ lua_pushboolean(L, p->IsExtraStage()); return 1; }
+	static int IsExtraStage2(T* p, lua_State *L)			{ lua_pushboolean(L, p->IsExtraStage2()); return 1; }
+	static int GetEasiestStepsDifficulty(T* p, lua_State *L){ lua_pushnumber(L, p->GetEasiestStepsDifficulty()); return 1; }
+	static int IsEventMode(T* p, lua_State *L)			{ lua_pushboolean(L, p->IsEventMode()); return 1; }
+	static int GetNumPlayersEnabled(T* p, lua_State *L)	{ lua_pushnumber(L, p->GetNumPlayersEnabled()); return 1; }
+	static int GetSongBeat(T* p, lua_State *L)			{ lua_pushnumber(L, p->m_fSongBeat); return 1; }
+	static int GetSongBeatVisible(T* p, lua_State *L)		{ lua_pushnumber(L, p->m_fSongBeatVisible); return 1; }
+	static int GetCurBPS(T* p, lua_State *L)			{ lua_pushnumber(L, p->m_fCurBPS); return 1; }
+	static int PlayerUsingBothSides(T* p, lua_State *L)	{ lua_pushboolean(L, p->PlayerUsingBothSides()); return 1; }
+	static int GetCoins(T* p, lua_State *L)				{ lua_pushnumber(L, p->m_iCoins); return 1; }
+	static int IsSideJoined(T* p, lua_State *L)			{ lua_pushboolean(L, p->m_bSideIsJoined[(PlayerNumber)IArg(1)]); return 1; }
+	static int GetCoinsNeededToJoin(T* p, lua_State *L)	{ lua_pushnumber(L, p->GetCoinsNeededToJoin()); return 1; }
+	static int PlayersCanJoin(T* p, lua_State *L)			{ lua_pushboolean(L, p->PlayersCanJoin()); return 1; }
+	static int GetNumSidesJoined(T* p, lua_State *L)		{ lua_pushnumber(L, p->GetNumSidesJoined()); return 1; }
+	static int GetCoinMode(T* p, lua_State *L)			{ lua_pushnumber(L, p->GetCoinMode()); return 1; }
+	static int GetPremium(T* p, lua_State *L)				{ lua_pushnumber(L, p->GetPremium()); return 1; }
+	static int IsSyncDataChanged(T* p, lua_State *L)		{ lua_pushboolean(L, p->IsSyncDataChanged()); return 1; }
+	static int IsWinner(T* p, lua_State *L)
 	{
 		PlayerNumber pn = (PlayerNumber)IArg(1);
-		lua_pushboolean(L, p->GetStageResult(pn)==RESULT_WIN); return 1;
+		lua_pushboolean(L, p->GetStageResult(pn) == RESULT_WIN); return 1;
 	}
 	static void Register(lua_State *L)
 	{
-		ADD_METHOD( IsPlayerEnabled )
-		ADD_METHOD( IsHumanPlayer )
-		ADD_METHOD( IsDisqualified )
-		ADD_METHOD( GetPlayerDisplayName )
-		ADD_METHOD( GetMasterPlayerNumber )
-		ADD_METHOD( ApplyGameCommand )
-		ADD_METHOD( DelayedGameCommand )
-		ADD_METHOD( GetCurrentGame )
-		ADD_METHOD( GetCurrentSong )
-		ADD_METHOD( SetCurrentSong )
-		ADD_METHOD( GetCurrentSteps )
-		ADD_METHOD( SetCurrentSteps )
-		ADD_METHOD( GetCurrentCourse )
-		ADD_METHOD( SetCurrentCourse )
-		ADD_METHOD( GetCurrentTrail )
-		ADD_METHOD( SetPreferredSong )
-		ADD_METHOD( GetPreferredSong )
-		ADD_METHOD( SetTemporaryEventMode )
-		ADD_METHOD( Env )
-		ADD_METHOD( SetEnv )
-		ADD_METHOD( GetEnv )
-		ADD_METHOD( GetEditSourceSteps )
-		ADD_METHOD( GetPreferredDifficulty )
-		ADD_METHOD( AnyPlayerHasRankingFeats )
-		ADD_METHOD( IsCourseMode )
-		ADD_METHOD( IsDemonstration )
-		ADD_METHOD( GetPlayMode )
-		ADD_METHOD( GetSortOrder )
-		ADD_METHOD( StageIndex )
-		ADD_METHOD( IsGoalComplete )
-		ADD_METHOD( PlayerIsUsingModifier )
-		ADD_METHOD( GetCourseSongIndex )
-		ADD_METHOD( IsExtraStage )
-		ADD_METHOD( IsExtraStage2 )
-		ADD_METHOD( GetEasiestStepsDifficulty )
-		ADD_METHOD( IsEventMode )
-		ADD_METHOD( GetNumPlayersEnabled )
-		ADD_METHOD( GetSongBeat )
-		ADD_METHOD( GetSongBeatVisible )
-		ADD_METHOD( GetCurBPS )
-		ADD_METHOD( PlayerUsingBothSides )
-		ADD_METHOD( GetCoins )
-		ADD_METHOD( IsSideJoined )
-		ADD_METHOD( GetCoinsNeededToJoin )
-		ADD_METHOD( PlayersCanJoin )
-		ADD_METHOD( GetNumSidesJoined )
-		ADD_METHOD( GetCoinMode )
-		ADD_METHOD( GetPremium )
-		ADD_METHOD( IsSyncDataChanged )
-		ADD_METHOD( IsWinner )
+		ADD_METHOD(IsPlayerEnabled)
+			ADD_METHOD(IsHumanPlayer)
+			ADD_METHOD(IsDisqualified)
+			ADD_METHOD(GetPlayerDisplayName)
+			ADD_METHOD(GetMasterPlayerNumber)
+			ADD_METHOD(ApplyGameCommand)
+			ADD_METHOD(DelayedGameCommand)
+			ADD_METHOD(GetCurrentGame)
+			ADD_METHOD(GetCurrentSong)
+			ADD_METHOD(SetCurrentSong)
+			ADD_METHOD(GetCurrentSteps)
+			ADD_METHOD(SetCurrentSteps)
+			ADD_METHOD(GetCurrentCourse)
+			ADD_METHOD(SetCurrentCourse)
+			ADD_METHOD(GetCurrentTrail)
+			ADD_METHOD(SetPreferredSong)
+			ADD_METHOD(GetPreferredSong)
+			ADD_METHOD(SetTemporaryEventMode)
+			ADD_METHOD(Env)
+			ADD_METHOD(SetEnv)
+			ADD_METHOD(GetEnv)
+			ADD_METHOD(GetEditSourceSteps)
+			ADD_METHOD(GetPreferredDifficulty)
+			ADD_METHOD(AnyPlayerHasRankingFeats)
+			ADD_METHOD(IsCourseMode)
+			ADD_METHOD(IsDemonstration)
+			ADD_METHOD(GetPlayMode)
+			ADD_METHOD(GetSortOrder)
+			ADD_METHOD(StageIndex)
+			ADD_METHOD(IsGoalComplete)
+			ADD_METHOD(PlayerIsUsingModifier)
+			ADD_METHOD(GetCourseSongIndex)
+			ADD_METHOD(IsExtraStage)
+			ADD_METHOD(IsExtraStage2)
+			ADD_METHOD(GetEasiestStepsDifficulty)
+			ADD_METHOD(IsEventMode)
+			ADD_METHOD(GetNumPlayersEnabled)
+			ADD_METHOD(GetSongBeat)
+			ADD_METHOD(GetSongBeatVisible)
+			ADD_METHOD(GetCurBPS)
+			ADD_METHOD(PlayerUsingBothSides)
+			ADD_METHOD(GetCoins)
+			ADD_METHOD(IsSideJoined)
+			ADD_METHOD(GetCoinsNeededToJoin)
+			ADD_METHOD(PlayersCanJoin)
+			ADD_METHOD(GetNumSidesJoined)
+			ADD_METHOD(GetCoinMode)
+			ADD_METHOD(GetPremium)
+			ADD_METHOD(IsSyncDataChanged)
+			ADD_METHOD(IsWinner)
 
-		Luna<T>::Register( L );
+			Luna<T>::Register(L);
 
 		// Add global singleton if constructed already.  If it's not constructed yet,
 		// then we'll register it later when we reinit Lua just before 
 		// initializing the display.
-		if( GAMESTATE )
+		if (GAMESTATE)
 		{
 			lua_pushstring(L, "GAMESTATE");
-			GAMESTATE->PushSelf( L );
+			GAMESTATE->PushSelf(L);
 			lua_settable(L, LUA_GLOBALSINDEX);
 		}
 	}
 };
 
-LUA_REGISTER_CLASS( GameState )
+LUA_REGISTER_CLASS(GameState)
 // lua end
 
 
@@ -2206,46 +2247,46 @@ LUA_REGISTER_CLASS( GameState )
 
 
 #include "LuaFunctions.h"
-LuaFunction_NoArgs( NumStagesLeft,			GAMESTATE->GetNumStagesLeft() )
-LuaFunction_NoArgs( IsFinalStage,			GAMESTATE->IsFinalStage() )
-LuaFunction_NoArgs( IsExtraStage,			GAMESTATE->IsExtraStage() )
-LuaFunction_NoArgs( IsExtraStage2,			GAMESTATE->IsExtraStage2() )
-LuaFunction_NoArgs( CourseSongIndex,		GAMESTATE->GetCourseSongIndex() )
-LuaFunction_NoArgs( PlayModeName,			PlayModeToString(GAMESTATE->m_PlayMode) )
-LuaFunction_NoArgs( CurStyleName,			CString( GAMESTATE->m_pCurStyle == NULL ? "none": GAMESTATE->GetCurrentStyle()->m_szName ) )
-LuaFunction_NoArgs( GetNumPlayersEnabled,	GAMESTATE->GetNumPlayersEnabled() )
-LuaFunction_NoArgs( GetEasiestNotesDifficulty, GAMESTATE->GetEasiestStepsDifficulty() )
+LuaFunction_NoArgs(NumStagesLeft, GAMESTATE->GetNumStagesLeft())
+LuaFunction_NoArgs(IsFinalStage, GAMESTATE->IsFinalStage())
+LuaFunction_NoArgs(IsExtraStage, GAMESTATE->IsExtraStage())
+LuaFunction_NoArgs(IsExtraStage2, GAMESTATE->IsExtraStage2())
+LuaFunction_NoArgs(CourseSongIndex, GAMESTATE->GetCourseSongIndex())
+LuaFunction_NoArgs(PlayModeName, PlayModeToString(GAMESTATE->m_PlayMode))
+LuaFunction_NoArgs(CurStyleName, CString(GAMESTATE->m_pCurStyle == NULL ? "none" : GAMESTATE->GetCurrentStyle()->m_szName))
+LuaFunction_NoArgs(GetNumPlayersEnabled, GAMESTATE->GetNumPlayersEnabled())
+LuaFunction_NoArgs(GetEasiestNotesDifficulty, GAMESTATE->GetEasiestStepsDifficulty())
 
 CString GetStageText()
 {
 	// all lowercase or compatibility with scripts
-	CString s = StageToString( GAMESTATE->GetCurrentStage() );
+	CString s = StageToString(GAMESTATE->GetCurrentStage());
 	s.MakeLower();
 	return s;
 }
-LuaFunction_NoArgs( GetStageText, GetStageText() )
+LuaFunction_NoArgs(GetStageText, GetStageText())
 
 /*
- * (c) 2001-2004 Chris Danford, Glenn Maynard, Chris Gomez
- * All rights reserved.
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons to
- * whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies of
- * the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
- * THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
- * INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
- * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
- * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
- * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
- * PERFORMANCE OF THIS SOFTWARE.
- */
+* (c) 2001-2004 Chris Danford, Glenn Maynard, Chris Gomez
+* All rights reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, and/or sell copies of the Software, and to permit persons to
+* whom the Software is furnished to do so, provided that the above
+* copyright notice(s) and this permission notice appear in all copies of
+* the Software and that both the above copyright notice(s) and this
+* permission notice appear in supporting documentation.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+* THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
+* INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
+* OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+* OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+* OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+* PERFORMANCE OF THIS SOFTWARE.
+*/

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -336,7 +336,6 @@ void GameState::HTTPBroadcastSongInProgress(const CString &sWriteOut)
 	//and we have a broadcast URL...
 	if (m_sSongBroadcastURL.length()>3)
 	{
-		m_SongBroadcastHTTP = new HTTPHelper();
 		m_SongBroadcastHTTP->Threaded_SubmitPostRequest(m_sSongBroadcastURL, sWriteOut);
 	}
 	else

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -48,7 +48,7 @@ public:
 	void SaveCurrentSettingsToProfile( PlayerNumber pn ); // called at the beginning of each stage
 
 	void SetSongInProgress( const CString &sWriteOut );
-	void HTTPBroadcastSongInProgress( bool bNoSong );
+	void HTTPBroadcastSongInProgress( bool bNoSong=false );
 
 	void Update( float fDelta );
 

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -48,7 +48,7 @@ public:
 	void SaveCurrentSettingsToProfile( PlayerNumber pn ); // called at the beginning of each stage
 
 	void SetSongInProgress( const CString &sWriteOut );
-	void HTTPBroadcastSongInProgress( );
+	void HTTPBroadcastSongInProgress( bool bNoSong );
 
 	void Update( float fDelta );
 

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -10,6 +10,11 @@
 #include "Difficulty.h"
 #include "MessageManager.h"
 #include "SongOptions.h"
+#include "Preference.h"
+
+#if !defined(WITHOUT_NETWORKING)
+#include "HTTPHelper.h"
+#endif
 
 #include <map>
 #include <deque>
@@ -35,16 +40,18 @@ public:
 	~GameState();
 	void Reset();
 	void ApplyCmdline(); // called by Reset
-	void ApplyGameCommand( const CString &sCommand, PlayerNumber pn=PLAYER_INVALID );
+	void ApplyGameCommand(const CString &sCommand, PlayerNumber pn = PLAYER_INVALID);
 	void BeginGame();	// called when first player joins
-	void JoinPlayer( PlayerNumber pn );
+	void JoinPlayer(PlayerNumber pn);
 	void PlayersFinalized();	// called after a style is chosen, which means the number of players is finalized
 	void EndGame();	// called on ScreenGameOver, ScreenMusicScroll, ScreenCredits
-	void SaveCurrentSettingsToProfile( PlayerNumber pn ); // called at the beginning of each stage
+	void SaveCurrentSettingsToProfile(PlayerNumber pn); // called at the beginning of each stage
 
-	void SetSongInProgress( const CString &sWriteOut );
+	void SetSongInProgress(const CString &sWriteOut);
+	void HTTPBroadcastSongInProgress(const CString &sWriteOut);
 
-	void Update( float fDelta );
+	void Update(float fDelta);
+
 
 	//
 	// Delayed command stuff
@@ -60,16 +67,16 @@ public:
 	PlayMode			m_PlayMode;			// many screens display different info depending on this value
 	int					m_iCoins;			// not "credits"
 	PlayerNumber		m_MasterPlayerNumber;	// used in Styles where one player controls both sides
-	BroadcastOnChange1D<CourseDifficulty,NUM_PLAYERS>	m_PreferredCourseDifficulty;// used in nonstop
+	BroadcastOnChange1D<CourseDifficulty, NUM_PLAYERS>	m_PreferredCourseDifficulty;// used in nonstop
 	bool DifficultiesLocked();
-	bool ChangePreferredDifficulty( PlayerNumber pn, Difficulty dc );
-	bool ChangePreferredDifficulty( PlayerNumber pn, int dir );
-	bool ChangePreferredCourseDifficulty( PlayerNumber pn, CourseDifficulty cd );
-	bool ChangePreferredCourseDifficulty( PlayerNumber pn, int dir );
-	bool IsCourseDifficultyShown( CourseDifficulty cd );
+	bool ChangePreferredDifficulty(PlayerNumber pn, Difficulty dc);
+	bool ChangePreferredDifficulty(PlayerNumber pn, int dir);
+	bool ChangePreferredCourseDifficulty(PlayerNumber pn, CourseDifficulty cd);
+	bool ChangePreferredCourseDifficulty(PlayerNumber pn, int dir);
+	bool IsCourseDifficultyShown(CourseDifficulty cd);
 	Difficulty GetEasiestStepsDifficulty() const;
 	RageTimer			m_timeGameStarted;	// from the moment the first player pressed Start
-	map<CString,CString> m_mapEnv;
+	map<CString, CString> m_mapEnv;
 	LuaTable			*m_Environment;
 
 	/* This is set to a random number per-game/round; it can be used for a random seed. */
@@ -83,19 +90,19 @@ public:
 	const Game*	GetCurrentGame();
 	const Style*	GetCurrentStyle() const;
 
-	void GetPlayerInfo( PlayerNumber pn, bool& bIsEnabledOut, bool& bIsHumanOut );
-	bool IsPlayerEnabled( PlayerNumber pn ) const;
+	void GetPlayerInfo(PlayerNumber pn, bool& bIsEnabledOut, bool& bIsHumanOut);
+	bool IsPlayerEnabled(PlayerNumber pn) const;
 	int	GetNumPlayersEnabled() const;
 	bool PlayerUsingBothSides() const;
 
-	bool IsHumanPlayer( PlayerNumber pn ) const;
+	bool IsHumanPlayer(PlayerNumber pn) const;
 	int GetNumHumanPlayers() const;
 	PlayerNumber GetFirstHumanPlayer() const;
 	PlayerNumber GetFirstDisabledPlayer() const;
-	bool IsCpuPlayer( PlayerNumber pn ) const;
+	bool IsCpuPlayer(PlayerNumber pn) const;
 	bool AnyPlayersAreCpu() const;
 
-	void GetCharacters( vector<Character*> &apCharactersOut );
+	void GetCharacters(vector<Character*> &apCharactersOut);
 	Character* GetRandomCharacter();
 	Character* GetDefaultCharacter();
 
@@ -105,10 +112,11 @@ public:
 
 	bool ShowMarvelous() const;
 
+	CString			m_sSongBroadcastURL;
 	CString			m_sLoadingMessage;	// used in loading screen
 	CString			m_sPreferredSongGroup;	// GROUP_ALL_MUSIC denotes no preferred group
 	bool			m_bChangedFailTypeOnScreenSongOptions;	// true if FailType was changed in the song options screen
-	BroadcastOnChange1D<Difficulty,NUM_PLAYERS>	m_PreferredDifficulty;
+	BroadcastOnChange1D<Difficulty, NUM_PLAYERS>	m_PreferredDifficulty;
 	SortOrder		m_SortOrder;			// set by MusicWheel
 	SortOrder		m_PreferredSortOrder;			// used by MusicWheel
 	bool			m_bEditing;			// NoteField does special stuff when this is true
@@ -116,6 +124,7 @@ public:
 	bool			m_bJukeboxUsesModifiers;
 	int				m_iNumStagesOfThisSong;
 	int				m_iCurrentStageIndex;
+
 
 	int				GetStageIndex() const;
 	void			BeginStage();
@@ -127,9 +136,9 @@ public:
 	bool			IsExtraStage() const;
 	bool			IsExtraStage2() const;
 	Stage			GetCurrentStage() const;
-	void			GetPossibleStages( vector<Stage> &out ) const;
+	void			GetPossibleStages(vector<Stage> &out) const;
 	int				GetCourseSongIndex() const;
-	CString			GetPlayerDisplayName( PlayerNumber pn ) const;
+	CString			GetPlayerDisplayName(PlayerNumber pn) const;
 
 
 	//
@@ -140,13 +149,13 @@ public:
 	BroadcastOnChangePtr<Song>	m_pCurSong;
 	// The last Song that the user manually changed to.
 	Song*		m_pPreferredSong;
-	BroadcastOnChangePtr1D<Steps,NUM_PLAYERS> m_pCurSteps;
-	
+	BroadcastOnChangePtr1D<Steps, NUM_PLAYERS> m_pCurSteps;
+
 	// NULL on ScreenSelectMusic if the currently selected wheel item isn't a Course.
 	BroadcastOnChangePtr<Course>	m_pCurCourse;
 	// The last Course that the user manually changed to.
 	Course*		m_pPreferredCourse;
-	BroadcastOnChangePtr1D<Trail,NUM_PLAYERS>	m_pCurTrail;
+	BroadcastOnChangePtr1D<Trail, NUM_PLAYERS>	m_pCurTrail;
 
 
 	//
@@ -166,25 +175,25 @@ public:
 
 	int			m_BeatToNoteSkinRev; /* hack: incremented whenever m_BeatToNoteSkin changes */
 	void ResetNoteSkins();
-	void ResetNoteSkinsForPlayer( PlayerNumber pn );
-	void GetAllUsedNoteSkins( vector<CString> &out ) const;
+	void ResetNoteSkinsForPlayer(PlayerNumber pn);
+	void GetAllUsedNoteSkins(vector<CString> &out) const;
 
 	static const float MUSIC_SECONDS_INVALID;
 
 	void ResetMusicStatistics();	// Call this when it's time to play a new song.  Clears the values above.
-	void UpdateSongPosition( float fPositionSeconds, const TimingData &timing, const RageTimer &timestamp = RageZeroTimer );
-	float GetSongPercent( float beat ) const;
+	void UpdateSongPosition(float fPositionSeconds, const TimingData &timing, const RageTimer &timestamp = RageZeroTimer);
+	float GetSongPercent(float beat) const;
 
-	bool IsPlayerHot( PlayerNumber pn ) const;
-	bool IsPlayerInDanger( PlayerNumber pn ) const;
-	bool IsPlayerDead( PlayerNumber pn ) const;
+	bool IsPlayerHot(PlayerNumber pn) const;
+	bool IsPlayerInDanger(PlayerNumber pn) const;
+	bool IsPlayerDead(PlayerNumber pn) const;
 	bool AllAreInDangerOrWorse() const;
 	bool AllAreDead() const;
 	bool AllHumanHaveComboOf30OrMoreMisses() const;
 	bool OneIsHot() const;
 
 	// used in PLAY_MODE_BATTLE and PLAY_MODE_RAVE
-	void SetNoteSkinForBeatRange( PlayerState* pPlayerState, const CString& sNoteSkin, float StartBeat, float EndBeat );
+	void SetNoteSkinForBeatRange(PlayerState* pPlayerState, const CString& sNoteSkin, float StartBeat, float EndBeat);
 
 	// used in PLAY_MODE_BATTLE
 	float	m_fOpponentHealthPercent;
@@ -194,17 +203,17 @@ public:
 
 	// used in workout
 	bool	m_bGoalComplete[NUM_PLAYERS];
-	
-	void GetUndisplayedBeats( const PlayerState* pPlayerState, float TotalSeconds, float &StartBeat, float &EndBeat ) const; // only meaningful when a NoteField is in use
-	void LaunchAttack( PlayerNumber target, const Attack& a );
-	void RebuildPlayerOptionsFromActiveAttacks( PlayerNumber pn );
+
+	void GetUndisplayedBeats(const PlayerState* pPlayerState, float TotalSeconds, float &StartBeat, float &EndBeat) const; // only meaningful when a NoteField is in use
+	void LaunchAttack(PlayerNumber target, const Attack& a);
+	void RebuildPlayerOptionsFromActiveAttacks(PlayerNumber pn);
 	void RemoveAllActiveAttacks();	// called on end of song
-	void RemoveActiveAttacksForPlayer( PlayerNumber pn, AttackLevel al=NUM_ATTACK_LEVELS /*all*/ );
-	void EndActiveAttacksForPlayer( PlayerNumber pn );
+	void RemoveActiveAttacksForPlayer(PlayerNumber pn, AttackLevel al = NUM_ATTACK_LEVELS /*all*/);
+	void EndActiveAttacksForPlayer(PlayerNumber pn);
 	void RemoveAllInventory();
-	int GetSumOfActiveAttackLevels( PlayerNumber pn ) const;
+	int GetSumOfActiveAttackLevels(PlayerNumber pn) const;
 	PlayerNumber GetBestPlayer() const;
-	StageResult GetStageResult( PlayerNumber pn ) const;
+	StageResult GetStageResult(PlayerNumber pn) const;
 
 	void ResetStageStatistics();	// Call this when it's time to play a new stage.
 
@@ -219,26 +228,32 @@ public:
 	SongOptions		m_SongOptions;
 	SongOptions		m_StoredSongOptions;
 
-	void ApplyModifiers( PlayerNumber pn, CString sModifiers );
+	void ApplyModifiers(PlayerNumber pn, CString sModifiers);
 	void StoreSelectedOptions();
 	void RestoreSelectedOptions();
 	void ResetCurrentOptions();
 
-	bool IsDisqualified( PlayerNumber pn );
-	bool PlayerIsUsingModifier( PlayerNumber pn, const CString &sModifier );
+	bool IsDisqualified(PlayerNumber pn);
+	bool PlayerIsUsingModifier(PlayerNumber pn, const CString &sModifier);
 
-	SongOptions::FailType GetPlayerFailType( PlayerNumber pn ) const;
+	SongOptions::FailType GetPlayerFailType(PlayerNumber pn) const;
 
 	// character stuff
 private:
 	vector<Character*> m_pCharacters;
+
+	//network private vars
+#if !defined(WITHOUT_NETWORKING)
+
+	HTTPHelper* m_SongBroadcastHTTP;
+#endif
 
 public:
 	Character* m_pCurCharacters[NUM_PLAYERS];
 
 	void ReloadCharacters();
 
-	
+
 
 
 	bool HasEarnedExtraStage() const;
@@ -262,9 +277,9 @@ public:
 		CString *pStringToFill;
 	};
 
-	void GetRankingFeats( PlayerNumber pn, vector<RankingFeat> &vFeatsOut ) const;
+	void GetRankingFeats(PlayerNumber pn, vector<RankingFeat> &vFeatsOut) const;
 	bool AnyPlayerHasRankingFeats() const;
-	void StoreRankingName( PlayerNumber pn, CString name );	// Called by name entry screens
+	void StoreRankingName(PlayerNumber pn, CString name);	// Called by name entry screens
 	vector<CString*> m_vpsNamesThatWereFilled;	// filled on StoreRankingName, 
 
 
@@ -281,7 +296,7 @@ public:
 	//
 	int m_iNumTimesThroughAttract;	// negative means play regardless of m_iAttractSoundFrequency setting
 	bool IsTimeToPlayAttractSounds() const;
-	void VisitAttractScreen( const CString sScreenName );
+	void VisitAttractScreen(const CString sScreenName);
 
 	//
 	// PlayerState
@@ -306,8 +321,8 @@ public:
 	BroadcastOnChange<StepsType> m_stEditSource;
 
 	// Workout stuff
-	float GetGoalPercentComplete( PlayerNumber pn );
-	bool IsGoalComplete( PlayerNumber pn )	{ return GetGoalPercentComplete( pn ) >= 1; }
+	float GetGoalPercentComplete(PlayerNumber pn);
+	bool IsGoalComplete(PlayerNumber pn)	{ return GetGoalPercentComplete(pn) >= 1; }
 
 	// Sync changes stuff
 	TimingData *m_pTimingDataOriginal;
@@ -318,7 +333,7 @@ public:
 	void RevertSyncChanges();
 
 	// Lua
-	void PushSelf( lua_State *L );
+	void PushSelf(lua_State *L);
 };
 
 
@@ -328,26 +343,26 @@ extern GameState*	GAMESTATE;	// global and accessable from anywhere in our progr
 #endif
 
 /*
- * (c) 2001-2004 Chris Danford, Glenn Maynard, Chris Gomez
- * All rights reserved.
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons to
- * whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies of
- * the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
- * THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
- * INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
- * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
- * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
- * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
- * PERFORMANCE OF THIS SOFTWARE.
- */
+* (c) 2001-2004 Chris Danford, Glenn Maynard, Chris Gomez
+* All rights reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, and/or sell copies of the Software, and to permit persons to
+* whom the Software is furnished to do so, provided that the above
+* copyright notice(s) and this permission notice appear in all copies of
+* the Software and that both the above copyright notice(s) and this
+* permission notice appear in supporting documentation.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+* THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
+* INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
+* OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+* OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+* OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+* PERFORMANCE OF THIS SOFTWARE.
+*/

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -48,7 +48,7 @@ public:
 	void SaveCurrentSettingsToProfile( PlayerNumber pn ); // called at the beginning of each stage
 
 	void SetSongInProgress( const CString &sWriteOut );
-	void HTTPBroadcastSongInProgress( const CString &sWriteOut );
+	void HTTPBroadcastSongInProgress( );
 
 	void Update( float fDelta );
 

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -40,17 +40,17 @@ public:
 	~GameState();
 	void Reset();
 	void ApplyCmdline(); // called by Reset
-	void ApplyGameCommand(const CString &sCommand, PlayerNumber pn = PLAYER_INVALID);
+	void ApplyGameCommand( const CString &sCommand, PlayerNumber pn=PLAYER_INVALID );
 	void BeginGame();	// called when first player joins
-	void JoinPlayer(PlayerNumber pn);
+	void JoinPlayer( PlayerNumber pn );
 	void PlayersFinalized();	// called after a style is chosen, which means the number of players is finalized
 	void EndGame();	// called on ScreenGameOver, ScreenMusicScroll, ScreenCredits
-	void SaveCurrentSettingsToProfile(PlayerNumber pn); // called at the beginning of each stage
+	void SaveCurrentSettingsToProfile( PlayerNumber pn ); // called at the beginning of each stage
 
-	void SetSongInProgress(const CString &sWriteOut);
-	void HTTPBroadcastSongInProgress(const CString &sWriteOut);
+	void SetSongInProgress( const CString &sWriteOut );
+	void HTTPBroadcastSongInProgress( const CString &sWriteOut );
 
-	void Update(float fDelta);
+	void Update( float fDelta );
 
 
 	//
@@ -67,16 +67,16 @@ public:
 	PlayMode			m_PlayMode;			// many screens display different info depending on this value
 	int					m_iCoins;			// not "credits"
 	PlayerNumber		m_MasterPlayerNumber;	// used in Styles where one player controls both sides
-	BroadcastOnChange1D<CourseDifficulty, NUM_PLAYERS>	m_PreferredCourseDifficulty;// used in nonstop
+	BroadcastOnChange1D<CourseDifficulty,NUM_PLAYERS>	m_PreferredCourseDifficulty;// used in nonstop
 	bool DifficultiesLocked();
-	bool ChangePreferredDifficulty(PlayerNumber pn, Difficulty dc);
-	bool ChangePreferredDifficulty(PlayerNumber pn, int dir);
-	bool ChangePreferredCourseDifficulty(PlayerNumber pn, CourseDifficulty cd);
-	bool ChangePreferredCourseDifficulty(PlayerNumber pn, int dir);
-	bool IsCourseDifficultyShown(CourseDifficulty cd);
+	bool ChangePreferredDifficulty( PlayerNumber pn, Difficulty dc );
+	bool ChangePreferredDifficulty( PlayerNumber pn, int dir );
+	bool ChangePreferredCourseDifficulty( PlayerNumber pn, CourseDifficulty cd );
+	bool ChangePreferredCourseDifficulty( PlayerNumber pn, int dir );
+	bool IsCourseDifficultyShown( CourseDifficulty cd );
 	Difficulty GetEasiestStepsDifficulty() const;
 	RageTimer			m_timeGameStarted;	// from the moment the first player pressed Start
-	map<CString, CString> m_mapEnv;
+	map<CString,CString> m_mapEnv;
 	LuaTable			*m_Environment;
 
 	/* This is set to a random number per-game/round; it can be used for a random seed. */
@@ -90,19 +90,19 @@ public:
 	const Game*	GetCurrentGame();
 	const Style*	GetCurrentStyle() const;
 
-	void GetPlayerInfo(PlayerNumber pn, bool& bIsEnabledOut, bool& bIsHumanOut);
-	bool IsPlayerEnabled(PlayerNumber pn) const;
+	void GetPlayerInfo( PlayerNumber pn, bool& bIsEnabledOut, bool& bIsHumanOut );
+	bool IsPlayerEnabled( PlayerNumber pn ) const;
 	int	GetNumPlayersEnabled() const;
 	bool PlayerUsingBothSides() const;
 
-	bool IsHumanPlayer(PlayerNumber pn) const;
+	bool IsHumanPlayer( PlayerNumber pn ) const;
 	int GetNumHumanPlayers() const;
 	PlayerNumber GetFirstHumanPlayer() const;
 	PlayerNumber GetFirstDisabledPlayer() const;
-	bool IsCpuPlayer(PlayerNumber pn) const;
+	bool IsCpuPlayer( PlayerNumber pn ) const;
 	bool AnyPlayersAreCpu() const;
 
-	void GetCharacters(vector<Character*> &apCharactersOut);
+	void GetCharacters( vector<Character*> &apCharactersOut );
 	Character* GetRandomCharacter();
 	Character* GetDefaultCharacter();
 
@@ -112,11 +112,12 @@ public:
 
 	bool ShowMarvelous() const;
 
+
 	CString			m_sSongBroadcastURL;
 	CString			m_sLoadingMessage;	// used in loading screen
 	CString			m_sPreferredSongGroup;	// GROUP_ALL_MUSIC denotes no preferred group
 	bool			m_bChangedFailTypeOnScreenSongOptions;	// true if FailType was changed in the song options screen
-	BroadcastOnChange1D<Difficulty, NUM_PLAYERS>	m_PreferredDifficulty;
+	BroadcastOnChange1D<Difficulty,NUM_PLAYERS>	m_PreferredDifficulty;
 	SortOrder		m_SortOrder;			// set by MusicWheel
 	SortOrder		m_PreferredSortOrder;			// used by MusicWheel
 	bool			m_bEditing;			// NoteField does special stuff when this is true
@@ -136,9 +137,9 @@ public:
 	bool			IsExtraStage() const;
 	bool			IsExtraStage2() const;
 	Stage			GetCurrentStage() const;
-	void			GetPossibleStages(vector<Stage> &out) const;
+	void			GetPossibleStages( vector<Stage> &out ) const;
 	int				GetCourseSongIndex() const;
-	CString			GetPlayerDisplayName(PlayerNumber pn) const;
+	CString			GetPlayerDisplayName( PlayerNumber pn ) const;
 
 
 	//
@@ -149,13 +150,13 @@ public:
 	BroadcastOnChangePtr<Song>	m_pCurSong;
 	// The last Song that the user manually changed to.
 	Song*		m_pPreferredSong;
-	BroadcastOnChangePtr1D<Steps, NUM_PLAYERS> m_pCurSteps;
-
+	BroadcastOnChangePtr1D<Steps,NUM_PLAYERS> m_pCurSteps;
+	
 	// NULL on ScreenSelectMusic if the currently selected wheel item isn't a Course.
 	BroadcastOnChangePtr<Course>	m_pCurCourse;
 	// The last Course that the user manually changed to.
 	Course*		m_pPreferredCourse;
-	BroadcastOnChangePtr1D<Trail, NUM_PLAYERS>	m_pCurTrail;
+	BroadcastOnChangePtr1D<Trail,NUM_PLAYERS>	m_pCurTrail;
 
 
 	//
@@ -175,25 +176,25 @@ public:
 
 	int			m_BeatToNoteSkinRev; /* hack: incremented whenever m_BeatToNoteSkin changes */
 	void ResetNoteSkins();
-	void ResetNoteSkinsForPlayer(PlayerNumber pn);
-	void GetAllUsedNoteSkins(vector<CString> &out) const;
+	void ResetNoteSkinsForPlayer( PlayerNumber pn );
+	void GetAllUsedNoteSkins( vector<CString> &out ) const;
 
 	static const float MUSIC_SECONDS_INVALID;
 
 	void ResetMusicStatistics();	// Call this when it's time to play a new song.  Clears the values above.
-	void UpdateSongPosition(float fPositionSeconds, const TimingData &timing, const RageTimer &timestamp = RageZeroTimer);
-	float GetSongPercent(float beat) const;
+	void UpdateSongPosition( float fPositionSeconds, const TimingData &timing, const RageTimer &timestamp = RageZeroTimer );
+	float GetSongPercent( float beat ) const;
 
-	bool IsPlayerHot(PlayerNumber pn) const;
-	bool IsPlayerInDanger(PlayerNumber pn) const;
-	bool IsPlayerDead(PlayerNumber pn) const;
+	bool IsPlayerHot( PlayerNumber pn ) const;
+	bool IsPlayerInDanger( PlayerNumber pn ) const;
+	bool IsPlayerDead( PlayerNumber pn ) const;
 	bool AllAreInDangerOrWorse() const;
 	bool AllAreDead() const;
 	bool AllHumanHaveComboOf30OrMoreMisses() const;
 	bool OneIsHot() const;
 
 	// used in PLAY_MODE_BATTLE and PLAY_MODE_RAVE
-	void SetNoteSkinForBeatRange(PlayerState* pPlayerState, const CString& sNoteSkin, float StartBeat, float EndBeat);
+	void SetNoteSkinForBeatRange( PlayerState* pPlayerState, const CString& sNoteSkin, float StartBeat, float EndBeat );
 
 	// used in PLAY_MODE_BATTLE
 	float	m_fOpponentHealthPercent;
@@ -203,17 +204,17 @@ public:
 
 	// used in workout
 	bool	m_bGoalComplete[NUM_PLAYERS];
-
-	void GetUndisplayedBeats(const PlayerState* pPlayerState, float TotalSeconds, float &StartBeat, float &EndBeat) const; // only meaningful when a NoteField is in use
-	void LaunchAttack(PlayerNumber target, const Attack& a);
-	void RebuildPlayerOptionsFromActiveAttacks(PlayerNumber pn);
+	
+	void GetUndisplayedBeats( const PlayerState* pPlayerState, float TotalSeconds, float &StartBeat, float &EndBeat ) const; // only meaningful when a NoteField is in use
+	void LaunchAttack( PlayerNumber target, const Attack& a );
+	void RebuildPlayerOptionsFromActiveAttacks( PlayerNumber pn );
 	void RemoveAllActiveAttacks();	// called on end of song
-	void RemoveActiveAttacksForPlayer(PlayerNumber pn, AttackLevel al = NUM_ATTACK_LEVELS /*all*/);
-	void EndActiveAttacksForPlayer(PlayerNumber pn);
+	void RemoveActiveAttacksForPlayer( PlayerNumber pn, AttackLevel al=NUM_ATTACK_LEVELS /*all*/ );
+	void EndActiveAttacksForPlayer( PlayerNumber pn );
 	void RemoveAllInventory();
-	int GetSumOfActiveAttackLevels(PlayerNumber pn) const;
+	int GetSumOfActiveAttackLevels( PlayerNumber pn ) const;
 	PlayerNumber GetBestPlayer() const;
-	StageResult GetStageResult(PlayerNumber pn) const;
+	StageResult GetStageResult( PlayerNumber pn ) const;
 
 	void ResetStageStatistics();	// Call this when it's time to play a new stage.
 
@@ -228,32 +229,32 @@ public:
 	SongOptions		m_SongOptions;
 	SongOptions		m_StoredSongOptions;
 
-	void ApplyModifiers(PlayerNumber pn, CString sModifiers);
+	void ApplyModifiers( PlayerNumber pn, CString sModifiers );
 	void StoreSelectedOptions();
 	void RestoreSelectedOptions();
 	void ResetCurrentOptions();
 
-	bool IsDisqualified(PlayerNumber pn);
-	bool PlayerIsUsingModifier(PlayerNumber pn, const CString &sModifier);
+	bool IsDisqualified( PlayerNumber pn );
+	bool PlayerIsUsingModifier( PlayerNumber pn, const CString &sModifier );
 
-	SongOptions::FailType GetPlayerFailType(PlayerNumber pn) const;
+	SongOptions::FailType GetPlayerFailType( PlayerNumber pn ) const;
 
 	// character stuff
 private:
 	vector<Character*> m_pCharacters;
-
+	
 	//network private vars
-#if !defined(WITHOUT_NETWORKING)
-
+	#if !defined(WITHOUT_NETWORKING)
+	
 	HTTPHelper* m_SongBroadcastHTTP;
-#endif
+	#endif
 
 public:
 	Character* m_pCurCharacters[NUM_PLAYERS];
 
 	void ReloadCharacters();
 
-
+	
 
 
 	bool HasEarnedExtraStage() const;
@@ -277,9 +278,9 @@ public:
 		CString *pStringToFill;
 	};
 
-	void GetRankingFeats(PlayerNumber pn, vector<RankingFeat> &vFeatsOut) const;
+	void GetRankingFeats( PlayerNumber pn, vector<RankingFeat> &vFeatsOut ) const;
 	bool AnyPlayerHasRankingFeats() const;
-	void StoreRankingName(PlayerNumber pn, CString name);	// Called by name entry screens
+	void StoreRankingName( PlayerNumber pn, CString name );	// Called by name entry screens
 	vector<CString*> m_vpsNamesThatWereFilled;	// filled on StoreRankingName, 
 
 
@@ -296,7 +297,7 @@ public:
 	//
 	int m_iNumTimesThroughAttract;	// negative means play regardless of m_iAttractSoundFrequency setting
 	bool IsTimeToPlayAttractSounds() const;
-	void VisitAttractScreen(const CString sScreenName);
+	void VisitAttractScreen( const CString sScreenName );
 
 	//
 	// PlayerState
@@ -321,8 +322,8 @@ public:
 	BroadcastOnChange<StepsType> m_stEditSource;
 
 	// Workout stuff
-	float GetGoalPercentComplete(PlayerNumber pn);
-	bool IsGoalComplete(PlayerNumber pn)	{ return GetGoalPercentComplete(pn) >= 1; }
+	float GetGoalPercentComplete( PlayerNumber pn );
+	bool IsGoalComplete( PlayerNumber pn )	{ return GetGoalPercentComplete( pn ) >= 1; }
 
 	// Sync changes stuff
 	TimingData *m_pTimingDataOriginal;
@@ -333,7 +334,7 @@ public:
 	void RevertSyncChanges();
 
 	// Lua
-	void PushSelf(lua_State *L);
+	void PushSelf( lua_State *L );
 };
 
 
@@ -343,26 +344,26 @@ extern GameState*	GAMESTATE;	// global and accessable from anywhere in our progr
 #endif
 
 /*
-* (c) 2001-2004 Chris Danford, Glenn Maynard, Chris Gomez
-* All rights reserved.
-*
-* Permission is hereby granted, free of charge, to any person obtaining a
-* copy of this software and associated documentation files (the
-* "Software"), to deal in the Software without restriction, including
-* without limitation the rights to use, copy, modify, merge, publish,
-* distribute, and/or sell copies of the Software, and to permit persons to
-* whom the Software is furnished to do so, provided that the above
-* copyright notice(s) and this permission notice appear in all copies of
-* the Software and that both the above copyright notice(s) and this
-* permission notice appear in supporting documentation.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
-* THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
-* INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
-* OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
-* OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
-* OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-* PERFORMANCE OF THIS SOFTWARE.
-*/
+ * (c) 2001-2004 Chris Danford, Glenn Maynard, Chris Gomez
+ * All rights reserved.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, provided that the above
+ * copyright notice(s) and this permission notice appear in all copies of
+ * the Software and that both the above copyright notice(s) and this
+ * permission notice appear in supporting documentation.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+ * THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
+ * INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
+ * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */

--- a/src/HTTPHelper.cpp
+++ b/src/HTTPHelper.cpp
@@ -21,12 +21,12 @@ CString HTTPHelper::SubmitPostRequest(const CString &URL, const CString &PostDat
 
 				wSocket.close();
 				wSocket.create();
-				wSocket.setTimeout(0,250000); //one second timeout
+				wSocket.setTimeout(3,0); //three second timeout
 
 				wSocket.blocking = false;
 				if( !wSocket.connect( Server, (short) Port ) )
 				{
-					LOG->Debug("HTTPHelper::SubmitPostRequest failed to connect to %s:%d ", Server,Port);
+					LOG->Info("HTTPHelper::SubmitPostRequest failed to connect to %s:%d ", Server,Port);
 					return sBUFFER;
 				}
 				//Produce HTTP POST broadcast
@@ -108,8 +108,10 @@ void HTTPHelper::Threaded_SubmitPostRequest(const CString &myURL, const CString 
 CString HTTPHelper::GetThreadedResult()
 {
 	m_ResultLock->Lock();
-	return _retBuffer;
+	CString ret (_retBuffer);
 	m_ResultLock->Unlock();
+	return ret;
+	
 }
 
 bool HTTPHelper::ParseHTTPAddress( const CString &URL, CString &sProto, CString &sServer, int &iPort, CString &sAddress )
@@ -156,7 +158,7 @@ CString HTTPHelper::URLEncode( const CString &URL, bool force )
 			Output+=t;
 		}
 		else
-			Output += "%" + ssprintf( "%X", t );
+			Output += "%" + ssprintf( "%X", t&0xFF );
 	}
 	return Output;
 }

--- a/src/HTTPHelper.cpp
+++ b/src/HTTPHelper.cpp
@@ -6,6 +6,7 @@ CString HTTPHelper::SubmitPostRequest(const CString &URL, const CString &PostDat
 	CString sBUFFER = "";
 	#if !defined(WITHOUT_NETWORKING)
 		EzSockets wSocket;
+		//w
 		CString Proto;
 		CString Server;
 		int Port=80;
@@ -21,9 +22,9 @@ CString HTTPHelper::SubmitPostRequest(const CString &URL, const CString &PostDat
 
 				wSocket.close();
 				wSocket.create();
-				wSocket.setTimeout(3,0); //three second timeout
-
-				wSocket.blocking = false;
+				wSocket.setTimeout(0,250000); //acceptable timeout
+				wSocket.setBlocking(true);
+				
 				if( !wSocket.connect( Server, (short) Port ) )
 				{
 					LOG->Info("HTTPHelper::SubmitPostRequest failed to connect to %s:%d ", Server,Port);
@@ -43,21 +44,24 @@ CString HTTPHelper::SubmitPostRequest(const CString &URL, const CString &PostDat
 
 				wSocket.SendData( Header.c_str(), Header.length() );
 
+				wSocket.setBlocking(false);
 				int BytesGot=0;
 
 				while(1)
 				{
 					char res[HTTP_CHUNK_SIZE];
+					
+					//WHY IS THIS BLOCKING UNTIL TIMEOUT OCCURS?!
 					int iSize = wSocket.ReadData( res, HTTP_CHUNK_SIZE );
 					if( iSize <= 0 )
 						break;
+					
 
 					sBUFFER.append( res, iSize );
 					BytesGot += iSize;
 					if( iSize < HTTP_CHUNK_SIZE )
 						break;
 				}
-
 				wSocket.close();
 		}
 		else

--- a/src/HTTPHelper.cpp
+++ b/src/HTTPHelper.cpp
@@ -27,7 +27,7 @@ CString HTTPHelper::SubmitPostRequest(const CString &URL, const CString &PostDat
 				
 				if( !wSocket.connect( Server, (short) Port ) )
 				{
-					LOG->Info("HTTPHelper::SubmitPostRequest failed to connect to %s:%d ", Server,Port);
+					LOG->Warn("HTTPHelper::SubmitPostRequest failed to connect to %s:%d ", Server.c_str(),Port);
 					return sBUFFER;
 				}
 				//Produce HTTP POST broadcast
@@ -66,7 +66,7 @@ CString HTTPHelper::SubmitPostRequest(const CString &URL, const CString &PostDat
 		}
 		else
 		{
-			LOG->Debug("HTTPHelper::SubmitPostRequest could not parse %s ", URL);
+			LOG->Warn("HTTPHelper::SubmitPostRequest could not parse %s ", URL.c_str());
 		}
 	#endif
 

--- a/src/HTTPHelper.cpp
+++ b/src/HTTPHelper.cpp
@@ -14,7 +14,7 @@ CString HTTPHelper::SubmitPostRequest(const CString &URL, const CString &PostDat
 
 		if( HTTPHelper::ParseHTTPAddress( URL, Proto, Server, Port, sAddress)  )
 		{
-				sAddress = HTTPHelper::URLEncode( sAddress );
+				//sAddress = HTTPHelper::URLEncode( sAddress );
 
 				if ( sAddress != "/" )
 					sAddress = "/" + sAddress;
@@ -143,7 +143,7 @@ bool HTTPHelper::ParseHTTPAddress( const CString &URL, CString &sProto, CString 
 	return true;
 }
 
-CString HTTPHelper::URLEncode( const CString &URL )
+CString HTTPHelper::URLEncode( const CString &URL, bool force )
 {
 	CString Input = StripOutContainers( URL );
 	CString Output;
@@ -151,7 +151,7 @@ CString HTTPHelper::URLEncode( const CString &URL )
 	for( unsigned k = 0; k < Input.size(); k++ )
 	{
 		char t = Input.at( k );
-		if ( ( t >= '!' ) && ( t <= 'z' ) )
+		if ( (( t >= '0' ) && ( t <= 'z' )) && force==false )
 		{
 			Output+=t;
 		}

--- a/src/HTTPHelper.cpp
+++ b/src/HTTPHelper.cpp
@@ -1,0 +1,190 @@
+#include "global.h"
+#include "HTTPHelper.h"
+
+CString HTTPHelper::SubmitPostRequest(const CString &URL, const CString &PostData)
+{
+	CString sBUFFER = "";
+	#if !defined(WITHOUT_NETWORKING)
+		EzSockets wSocket;
+		CString Proto;
+		CString Server;
+		int Port=80;
+		CString sAddress;
+	
+
+		if( HTTPHelper::ParseHTTPAddress( URL, Proto, Server, Port, sAddress)  )
+		{
+				sAddress = HTTPHelper::URLEncode( sAddress );
+
+				if ( sAddress != "/" )
+					sAddress = "/" + sAddress;
+
+				wSocket.close();
+				wSocket.create();
+				wSocket.setTimeout(0,250000); //one second timeout
+
+				wSocket.blocking = false;
+				if( !wSocket.connect( Server, (short) Port ) )
+				{
+					LOG->Debug("HTTPHelper::SubmitPostRequest failed to connect to %s:%d ", Server,Port);
+					return sBUFFER;
+				}
+				//Produce HTTP POST broadcast
+
+				CString Header="";
+
+				Header = "POST "+ sAddress + " HTTP/1.1\r\n";
+				Header+= "Host: " + Server + "\r\n";
+				Header+= "User-Agent: OpenITG/1.0.0\r\n";
+				Header+= "Accept: */*\r\n";
+				Header+= "Content-Length: " + SSTR( strlen(PostData.c_str() ) ) + "\r\n";
+				Header+= "Content-Type: application/x-www-form-urlencoded\r\n\r\n";
+				Header+= PostData;
+
+				wSocket.SendData( Header.c_str(), Header.length() );
+
+				int BytesGot=0;
+
+				while(1)
+				{
+					char res[HTTP_CHUNK_SIZE];
+					int iSize = wSocket.ReadData( res, HTTP_CHUNK_SIZE );
+					if( iSize <= 0 )
+						break;
+
+					sBUFFER.append( res, iSize );
+					BytesGot += iSize;
+					if( iSize < HTTP_CHUNK_SIZE )
+						break;
+				}
+
+				wSocket.close();
+		}
+		else
+		{
+			LOG->Debug("HTTPHelper::SubmitPostRequest could not parse %s ", URL);
+		}
+	#endif
+
+	return sBUFFER;
+}
+
+HTTPHelper::HTTPHelper()
+{
+	_URL="";
+	_PostData="";
+	_retBuffer="";
+	m_ResultLock = new RageMutex("ResultLock");
+}
+
+HTTPHelper::~HTTPHelper()
+{
+	delete m_ResultLock;
+	//delete _URL;
+	//delete _PostData;
+	//delete _retBuffer;
+}
+
+
+//Wrapper of function to the submit post request so we can use a mutex on the result
+void HTTPHelper::Threaded_SubmitPostRequest_Thread_Wrapper()
+{
+	m_ResultLock->Lock();
+	_retBuffer=SubmitPostRequest(_URL,_PostData);
+	m_ResultLock->Unlock();
+}
+
+//Starts a threaded version of SubmitPostRequest -- Game can continue immediatly
+void HTTPHelper::Threaded_SubmitPostRequest(const CString &myURL, const CString &myPostData)
+{
+	RageThread HTTPThread;
+	_URL=myURL;
+	_PostData=myPostData;
+	HTTPThread.SetName("HTTPThread_SubmitPostRequest");
+	HTTPThread.Create(Threaded_SubmitPostRequest_Start, this);
+}
+
+//Returns the result stored in an object after the mutex has been released
+CString HTTPHelper::GetThreadedResult()
+{
+	m_ResultLock->Lock();
+	return _retBuffer;
+	m_ResultLock->Unlock();
+}
+
+bool HTTPHelper::ParseHTTPAddress( const CString &URL, CString &sProto, CString &sServer, int &iPort, CString &sAddress )
+{
+	// [PROTO://]SERVER[:PORT][/URL]
+
+	Regex re(
+		"^([A-Z]+)://" // [0]: HTTP://
+		"([^/:]+)"     // [1]: a.b.com
+		"(:([0-9]+))?" // [2], [3]: :1234 (optional, default 80)
+		"(/(.*))?$");    // [4], [5]: /foo.html (optional)
+
+	vector<CString> asMatches;
+	if( !re.Compare( URL, asMatches ) )
+		return false;
+	ASSERT( asMatches.size() == 6 );
+
+	sProto = asMatches[0];
+	sServer = asMatches[1];
+	if( asMatches[3] != "" )
+	{
+		iPort = atoi(asMatches[3]);
+		if( iPort == 0 )
+			return false;
+	}
+	else
+		iPort = 80;
+
+	sAddress = asMatches[5];
+
+	return true;
+}
+
+CString HTTPHelper::URLEncode( const CString &URL )
+{
+	CString Input = StripOutContainers( URL );
+	CString Output;
+
+	for( unsigned k = 0; k < Input.size(); k++ )
+	{
+		char t = Input.at( k );
+		if ( ( t >= '!' ) && ( t <= 'z' ) )
+		{
+			Output+=t;
+		}
+		else
+			Output += "%" + ssprintf( "%X", t );
+	}
+	return Output;
+}
+
+CString HTTPHelper::StripOutContainers( const CString & In )
+{
+	if( In.size() == 0 )
+		return "";
+
+	unsigned i = 0;
+	char t = In.at(i);
+	while( t == ' ' && i < In.length() )
+	{
+		t = In.at(++i);
+	}
+
+	if( t == '\"' || t == '\'' )
+	{
+		unsigned j = i+1; 
+		char u = In.at(j);
+		while( u != t && j < In.length() )
+		{
+			u = In.at(++j);
+		}
+		if( j == i )
+			return StripOutContainers( In.substr(i+1) );
+		else
+			return StripOutContainers( In.substr(i+1, j-i-1) );
+	}
+	return In.substr( i );
+}

--- a/src/HTTPHelper.h
+++ b/src/HTTPHelper.h
@@ -1,0 +1,40 @@
+#ifndef HTTPHelper_H
+#define HTTPHelper_H
+
+#include "global.h" // StepMania only includes
+#include "ezsockets.h"
+#include "RageUtil.h"
+#include "RageLog.h"
+#include "RageThreads.h"
+#include <sstream>
+#define HTTP_CHUNK_SIZE 256
+#define SSTR( x ) static_cast< std::ostringstream & >( \
+        ( std::ostringstream() << std::dec << x ) ).str()
+
+class HTTPHelper
+{
+public:
+
+	HTTPHelper();
+	~HTTPHelper();
+	//True if proper string, false if improper
+	static bool ParseHTTPAddress( const CString & URL, CString & Proto, CString & Server, int & Port, CString & Addy );
+	static CString URLEncode( const CString &URL );			//Encode any string in URL-style
+	static CString StripOutContainers( const CString & In );	//Strip off "'s and ''s
+	static CString SubmitPostRequest( const CString &URL, const CString &PostData ); // Sends a URL Post Request
+	void Threaded_SubmitPostRequest( const CString &URL, const CString &PostData ); // Sends a URL Post Request
+	CString GetThreadedResult();
+
+	
+private:
+	static CString HTTPThread_SubmitPostRequest( const CString &URL, const CString &PostData ); // Sends a URL Post Request
+	void Threaded_SubmitPostRequest_Thread_Wrapper(); //wrapper for mutex use
+	static int Threaded_SubmitPostRequest_Start(void *p) { ((HTTPHelper *)p)->Threaded_SubmitPostRequest_Thread_Wrapper(); return 0; };
+
+	CString _URL;
+	CString _PostData;
+	CString _retBuffer;
+	RageMutex *m_ResultLock;
+};
+
+#endif

--- a/src/HTTPHelper.h
+++ b/src/HTTPHelper.h
@@ -7,7 +7,7 @@
 #include "RageLog.h"
 #include "RageThreads.h"
 #include <sstream>
-#define HTTP_CHUNK_SIZE 256
+#define HTTP_CHUNK_SIZE 1024 //matches EZSockets
 #define SSTR( x ) static_cast< std::ostringstream & >( \
         ( std::ostringstream() << std::dec << x ) ).str()
 

--- a/src/HTTPHelper.h
+++ b/src/HTTPHelper.h
@@ -19,7 +19,7 @@ public:
 	~HTTPHelper();
 	//True if proper string, false if improper
 	static bool ParseHTTPAddress( const CString & URL, CString & Proto, CString & Server, int & Port, CString & Addy );
-	static CString URLEncode( const CString &URL );			//Encode any string in URL-style
+	static CString URLEncode( const CString &URL, bool force=false );			//Encode any string in URL-style
 	static CString StripOutContainers( const CString & In );	//Strip off "'s and ''s
 	static CString SubmitPostRequest( const CString &URL, const CString &PostData ); // Sends a URL Post Request
 	void Threaded_SubmitPostRequest( const CString &URL, const CString &PostData ); // Sends a URL Post Request

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -423,7 +423,7 @@ ProductInfo.cpp ProductInfo.h
 
 if !WITHOUT_NETWORKING
 # Compile NetworkSyncManager even if networking is disabled; it'll stub itself.
-GlobalSingletons += ezsockets.cpp ezsockets.h
+GlobalSingletons += ezsockets.cpp ezsockets.h HTTPHelper.cpp HTTPHelper.h
 endif
 
 ibutton = \

--- a/src/MsdFile.cpp
+++ b/src/MsdFile.cpp
@@ -118,6 +118,29 @@ void MsdFile::ReadBuf( char *buf, int len )
 		AddParam(buf+value_start, i - value_start);
 }
 
+//static helper for other features
+CString MsdFile::ReadFileIntoString(CString sNewPath)
+{
+	RageFile f;
+	/* Open file. */
+	if( !f.Open( sNewPath ) )
+	{
+		return NULL;
+	}
+
+	// allocate a string to hold the file
+	CString FileString;
+	FileString.reserve( f.GetFileSize() );
+
+	int iBytesRead = f.Read( FileString );
+	if( iBytesRead == -1 )
+	{
+		return NULL;
+	}
+	return FileString;
+
+}
+
 // returns true if successful, false otherwise
 bool MsdFile::ReadFile( CString sNewPath )
 {

--- a/src/MsdFile.h
+++ b/src/MsdFile.h
@@ -20,6 +20,8 @@ public:
 	bool ReadFile( CString sFilePath );
 	void ReadFromString( const CString &sString );
 
+	static CString ReadFileIntoString(CString sNewPath);
+
 	CString GetError() const { return error; }
 
 	unsigned GetNumValues() const { return values.size(); }

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -585,7 +585,8 @@ void ProfileManager::AddStepsScore( const Song* pSong, const Steps* pSteps, Play
 	//broadcast score to db if it's not an edit from the card or a custom song -- could put something inappropriate in there
 	//if we have networking
 	#if !defined(WITHOUT_NETWORKING)
-	if( PROFILEMAN->IsPersistentProfile(pn) ) // anonymous profiles keep generating guids and polluting the database, higher collission potential. Require a USB for score to broadcast
+	// anonymous profiles keep generating guids and polluting the database, higher collission potential. Require a USB for score to broadcast
+	if( PROFILEMAN->ProfileWasLoadedFromMemoryCard(pn) ) 
 	{
 		if( !pSteps->IsAPlayerEdit() && !pSong->IsCustomSong() )
 		{

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -585,86 +585,89 @@ void ProfileManager::AddStepsScore( const Song* pSong, const Steps* pSteps, Play
 	//broadcast score to db if it's not an edit from the card or a custom song -- could put something inappropriate in there
 	//if we have networking
 	#if !defined(WITHOUT_NETWORKING)
-	if( !pSteps->IsAPlayerEdit() && !pSong->IsCustomSong() )
+	if( PROFILEMAN->IsPersistentProfile(pn) ) // anonymous profiles keep generating guids and polluting the database, higher collission potential. Require a USB for score to broadcast
 	{
-		char temp[50];
-		
-		CString sHSName = HTTPHelper::URLEncode(hs.sName);
-		Profile* pProfile = PROFILEMAN->GetProfile(pn);
-		if( pProfile && !pProfile->m_sLastUsedHighScoreName.empty() )
+		if( !pSteps->IsAPlayerEdit() && !pSong->IsCustomSong() )
 		{
-			sHSName = HTTPHelper::URLEncode(pProfile->m_sLastUsedHighScoreName);
-		}
-		CString sTitle = HTTPHelper::URLEncode(pSong->GetTranslitFullTitle(),true);
-		CString sArtist = HTTPHelper::URLEncode(pSong->GetDisplayArtist(),true);
-		CString sDir (HTTPHelper::URLEncode(pSong->GetSongDir()));
+			char temp[50];
 		
-		sprintf(temp, "%d", pSteps->GetDifficulty());
-		CString sDifficulty=HTTPHelper::URLEncode(temp);
-		//LOG->Info("ProfileManager::AddStepsScore Check diff %s",sDifficulty.c_str());
+			CString sHSName = HTTPHelper::URLEncode(hs.sName);
+			Profile* pProfile = PROFILEMAN->GetProfile(pn);
+			if( pProfile && !pProfile->m_sLastUsedHighScoreName.empty() )
+			{
+				sHSName = HTTPHelper::URLEncode(pProfile->m_sLastUsedHighScoreName);
+			}
+			CString sTitle = HTTPHelper::URLEncode(pSong->GetTranslitFullTitle(),true);
+			CString sArtist = HTTPHelper::URLEncode(pSong->GetDisplayArtist(),true);
+			CString sDir (HTTPHelper::URLEncode(pSong->GetSongDir()));
 		
-		StepsType st = pSteps->m_StepsType;
-		CString sStepType="0";
-		switch (st)
-		{
-			case STEPS_TYPE_DANCE_DOUBLE:
-			case STEPS_TYPE_PUMP_HALFDOUBLE:
-			case STEPS_TYPE_PUMP_DOUBLE:
-			case STEPS_TYPE_EZ2_DOUBLE:
-			case STEPS_TYPE_BM_DOUBLE5:
-			case STEPS_TYPE_BM_DOUBLE7:
-			case STEPS_TYPE_MANIAX_DOUBLE:
-			case STEPS_TYPE_TECHNO_DOUBLE4:
-			case STEPS_TYPE_TECHNO_DOUBLE5:
-				sStepType="1";
-				break;
-			default:
-				break;
-		}
-		sStepType= HTTPHelper::URLEncode(sStepType);
+			sprintf(temp, "%d", pSteps->GetDifficulty());
+			CString sDifficulty=HTTPHelper::URLEncode(temp);
+			//LOG->Info("ProfileManager::AddStepsScore Check diff %s",sDifficulty.c_str());
 		
-		sprintf(temp, "%d", hs.grade);
-		CString sGrade=HTTPHelper::URLEncode(temp);
+			StepsType st = pSteps->m_StepsType;
+			CString sStepType="0";
+			switch (st)
+			{
+				case STEPS_TYPE_DANCE_DOUBLE:
+				case STEPS_TYPE_PUMP_HALFDOUBLE:
+				case STEPS_TYPE_PUMP_DOUBLE:
+				case STEPS_TYPE_EZ2_DOUBLE:
+				case STEPS_TYPE_BM_DOUBLE5:
+				case STEPS_TYPE_BM_DOUBLE7:
+				case STEPS_TYPE_MANIAX_DOUBLE:
+				case STEPS_TYPE_TECHNO_DOUBLE4:
+				case STEPS_TYPE_TECHNO_DOUBLE5:
+					sStepType="1";
+					break;
+				default:
+					break;
+			}
+			sStepType= HTTPHelper::URLEncode(sStepType);
+		
+			sprintf(temp, "%d", hs.grade);
+			CString sGrade=HTTPHelper::URLEncode(temp);
 
-		sprintf(temp, "%f", hs.fPercentDP);
-		CString sPercent=HTTPHelper::URLEncode(temp);
+			sprintf(temp, "%f", hs.fPercentDP);
+			CString sPercent=HTTPHelper::URLEncode(temp);
 		
-		sprintf(temp, "%d", hs.iScore);
-		CString sScore= HTTPHelper::URLEncode(temp);
+			sprintf(temp, "%d", hs.iScore);
+			CString sScore= HTTPHelper::URLEncode(temp);
 
-		CString sPlayerGUID =  "0";
+			CString sPlayerGUID =  "0";
 
-		if( pProfile )
-		{
-			sPlayerGUID =  HTTPHelper::URLEncode(PROFILEMAN->GetProfile(pn)->m_sGuid);
+			if( pProfile )
+			{
+				sPlayerGUID =  HTTPHelper::URLEncode(PROFILEMAN->GetProfile(pn)->m_sGuid);
+			}
+		
+			CString sMachineGUID = HTTPHelper::URLEncode(hs.sMachineGuid);
+			CString sEventMode = "0";
+			if (GAMESTATE->IsEventMode()) sEventMode = "1";
+		
+
+			CString sMD5Sum = MsdFile::ReadFileIntoString(pSong->GetSongFilePath());
+			if(sMD5Sum==NULL)
+			{
+				sMD5Sum=sDir;
+				sMD5Sum.append(sMachineGUID);
+			}
+			sMD5Sum= HTTPHelper::URLEncode(NSMAN->MD5Hex(sMD5Sum));
+
+			CString sDataToSend="machineguid="+sMachineGUID+"&path="+sDir+"&smfilemd5="+sMD5Sum+"&title="+sTitle+"&artist="+sArtist+"&playerguid="+sPlayerGUID+"&eventmode="+sEventMode+"&difficulty="+sDifficulty+"&steptype="+sStepType+"&name="+sHSName+"&score="+sScore+"&percent="+sPercent+"&grade="+sGrade+"";
+			LOG->Info("ProfileManager::AddStepsScore Want to send %s to %s",sDataToSend.c_str(), m_sScoreBroadcastURL.c_str());
+		
+			//and we have a broadcast URL...
+			if (m_sScoreBroadcastURL.length()>3)
+			{
+				m_ScoreBroadcastHTTP->Threaded_SubmitPostRequest(m_sScoreBroadcastURL, sDataToSend);
+				//LOG->Info("ProfileManager::AddStepsScore sent!!");
+				//CString res = m_ScoreBroadcastHTTP->GetThreadedResult();
+				//LOG->Info("ProfileManager::AddStepsScore res: %s",res.c_str());
+			}
+		
+		
 		}
-		
-		CString sMachineGUID = HTTPHelper::URLEncode(hs.sMachineGuid);
-		CString sEventMode = "0";
-		if (GAMESTATE->IsEventMode()) sEventMode = "1";
-		
-
-		CString sMD5Sum = MsdFile::ReadFileIntoString(pSong->GetSongFilePath());
-		if(sMD5Sum==NULL)
-		{
-			sMD5Sum=sDir;
-			sMD5Sum.append(sMachineGUID);
-		}
-		sMD5Sum= HTTPHelper::URLEncode(NSMAN->MD5Hex(sMD5Sum));
-
-		CString sDataToSend="machineguid="+sMachineGUID+"&path="+sDir+"&md5="+sMD5Sum+"&title="+sTitle+"&artist="+sArtist+"&playerguid="+sPlayerGUID+"&eventmode="+sEventMode+"&difficulty="+sDifficulty+"&steptype="+sStepType+"&name="+sHSName+"&score="+sScore+"&percent="+sPercent+"&grade="+sGrade+"";
-		LOG->Info("ProfileManager::AddStepsScore Want to send %s to %s",sDataToSend.c_str(), m_sScoreBroadcastURL.c_str());
-		
-		//and we have a broadcast URL...
-		if (m_sScoreBroadcastURL.length()>3)
-		{
-			m_ScoreBroadcastHTTP->Threaded_SubmitPostRequest(m_sScoreBroadcastURL, sDataToSend);
-			//LOG->Info("ProfileManager::AddStepsScore sent!!");
-			//CString res = m_ScoreBroadcastHTTP->GetThreadedResult();
-			//LOG->Info("ProfileManager::AddStepsScore res: %s",res.c_str());
-		}
-		
-		
 	}
 	#endif
 }

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -639,10 +639,6 @@ void ProfileManager::AddStepsScore( const Song* pSong, const Steps* pSteps, Play
 			CString res = m_ScoreBroadcastHTTP->GetThreadedResult();
 			LOG->Info("ProfileManager::AddStepsScore res: %s",res.c_str());
 		}
-		else
-		{
-			//LOG->Info("ProfileManager::AddStepsScore too short!!");
-		}
 		
 		
 	}

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -603,7 +603,6 @@ void ProfileManager::AddStepsScore( const Song* pSong, const Steps* pSteps, Play
 		
 			sprintf(temp, "%d", pSteps->GetDifficulty());
 			CString sDifficulty=HTTPHelper::URLEncode(temp);
-			//LOG->Info("ProfileManager::AddStepsScore Check diff %s",sDifficulty.c_str());
 		
 			StepsType st = pSteps->m_StepsType;
 			CString sStepType="0";
@@ -655,7 +654,7 @@ void ProfileManager::AddStepsScore( const Song* pSong, const Steps* pSteps, Play
 			sMD5Sum= HTTPHelper::URLEncode(NSMAN->MD5Hex(sMD5Sum));
 
 			CString sDataToSend="machineguid="+sMachineGUID+"&path="+sDir+"&smfilemd5="+sMD5Sum+"&title="+sTitle+"&artist="+sArtist+"&playerguid="+sPlayerGUID+"&eventmode="+sEventMode+"&difficulty="+sDifficulty+"&steptype="+sStepType+"&name="+sHSName+"&score="+sScore+"&percent="+sPercent+"&grade="+sGrade+"";
-			LOG->Info("ProfileManager::AddStepsScore Want to send %s to %s",sDataToSend.c_str(), m_sScoreBroadcastURL.c_str());
+			//LOG->Info("ProfileManager::AddStepsScore Want to send %s to %s",sDataToSend.c_str(), m_sScoreBroadcastURL.c_str());
 		
 			//and we have a broadcast URL...
 			if (m_sScoreBroadcastURL.length()>3)

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -627,13 +627,19 @@ void ProfileManager::AddStepsScore( const Song* pSong, const Steps* pSteps, Play
 		sprintf(temp, "%d", hs.iScore);
 		CString sScore= HTTPHelper::URLEncode(temp);
 
-		CString MD5Sum =  HTTPHelper::URLEncode(NSMAN->MD5Hex(MsdFile::ReadFileIntoString(pSong->GetSongFilePath())));
-
 		CString sPlayerGUID =  HTTPHelper::URLEncode(PROFILEMAN->GetProfile(pn)->m_sGuid);
 		CString sMachineGUID = HTTPHelper::URLEncode(hs.sMachineGuid);
 		CString sEventMode = "0";
 		if (GAMESTATE->IsEventMode()) sEventMode = "1";
 		
+
+		CString sMD5Sum = MsdFile::ReadFileIntoString(pSong->GetSongFilePath());
+		if(sMD5Sum==NULL)
+		{
+			sMD5Sum=sDir;
+			sMD5Sum.append(sMachineGUID);
+		}
+		sMD5Sum= HTTPHelper::URLEncode(NSMAN->MD5Hex(sMD5Sum));
 
 		CString sDataToSend="machineguid="+sMachineGUID+"&path="+sDir+"&md5="+MD5Sum+"&title="+sTitle+"&artist="+sArtist+"&playerguid="+sPlayerGUID+"&eventmode="+sEventMode+"&difficulty="+sDifficulty+"&steptype="+sStepType+"&name="+sHSName+"&score="+sScore+"&percent="+sPercent+"&grade="+sGrade+"";
 		LOG->Info("ProfileManager::AddStepsScore Want to send %s to %s",sDataToSend.c_str(), m_sScoreBroadcastURL.c_str());

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -588,6 +588,7 @@ void ProfileManager::AddStepsScore( const Song* pSong, const Steps* pSteps, Play
 		
 		CString sHSName = HTTPHelper::URLEncode(hs.sName);
 		CString sTitle = HTTPHelper::URLEncode(pSong->GetTranslitFullTitle(),true);
+		CString sArtist = HTTPHelper::URLEncode(pSong->GetDisplayArtist(),true);
 		CString sDir (HTTPHelper::URLEncode(pSong->GetSongDir()));
 		
 		sprintf(temp, "%d", pSteps->GetDifficulty());
@@ -623,16 +624,20 @@ void ProfileManager::AddStepsScore( const Song* pSong, const Steps* pSteps, Play
 		sprintf(temp, "%d", hs.iScore);
 		CString sScore= HTTPHelper::URLEncode(temp);
 
+		CString sPlayerGUID =  HTTPHelper::URLEncode(PROFILEMAN->GetProfile(pn)->m_sGuid);
+		CString sMachineGUID = HTTPHelper::URLEncode(hs.sMachineGuid);
 		
 
-		CString sDataToSend="key="+sDir+"&title="+sTitle+"&difficulty="+sDifficulty+"&steptype="+sStepType+"&name="+sHSName+"&score="+sScore+"&percent="+sPercent+"&grade="+sGrade+"";
-//		LOG->Info("ProfileManager::AddStepsScore Want to send %s to %s",sDataToSend.c_str(), m_sScoreBroadcastURL.c_str());
+		CString sDataToSend="machineguid="+sMachineGUID+"&key="+sDir+"&title="+sTitle+"&artist="+sArtist+"&playerguid="+sPlayerGUID+"&difficulty="+sDifficulty+"&steptype="+sStepType+"&name="+sHSName+"&score="+sScore+"&percent="+sPercent+"&grade="+sGrade+"";
+		LOG->Info("ProfileManager::AddStepsScore Want to send %s to %s",sDataToSend.c_str(), m_sScoreBroadcastURL.c_str());
 		
 		//and we have a broadcast URL...
 		if (m_sScoreBroadcastURL.length()>3)
 		{
 			m_ScoreBroadcastHTTP->Threaded_SubmitPostRequest(m_sScoreBroadcastURL, sDataToSend);
+			LOG->Info("ProfileManager::AddStepsScore sent!!");
 			CString res = m_ScoreBroadcastHTTP->GetThreadedResult();
+			LOG->Info("ProfileManager::AddStepsScore res: %s",res.c_str());
 		}
 		else
 		{

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -641,7 +641,7 @@ void ProfileManager::AddStepsScore( const Song* pSong, const Steps* pSteps, Play
 		}
 		sMD5Sum= HTTPHelper::URLEncode(NSMAN->MD5Hex(sMD5Sum));
 
-		CString sDataToSend="machineguid="+sMachineGUID+"&path="+sDir+"&md5="+MD5Sum+"&title="+sTitle+"&artist="+sArtist+"&playerguid="+sPlayerGUID+"&eventmode="+sEventMode+"&difficulty="+sDifficulty+"&steptype="+sStepType+"&name="+sHSName+"&score="+sScore+"&percent="+sPercent+"&grade="+sGrade+"";
+		CString sDataToSend="machineguid="+sMachineGUID+"&path="+sDir+"&md5="+sMD5Sum+"&title="+sTitle+"&artist="+sArtist+"&playerguid="+sPlayerGUID+"&eventmode="+sEventMode+"&difficulty="+sDifficulty+"&steptype="+sStepType+"&name="+sHSName+"&score="+sScore+"&percent="+sPercent+"&grade="+sGrade+"";
 		LOG->Info("ProfileManager::AddStepsScore Want to send %s to %s",sDataToSend.c_str(), m_sScoreBroadcastURL.c_str());
 		
 		//and we have a broadcast URL...

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -590,6 +590,11 @@ void ProfileManager::AddStepsScore( const Song* pSong, const Steps* pSteps, Play
 		char temp[50];
 		
 		CString sHSName = HTTPHelper::URLEncode(hs.sName);
+		Profile* pProfile = PROFILEMAN->GetProfile(pn);
+		if( pProfile && !pProfile->m_sLastUsedHighScoreName.empty() )
+		{
+			sHSName = HTTPHelper::URLEncode(pProfile->m_sLastUsedHighScoreName);
+		}
 		CString sTitle = HTTPHelper::URLEncode(pSong->GetTranslitFullTitle(),true);
 		CString sArtist = HTTPHelper::URLEncode(pSong->GetDisplayArtist(),true);
 		CString sDir (HTTPHelper::URLEncode(pSong->GetSongDir()));
@@ -627,7 +632,13 @@ void ProfileManager::AddStepsScore( const Song* pSong, const Steps* pSteps, Play
 		sprintf(temp, "%d", hs.iScore);
 		CString sScore= HTTPHelper::URLEncode(temp);
 
-		CString sPlayerGUID =  HTTPHelper::URLEncode(PROFILEMAN->GetProfile(pn)->m_sGuid);
+		CString sPlayerGUID =  "0";
+
+		if( pProfile )
+		{
+			sPlayerGUID =  HTTPHelper::URLEncode(PROFILEMAN->GetProfile(pn)->m_sGuid);
+		}
+		
 		CString sMachineGUID = HTTPHelper::URLEncode(hs.sMachineGuid);
 		CString sEventMode = "0";
 		if (GAMESTATE->IsEventMode()) sEventMode = "1";

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -545,6 +545,7 @@ void ProfileManager::AddStepsScore( const Song* pSong, const Steps* pSteps, Play
 
 	iPersonalIndexOut = -1;
 	iMachineIndexOut = -1;
+	
 
 	// In event mode, set the score's name immediately to the Profile's last
 	// used name.  If no profile last used name exists, use "EVNT".
@@ -630,9 +631,11 @@ void ProfileManager::AddStepsScore( const Song* pSong, const Steps* pSteps, Play
 
 		CString sPlayerGUID =  HTTPHelper::URLEncode(PROFILEMAN->GetProfile(pn)->m_sGuid);
 		CString sMachineGUID = HTTPHelper::URLEncode(hs.sMachineGuid);
+		CString sEventMode = "0";
+		if (GAMESTATE->IsEventMode()) sEventMode = "1";
 		
 
-		CString sDataToSend="machineguid="+sMachineGUID+"&path="+sDir+"&md5="+MD5Sum+"&title="+sTitle+"&artist="+sArtist+"&playerguid="+sPlayerGUID+"&difficulty="+sDifficulty+"&steptype="+sStepType+"&name="+sHSName+"&score="+sScore+"&percent="+sPercent+"&grade="+sGrade+"";
+		CString sDataToSend="machineguid="+sMachineGUID+"&path="+sDir+"&md5="+MD5Sum+"&title="+sTitle+"&artist="+sArtist+"&playerguid="+sPlayerGUID+"&eventmode="+sEventMode+"&difficulty="+sDifficulty+"&steptype="+sStepType+"&name="+sHSName+"&score="+sScore+"&percent="+sPercent+"&grade="+sGrade+"";
 		LOG->Info("ProfileManager::AddStepsScore Want to send %s to %s",sDataToSend.c_str(), m_sScoreBroadcastURL.c_str());
 		
 		//and we have a broadcast URL...

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -628,7 +628,7 @@ void ProfileManager::AddStepsScore( const Song* pSong, const Steps* pSteps, Play
 		CString sMachineGUID = HTTPHelper::URLEncode(hs.sMachineGuid);
 		
 
-		CString sDataToSend="machineguid="+sMachineGUID+"&key="+sDir+"&title="+sTitle+"&artist="+sArtist+"&playerguid="+sPlayerGUID+"&difficulty="+sDifficulty+"&steptype="+sStepType+"&name="+sHSName+"&score="+sScore+"&percent="+sPercent+"&grade="+sGrade+"";
+		CString sDataToSend="machineguid="+sMachineGUID+"&path="+sDir+"&title="+sTitle+"&artist="+sArtist+"&playerguid="+sPlayerGUID+"&difficulty="+sDifficulty+"&steptype="+sStepType+"&name="+sHSName+"&score="+sScore+"&percent="+sPercent+"&grade="+sGrade+"";
 		LOG->Info("ProfileManager::AddStepsScore Want to send %s to %s",sDataToSend.c_str(), m_sScoreBroadcastURL.c_str());
 		
 		//and we have a broadcast URL...

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -9,6 +9,8 @@
 #include "Steps.h"
 #include "MemoryCardManager.h"
 #include "Style.h"
+#include "NetworkSyncManager.h"
+#include "MsdFile.h"
 
 /* GUID generation for arcade */
 #include "DiagnosticsUtil.h"
@@ -624,20 +626,22 @@ void ProfileManager::AddStepsScore( const Song* pSong, const Steps* pSteps, Play
 		sprintf(temp, "%d", hs.iScore);
 		CString sScore= HTTPHelper::URLEncode(temp);
 
+		CString MD5Sum =  HTTPHelper::URLEncode(NSMAN->MD5Hex(MsdFile::ReadFileIntoString(pSong->GetSongFilePath())));
+
 		CString sPlayerGUID =  HTTPHelper::URLEncode(PROFILEMAN->GetProfile(pn)->m_sGuid);
 		CString sMachineGUID = HTTPHelper::URLEncode(hs.sMachineGuid);
 		
 
-		CString sDataToSend="machineguid="+sMachineGUID+"&path="+sDir+"&title="+sTitle+"&artist="+sArtist+"&playerguid="+sPlayerGUID+"&difficulty="+sDifficulty+"&steptype="+sStepType+"&name="+sHSName+"&score="+sScore+"&percent="+sPercent+"&grade="+sGrade+"";
+		CString sDataToSend="machineguid="+sMachineGUID+"&path="+sDir+"&md5="+MD5Sum+"&title="+sTitle+"&artist="+sArtist+"&playerguid="+sPlayerGUID+"&difficulty="+sDifficulty+"&steptype="+sStepType+"&name="+sHSName+"&score="+sScore+"&percent="+sPercent+"&grade="+sGrade+"";
 		LOG->Info("ProfileManager::AddStepsScore Want to send %s to %s",sDataToSend.c_str(), m_sScoreBroadcastURL.c_str());
 		
 		//and we have a broadcast URL...
 		if (m_sScoreBroadcastURL.length()>3)
 		{
 			m_ScoreBroadcastHTTP->Threaded_SubmitPostRequest(m_sScoreBroadcastURL, sDataToSend);
-			LOG->Info("ProfileManager::AddStepsScore sent!!");
-			CString res = m_ScoreBroadcastHTTP->GetThreadedResult();
-			LOG->Info("ProfileManager::AddStepsScore res: %s",res.c_str());
+			//LOG->Info("ProfileManager::AddStepsScore sent!!");
+			//CString res = m_ScoreBroadcastHTTP->GetThreadedResult();
+			//LOG->Info("ProfileManager::AddStepsScore res: %s",res.c_str());
 		}
 		
 		

--- a/src/ProfileManager.h
+++ b/src/ProfileManager.h
@@ -7,6 +7,10 @@
 #include "GameConstantsAndTypes.h"
 #include "Profile.h"
 
+#if !defined(WITHOUT_NETWORKING)
+#include "HTTPHelper.h"
+#endif
+
 class Song;
 class Style;
 struct lua_State;
@@ -117,6 +121,12 @@ private:
 	Profile	m_Profile[NUM_PLAYERS];	
 
 	Profile m_MachineProfile;
+	
+	CString			m_sScoreBroadcastURL;
+	//network private vars
+	#if !defined(WITHOUT_NETWORKING)
+	HTTPHelper* m_ScoreBroadcastHTTP;
+	#endif
 
 };
 

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -1952,7 +1952,10 @@ void ScreenGameplay::AbortGiveUp( bool bShowText )
 		return;
 
 	if ( !bShowText )
+	{
 		GAMESTATE->SetSongInProgress("(none)");
+		GAMESTATE->HTTPBroadcastSongInProgress("");
+	}
 
 	m_textDebug.StopTweening();
 	if( bShowText )
@@ -2104,6 +2107,7 @@ void ScreenGameplay::SongFinished()
 	/* Extremely important: if we don't remove attacks before moving on to the next
 	 * screen, they'll still be turned on eventually. */
 	GAMESTATE->SetSongInProgress("(none)");
+	GAMESTATE->HTTPBroadcastSongInProgress("");
 	GAMESTATE->RemoveAllActiveAttacks();
 	FOREACH_EnabledPlayer( p )
 		m_ActiveAttackList[p].Refresh();

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -856,7 +856,7 @@ void ScreenGameplay::LoadNextSong()
 	iPlaySongIndex %= m_apSongsQueue.size();
 	GAMESTATE->m_pCurSong.Set( m_apSongsQueue[iPlaySongIndex] );
 	GAMESTATE->SetSongInProgress( GAMESTATE->m_pCurSong->GetSongDir() ); //song simfile dir
-	GAMESTATE->HTTPBroadcastSongInProgress(GAMESTATE->m_pCurSong->GetTranslitFullTitle().c_str()); //song title
+	GAMESTATE->HTTPBroadcastSongInProgress();
 	STATSMAN->m_CurStageStats.vpPlayedSongs.push_back( GAMESTATE->m_pCurSong );
 
 	// No need to do this here.  We do it in SongFinished().

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -1954,7 +1954,7 @@ void ScreenGameplay::AbortGiveUp( bool bShowText )
 	if ( !bShowText )
 	{
 		GAMESTATE->SetSongInProgress("(none)");
-		GAMESTATE->HTTPBroadcastSongInProgress("");
+		GAMESTATE->HTTPBroadcastSongInProgress(true);
 	}
 
 	m_textDebug.StopTweening();
@@ -2107,7 +2107,7 @@ void ScreenGameplay::SongFinished()
 	/* Extremely important: if we don't remove attacks before moving on to the next
 	 * screen, they'll still be turned on eventually. */
 	GAMESTATE->SetSongInProgress("(none)");
-	GAMESTATE->HTTPBroadcastSongInProgress("");
+	GAMESTATE->HTTPBroadcastSongInProgress(true);
 	GAMESTATE->RemoveAllActiveAttacks();
 	FOREACH_EnabledPlayer( p )
 		m_ActiveAttackList[p].Refresh();

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -855,7 +855,8 @@ void ScreenGameplay::LoadNextSong()
 	int iPlaySongIndex = GAMESTATE->GetCourseSongIndex();
 	iPlaySongIndex %= m_apSongsQueue.size();
 	GAMESTATE->m_pCurSong.Set( m_apSongsQueue[iPlaySongIndex] );
-	GAMESTATE->SetSongInProgress( GAMESTATE->m_pCurSong->GetSongDir() );
+	GAMESTATE->SetSongInProgress( GAMESTATE->m_pCurSong->GetSongDir() ); //song simfile dir
+	GAMESTATE->HTTPBroadcastSongInProgress(GAMESTATE->m_pCurSong->GetTranslitFullTitle().c_str()); //song title
 	STATSMAN->m_CurStageStats.vpPlayedSongs.push_back( GAMESTATE->m_pCurSong );
 
 	// No need to do this here.  We do it in SongFinished().

--- a/src/ScreenPackages.cpp
+++ b/src/ScreenPackages.cpp
@@ -18,138 +18,138 @@
 #define	NUM_PACKAGES_SHOW			THEME->GetMetricI(m_sName,"NumPackagesShow")
 #define NUM_LINKS_SHOW				THEME->GetMetricI(m_sName,"NumLinksShow")
 
-AutoScreenMessage( SM_BackFromURL )
+AutoScreenMessage(SM_BackFromURL)
 
-REGISTER_SCREEN_CLASS( ScreenPackages );
-ScreenPackages::ScreenPackages( CString sClassName ) : ScreenWithMenuElements( sClassName )
+REGISTER_SCREEN_CLASS(ScreenPackages);
+ScreenPackages::ScreenPackages(CString sClassName) : ScreenWithMenuElements(sClassName)
 {
 }
 
 void ScreenPackages::Init()
 {
 	ScreenWithMenuElements::Init();
-	
+
 	m_iPackagesPos = 0;
 	m_iLinksPos = 0;
 	m_iDLorLST = 0;
 	m_bIsDownloading = false;
-	m_bCanDL = THEME->GetMetricB( m_sName, "CanDL" );
+	m_bCanDL = THEME->GetMetricB(m_sName, "CanDL");
 	m_sStatus = "";
 	m_fLastUpdate = 0;
 	m_iTotalBytes = 0;
 	m_iDownloaded = 0;
 
-	FOREACH_PlayerNumber( pn )
+	FOREACH_PlayerNumber(pn)
 		GAMESTATE->m_bSideIsJoined[pn] = true;
 
-	m_sprExistingBG.SetName( "PackagesBG" );
-	m_sprExistingBG.Load( THEME->GetPathG( m_sName, "PackagesBG" ) );
-	SET_XY_AND_ON_COMMAND( m_sprExistingBG );
-	this->AddChild( &m_sprExistingBG );
+	m_sprExistingBG.SetName("PackagesBG");
+	m_sprExistingBG.Load(THEME->GetPathG(m_sName, "PackagesBG"));
+	SET_XY_AND_ON_COMMAND(m_sprExistingBG);
+	this->AddChild(&m_sprExistingBG);
 
-	m_sprWebBG.SetName( "WebBG" );
-	m_sprWebBG.Load( THEME->GetPathG( m_sName, "WebBG" ) );
-	SET_XY_AND_ON_COMMAND( m_sprWebBG );
-	this->AddChild( &m_sprWebBG );
+	m_sprWebBG.SetName("WebBG");
+	m_sprWebBG.Load(THEME->GetPathG(m_sName, "WebBG"));
+	SET_XY_AND_ON_COMMAND(m_sprWebBG);
+	this->AddChild(&m_sprWebBG);
 
-	COMMAND( m_sprExistingBG, "Back" );
-	COMMAND( m_sprWebBG, "Away" );
+	COMMAND(m_sprExistingBG, "Back");
+	COMMAND(m_sprWebBG, "Away");
 
-//	m_fOutputFile.
-	m_textPackages.LoadFromFont( THEME->GetPathF(m_sName,"default") );
-	m_textPackages.SetShadowLength( 0 );
-	m_textPackages.SetName( "Packages" );
-	m_textPackages.SetMaxWidth( EXISTINGBG_WIDTH );
-	SET_XY_AND_ON_COMMAND( m_textPackages );
-	this->AddChild( &m_textPackages );
+	//	m_fOutputFile.
+	m_textPackages.LoadFromFont(THEME->GetPathF(m_sName, "default"));
+	m_textPackages.SetShadowLength(0);
+	m_textPackages.SetName("Packages");
+	m_textPackages.SetMaxWidth(EXISTINGBG_WIDTH);
+	SET_XY_AND_ON_COMMAND(m_textPackages);
+	this->AddChild(&m_textPackages);
 	RefreshPackages();
 
-	m_textWeb.LoadFromFont( THEME->GetPathF(m_sName,"default") );
-	m_textWeb.SetShadowLength( 0 );
-	m_textWeb.SetName( "Web" );
-	m_textWeb.SetMaxWidth( WEBBG_WIDTH );
-	SET_XY_AND_ON_COMMAND( m_textWeb );
-	this->AddChild( &m_textWeb);
-	m_Links.push_back( " " );
-	m_LinkTitles.push_back( "--Visit URL--" );
+	m_textWeb.LoadFromFont(THEME->GetPathF(m_sName, "default"));
+	m_textWeb.SetShadowLength(0);
+	m_textWeb.SetName("Web");
+	m_textWeb.SetMaxWidth(WEBBG_WIDTH);
+	SET_XY_AND_ON_COMMAND(m_textWeb);
+	this->AddChild(&m_textWeb);
+	m_Links.push_back(" ");
+	m_LinkTitles.push_back("--Visit URL--");
 
-	m_textURL.LoadFromFont( THEME->GetPathF( m_sName,"default") );
-	m_textURL.SetShadowLength( 0 );
-	m_textURL.SetName( "WebURL" );
-	SET_XY_AND_ON_COMMAND( m_textURL );
-	this->AddChild( &m_textURL );
+	m_textURL.LoadFromFont(THEME->GetPathF(m_sName, "default"));
+	m_textURL.SetShadowLength(0);
+	m_textURL.SetName("WebURL");
+	SET_XY_AND_ON_COMMAND(m_textURL);
+	this->AddChild(&m_textURL);
 	UpdateLinksList();
-	
-	m_sprWebSel.SetName( "WebSel" );
-	m_sprWebSel.Load( THEME->GetPathG( m_sName, "WebSel" ) );
-	SET_XY_AND_ON_COMMAND( m_sprWebSel );
-	this->AddChild( &m_sprWebSel );
 
-	m_sprDLBG.SetName( "Download" );
-	m_sprDLBG.Load( THEME->GetPathG( m_sName, "DownloadBG" ) );
-	SET_XY_AND_ON_COMMAND( m_sprDLBG );
-	this->AddChild( &m_sprDLBG );
+	m_sprWebSel.SetName("WebSel");
+	m_sprWebSel.Load(THEME->GetPathG(m_sName, "WebSel"));
+	SET_XY_AND_ON_COMMAND(m_sprWebSel);
+	this->AddChild(&m_sprWebSel);
+
+	m_sprDLBG.SetName("Download");
+	m_sprDLBG.Load(THEME->GetPathG(m_sName, "DownloadBG"));
+	SET_XY_AND_ON_COMMAND(m_sprDLBG);
+	this->AddChild(&m_sprDLBG);
 
 	//(HTTP ELEMENTS)
-	m_sprDL.SetName( "Download" );
-	m_sprDL.Load( THEME->GetPathG( m_sName, "Download" ) );
-	SET_XY_AND_ON_COMMAND( m_sprDL );
-	this->AddChild( &m_sprDL );
-	m_sprDL.SetDiffuse( THEME->GetMetricC( m_sName, "DownloadProgressColor" ) );
+	m_sprDL.SetName("Download");
+	m_sprDL.Load(THEME->GetPathG(m_sName, "Download"));
+	SET_XY_AND_ON_COMMAND(m_sprDL);
+	this->AddChild(&m_sprDL);
+	m_sprDL.SetDiffuse(THEME->GetMetricC(m_sName, "DownloadProgressColor"));
 
-	m_textStatus.LoadFromFont( THEME->GetPathF(m_sName,"default") );
-	m_textStatus.SetShadowLength( 0 );
-	m_textStatus.SetName( "DownloadStatus" );
-	SET_XY_AND_ON_COMMAND( m_textStatus );
-	this->AddChild( &m_textStatus );
+	m_textStatus.LoadFromFont(THEME->GetPathF(m_sName, "default"));
+	m_textStatus.SetShadowLength(0);
+	m_textStatus.SetName("DownloadStatus");
+	SET_XY_AND_ON_COMMAND(m_textStatus);
+	this->AddChild(&m_textStatus);
 
 	UpdateProgress();
 
 	//Workaround:  For some reason, the first download sometimes
 	//corrupts; by opening and closing the rage file, this 
 	//problem does not occour.  Go figure?
-	
+
 	//XXX:  This is a really dirty work around!
 	//Why does RageFile do this?
 
 	//It's always some strange number of bytes at the end of the
 	//file when it corrupts.
-	m_fOutputFile.Open( "Packages/dummy.txt", RageFile::WRITE );
+	m_fOutputFile.Open("Packages/dummy.txt", RageFile::WRITE);
 	m_fOutputFile.Close();
 }
 
-void ScreenPackages::HandleScreenMessage( const ScreenMessage SM )
+void ScreenPackages::HandleScreenMessage(const ScreenMessage SM)
 {
-	if( SM == SM_GoToPrevScreen )
+	if (SM == SM_GoToPrevScreen)
 	{
-		SCREENMAN->SetNewScreen( THEME->GetMetric (m_sName, "PrevScreen") );
+		SCREENMAN->SetNewScreen(THEME->GetMetric(m_sName, "PrevScreen"));
 	}
-	else if( SM ==SM_GoToNextScreen )
+	else if (SM == SM_GoToNextScreen)
 	{
-		SCREENMAN->SetNewScreen( THEME->GetMetric (m_sName, "NextScreen") );
+		SCREENMAN->SetNewScreen(THEME->GetMetric(m_sName, "NextScreen"));
 	}
-	else if( SM == SM_BackFromURL )
+	else if (SM == SM_BackFromURL)
 	{
-		if ( !ScreenTextEntry::s_bCancelledLast )
-			EnterURL( ScreenTextEntry::s_sLastAnswer );
+		if (!ScreenTextEntry::s_bCancelledLast)
+			EnterURL(ScreenTextEntry::s_sLastAnswer);
 	}
-	ScreenWithMenuElements::HandleScreenMessage( SM );
+	ScreenWithMenuElements::HandleScreenMessage(SM);
 }
 
-void ScreenPackages::Input( const DeviceInput& DeviceI, const InputEventType type, const GameInput &GameI, const MenuInput &MenuI, const StyleInput &StyleI )
+void ScreenPackages::Input(const DeviceInput& DeviceI, const InputEventType type, const GameInput &GameI, const MenuInput &MenuI, const StyleInput &StyleI)
 {
-	ScreenWithMenuElements::Input( DeviceI, type, GameI, MenuI, StyleI );
+	ScreenWithMenuElements::Input(DeviceI, type, GameI, MenuI, StyleI);
 }
 
-void ScreenPackages::Update( float fDeltaTime )
+void ScreenPackages::Update(float fDeltaTime)
 {
 	HTTPUpdate();
 
 	m_fLastUpdate += fDeltaTime;
-	if ( m_fLastUpdate >= 1.0 )
+	if (m_fLastUpdate >= 1.0)
 	{
-		if ( m_bIsDownloading && m_bGotHeader )
-			m_sStatus = ssprintf( "DL @ %d KB/s", int((m_iDownloaded-m_bytesLastUpdate)/1024) );
+		if (m_bIsDownloading && m_bGotHeader)
+			m_sStatus = ssprintf("DL @ %d KB/s", int((m_iDownloaded - m_bytesLastUpdate) / 1024));
 
 		m_bytesLastUpdate = m_iDownloaded;
 		UpdateProgress();
@@ -159,25 +159,25 @@ void ScreenPackages::Update( float fDeltaTime )
 	ScreenWithMenuElements::Update(fDeltaTime);
 }
 
-void ScreenPackages::MenuStart( PlayerNumber pn )
+void ScreenPackages::MenuStart(PlayerNumber pn)
 {
-	if ( m_iDLorLST == 1 )
+	if (m_iDLorLST == 1)
 	{
-		if ( m_iLinksPos == 0 )
-			SCREENMAN->TextEntry( SM_BackFromURL, "Enter URL:", "http://", 255 );
+		if (m_iLinksPos == 0)
+			SCREENMAN->TextEntry(SM_BackFromURL, "Enter URL:", "http://", 255);
 		else
-			EnterURL( m_Links[m_iLinksPos] );
+			EnterURL(m_Links[m_iLinksPos]);
 	}
-	ScreenWithMenuElements::MenuStart( pn );
+	ScreenWithMenuElements::MenuStart(pn);
 }
 
-void ScreenPackages::MenuUp( PlayerNumber pn, const InputEventType type )
+void ScreenPackages::MenuUp(PlayerNumber pn, const InputEventType type)
 {
-	if ( m_bIsDownloading )
+	if (m_bIsDownloading)
 		return;
-	if ( m_iDLorLST == 0)
+	if (m_iDLorLST == 0)
 	{
-		if ( m_iPackagesPos > 0)
+		if (m_iPackagesPos > 0)
 		{
 			m_iPackagesPos--;
 			UpdatePackagesList();
@@ -185,23 +185,23 @@ void ScreenPackages::MenuUp( PlayerNumber pn, const InputEventType type )
 	}
 	else
 	{
-		if ( m_iLinksPos > 0 )
+		if (m_iLinksPos > 0)
 		{
 			m_iLinksPos--;
 			UpdateLinksList();
 		}
 	}
-	ScreenWithMenuElements::MenuUp( pn, type );
+	ScreenWithMenuElements::MenuUp(pn, type);
 }
 
-void ScreenPackages::MenuDown( PlayerNumber pn, const InputEventType type )
+void ScreenPackages::MenuDown(PlayerNumber pn, const InputEventType type)
 {
-	if ( m_bIsDownloading )
+	if (m_bIsDownloading)
 		return;
-	
-	if ( m_iDLorLST == 0)
+
+	if (m_iDLorLST == 0)
 	{
-		if( (unsigned) m_iPackagesPos < m_Packages.size() - 1 )
+		if ((unsigned)m_iPackagesPos < m_Packages.size() - 1)
 		{
 			m_iPackagesPos++;
 			UpdatePackagesList();
@@ -209,84 +209,84 @@ void ScreenPackages::MenuDown( PlayerNumber pn, const InputEventType type )
 	}
 	else
 	{
-		if( (unsigned) m_iLinksPos < m_LinkTitles.size() - 1 )
+		if ((unsigned)m_iLinksPos < m_LinkTitles.size() - 1)
 		{
 			m_iLinksPos++;
 			UpdateLinksList();
 		}
 	}
-	ScreenWithMenuElements::MenuDown( pn, type );
+	ScreenWithMenuElements::MenuDown(pn, type);
 }
 
-void ScreenPackages::MenuLeft( PlayerNumber pn, const InputEventType type )
+void ScreenPackages::MenuLeft(PlayerNumber pn, const InputEventType type)
 {
-	if ( m_bIsDownloading )
+	if (m_bIsDownloading)
 		return;
-	if ( !m_bCanDL )
+	if (!m_bCanDL)
 		return;
-	
-	m_sprExistingBG.StopTweening( );
-	m_sprWebBG.StopTweening( );
-	
-	if ( m_iDLorLST == 0 )
+
+	m_sprExistingBG.StopTweening();
+	m_sprWebBG.StopTweening();
+
+	if (m_iDLorLST == 0)
 	{
 		m_iDLorLST = 1;
-		COMMAND( m_sprExistingBG, "Away" );
-		COMMAND( m_sprWebBG, "Back" );
+		COMMAND(m_sprExistingBG, "Away");
+		COMMAND(m_sprWebBG, "Back");
 	}
-	else 
-	{	
-		m_iDLorLST = 0;
-		COMMAND( m_sprExistingBG, "Back" );
-		COMMAND( m_sprWebBG, "Away" );
-	}
-	ScreenWithMenuElements::MenuLeft( pn, type );
-}
-
-void ScreenPackages::MenuRight( PlayerNumber pn, const InputEventType type )
-{
-	if ( m_bIsDownloading )
-		return;
-	MenuLeft( pn, type );
-	ScreenWithMenuElements::MenuRight( pn, type );
-}
-
-void ScreenPackages::MenuBack( PlayerNumber pn )
-{
-	if ( m_bIsDownloading )
+	else
 	{
-		SCREENMAN->SystemMessage( "Download Cancelled." );
-		CancelDownload( );
+		m_iDLorLST = 0;
+		COMMAND(m_sprExistingBG, "Back");
+		COMMAND(m_sprWebBG, "Away");
+	}
+	ScreenWithMenuElements::MenuLeft(pn, type);
+}
+
+void ScreenPackages::MenuRight(PlayerNumber pn, const InputEventType type)
+{
+	if (m_bIsDownloading)
+		return;
+	MenuLeft(pn, type);
+	ScreenWithMenuElements::MenuRight(pn, type);
+}
+
+void ScreenPackages::MenuBack(PlayerNumber pn)
+{
+	if (m_bIsDownloading)
+	{
+		SCREENMAN->SystemMessage("Download Cancelled.");
+		CancelDownload();
 		return;
 	}
 
 	TweenOffScreen();
-	Cancel( SM_GoToPrevScreen );
-	ScreenWithMenuElements::MenuBack( pn );
+	Cancel(SM_GoToPrevScreen);
+	ScreenWithMenuElements::MenuBack(pn);
 }
 
-void ScreenPackages::TweenOffScreen( )
+void ScreenPackages::TweenOffScreen()
 {
-	OFF_COMMAND( m_sprExistingBG );
-	OFF_COMMAND( m_sprWebBG );
-	OFF_COMMAND( m_sprWebSel );
-	OFF_COMMAND( m_textPackages );
-	OFF_COMMAND( m_textWeb );
-	OFF_COMMAND( m_sprDL );
-	OFF_COMMAND( m_sprDLBG );
-	OFF_COMMAND( m_textStatus );
+	OFF_COMMAND(m_sprExistingBG);
+	OFF_COMMAND(m_sprWebBG);
+	OFF_COMMAND(m_sprWebSel);
+	OFF_COMMAND(m_textPackages);
+	OFF_COMMAND(m_textWeb);
+	OFF_COMMAND(m_sprDL);
+	OFF_COMMAND(m_sprDLBG);
+	OFF_COMMAND(m_textStatus);
 
 	m_fOutputFile.Close();
 }
 
 void ScreenPackages::RefreshPackages()
 {
-	GetDirListing( "Packages/*.*zip", m_Packages, false, false );
-	
-	if ( m_iPackagesPos < 0 )
+	GetDirListing("Packages/*.*zip", m_Packages, false, false);
+
+	if (m_iPackagesPos < 0)
 		m_iPackagesPos = 0;
-	
-	if( (unsigned) m_iPackagesPos >= m_Packages.size() )
+
+	if ((unsigned)m_iPackagesPos >= m_Packages.size())
 		m_iPackagesPos = m_Packages.size() - 1;
 
 	UpdatePackagesList();
@@ -294,163 +294,119 @@ void ScreenPackages::RefreshPackages()
 
 void ScreenPackages::UpdatePackagesList()
 {
-	CString TempText="";
-	int min = m_iPackagesPos-NUM_PACKAGES_SHOW;
-	int max = m_iPackagesPos+NUM_PACKAGES_SHOW;
-	for (int i=min; i<max; i++ )
+	CString TempText = "";
+	int min = m_iPackagesPos - NUM_PACKAGES_SHOW;
+	int max = m_iPackagesPos + NUM_PACKAGES_SHOW;
+	for (int i = min; i<max; i++)
 	{
-		if ( i >= 0 && (unsigned) i < m_Packages.size() )
+		if (i >= 0 && (unsigned)i < m_Packages.size())
 			TempText += m_Packages[i] + '\n';
 		else
 			TempText += '\n';
 	}
-	m_textPackages.SetText( TempText );
+	m_textPackages.SetText(TempText);
 }
 
 void ScreenPackages::UpdateLinksList()
 {
-	CString TempText="";
-	if( (unsigned) m_iLinksPos >= m_LinkTitles.size() )
+	CString TempText = "";
+	if ((unsigned)m_iLinksPos >= m_LinkTitles.size())
 		m_iLinksPos = m_LinkTitles.size() - 1;
-	int min = m_iLinksPos-NUM_LINKS_SHOW;
-	int max = m_iLinksPos+NUM_LINKS_SHOW;
-	for (int i=min; i<max; i++ )
+	int min = m_iLinksPos - NUM_LINKS_SHOW;
+	int max = m_iLinksPos + NUM_LINKS_SHOW;
+	for (int i = min; i<max; i++)
 	{
-		if( i >= 0 && (unsigned) i < m_LinkTitles.size() )
+		if (i >= 0 && (unsigned)i < m_LinkTitles.size())
 			TempText += m_LinkTitles[i] + '\n';
 		else
 			TempText += '\n';
 	}
-	m_textWeb.SetText( TempText );
-	if ( m_iLinksPos >= 0 && (unsigned) m_iLinksPos < m_Links.size() )
-		m_textURL.SetText( m_Links[m_iLinksPos] );
+	m_textWeb.SetText(TempText);
+	if (m_iLinksPos >= 0 && (unsigned)m_iLinksPos < m_Links.size())
+		m_textURL.SetText(m_Links[m_iLinksPos]);
 	else
-		m_textURL.SetText( " " );
+		m_textURL.SetText(" ");
 }
 
 void ScreenPackages::HTMLParse()
 {
 	m_Links.clear();
 	m_LinkTitles.clear();
-	m_Links.push_back( " " );
-	m_LinkTitles.push_back( "--Visit URL--" );
+	m_Links.push_back(" ");
+	m_LinkTitles.push_back("--Visit URL--");
 
 	//XXX: VERY DIRTY HTML PARSER!
 	//Only designed to find links on websites.
-	int i = m_sBUFFER.find( "<A " );
+	int i = m_sBUFFER.find("<A ");
 	int j = 0;
 	int k = 0;
 	int l = 0;
 	int m = 0;
 
-	for ( int mode = 0; mode < 2; mode++ )
+	for (int mode = 0; mode < 2; mode++)
 	{
-		while ( i>=0 )
+		while (i >= 0)
 		{
-			k = m_sBUFFER.find( ">", i+1 );
-			l = m_sBUFFER.find( "HREF", i+1);
-			m = m_sBUFFER.find( "=", l );
+			k = m_sBUFFER.find(">", i + 1);
+			l = m_sBUFFER.find("HREF", i + 1);
+			m = m_sBUFFER.find("=", l);
 
-			if ( ( l > k ) || ( m > k ) )	//no "href" in this tag.
+			if ((l > k) || (m > k))	//no "href" in this tag.
 			{
-				if ( mode == 0 )
-					i = m_sBUFFER.find( "<A ", i+1 );
+				if (mode == 0)
+					i = m_sBUFFER.find("<A ", i + 1);
 				else
-					i = m_sBUFFER.find( "<a ", i+1 );
+					i = m_sBUFFER.find("<a ", i + 1);
 				continue;
 			}
 
-			l = m_sBUFFER.find( "</", m+1 );
+			l = m_sBUFFER.find("</", m + 1);
 
 			//Special case: There is exactly one extra tag in the link.
-			j = m_sBUFFER.find( ">", k+1 );
-			if ( j < l )
+			j = m_sBUFFER.find(">", k + 1);
+			if (j < l)
 				k = j;
 
-			CString TempLink = StripOutContainers( m_sBUFFER.substr(m+1,k-m-1) );
-			if ( TempLink.substr(0,7).compare("http://") != 0 )
+			CString TempLink = HTTPHelper::StripOutContainers(m_sBUFFER.substr(m + 1, k - m - 1));
+			if (TempLink.substr(0, 7).compare("http://") != 0)
 				TempLink = m_sBaseAddress + TempLink;
 
-			CString TempTitle = m_sBUFFER.substr( k+1, l-k-1 );
+			CString TempTitle = m_sBUFFER.substr(k + 1, l - k - 1);
 
-			m_Links.push_back( TempLink );
-			m_LinkTitles.push_back( TempTitle );
+			m_Links.push_back(TempLink);
+			m_LinkTitles.push_back(TempTitle);
 
-			if ( mode == 0 )
-				i = m_sBUFFER.find( "<A ", i+1 );
+			if (mode == 0)
+				i = m_sBUFFER.find("<A ", i + 1);
 			else
-				i = m_sBUFFER.find( "<a ", i+1 );
+				i = m_sBUFFER.find("<a ", i + 1);
 		}
-		if ( mode == 0 )
-			i = m_sBUFFER.find( "<a " );
+		if (mode == 0)
+			i = m_sBUFFER.find("<a ");
 	}
 	UpdateLinksList();
 }
 
-CString ScreenPackages::URLEncode( const CString &URL )
-{
-	CString Input = StripOutContainers( URL );
-	CString Output;
 
-	for( unsigned k = 0; k < Input.size(); k++ )
-	{
-		char t = Input.at( k );
-		if ( ( t >= '!' ) && ( t <= 'z' ) )
-		{
-			Output+=t;
-		}
-		else
-			Output += "%" + ssprintf( "%X", t );
-	}
-	return Output;
-}
-
-CString ScreenPackages::StripOutContainers( const CString & In )
-{
-	if( In.size() == 0 )
-		return "";
-
-	unsigned i = 0;
-	char t = In.at(i);
-	while( t == ' ' && i < In.length() )
-	{
-		t = In.at(++i);
-	}
-
-	if( t == '\"' || t == '\'' )
-	{
-		unsigned j = i+1; 
-		char u = In.at(j);
-		while( u != t && j < In.length() )
-		{
-			u = In.at(++j);
-		}
-		if( j == i )
-			return StripOutContainers( In.substr(i+1) );
-		else
-			return StripOutContainers( In.substr(i+1, j-i-1) );
-	}
-	return In.substr( i );
-}
 
 void ScreenPackages::UpdateProgress()
 {
 	float DownloadedRatio;
 
-	if( m_iTotalBytes < 1 )
+	if (m_iTotalBytes < 1)
 		DownloadedRatio = 0;
 	else
 		DownloadedRatio = float(m_iDownloaded) / float(m_iTotalBytes);
 
 	float dLY = DownloadedRatio / 2 * m_sprDLBG.GetUnzoomedWidth();
 
-	m_sprDL.SetX( m_sprDLBG.GetX() - m_sprDLBG.GetUnzoomedWidth() / 2.0f + dLY );
-	m_sprDL.SetWidth( dLY * 2 );
+	m_sprDL.SetX(m_sprDLBG.GetX() - m_sprDLBG.GetUnzoomedWidth() / 2.0f + dLY);
+	m_sprDL.SetWidth(dLY * 2);
 
-	m_textStatus.SetText( m_sStatus );
+	m_textStatus.SetText(m_sStatus);
 }
 
-void ScreenPackages::CancelDownload( )
+void ScreenPackages::CancelDownload()
 {
 	m_wSocket.close();
 	m_bIsDownloading = false;
@@ -459,17 +415,17 @@ void ScreenPackages::CancelDownload( )
 	m_fOutputFile.Close();
 	m_sStatus = "Failed.";
 	m_sBUFFER = "";
-	if( !FILEMAN->Remove( "Packages/" + m_sEndName ) )
-		SCREENMAN->SystemMessage( "Packages/" + m_sEndName );
+	if (!FILEMAN->Remove("Packages/" + m_sEndName))
+		SCREENMAN->SystemMessage("Packages/" + m_sEndName);
 }
-void ScreenPackages::EnterURL( const CString & sURL )
+void ScreenPackages::EnterURL(const CString & sURL)
 {
 	CString Proto;
 	CString Server;
-	int Port=80;
+	int Port = 80;
 	CString sAddress;
 
-	if( !ParseHTTPAddress( sURL, Proto, Server, Port, sAddress ) )
+	if (!HTTPHelper::ParseHTTPAddress(sURL, Proto, Server, Port, sAddress))
 	{
 		m_sStatus = "Invalid URL.";
 		UpdateProgress();
@@ -478,20 +434,20 @@ void ScreenPackages::EnterURL( const CString & sURL )
 
 	//Determine if this is a website, or a package?
 	//Criteria: does it end with *zip?
-	if( sAddress.Right(3).CompareNoCase("zip") == 0 )
-		m_bIsPackage=true;
+	if (sAddress.Right(3).CompareNoCase("zip") == 0)
+		m_bIsPackage = true;
 	else
 		m_bIsPackage = false;
 
 	m_sBaseAddress = "http://" + Server;
-	if( Port != 80 )
-		m_sBaseAddress += ssprintf( ":%d", Port );
+	if (Port != 80)
+		m_sBaseAddress += ssprintf(":%d", Port);
 	m_sBaseAddress += "/";
 
-	if( sAddress.Right(1) != "/" )
+	if (sAddress.Right(1) != "/")
 	{
-		m_sEndName = Basename( sAddress );
-		m_sBaseAddress += Dirname( sAddress );
+		m_sEndName = Basename(sAddress);
+		m_sBaseAddress += Dirname(sAddress);
 	}
 	else
 	{
@@ -505,18 +461,18 @@ void ScreenPackages::EnterURL( const CString & sURL )
 	//XXX: This should be fixed by a prompt or something?
 
 	//if we are not talking about a file, let's not worry
-	if( m_sEndName != "" && m_bIsPackage )
+	if (m_sEndName != "" && m_bIsPackage)
 	{
 		CStringArray AddTo;
-		GetDirListing( "Packages/"+m_sEndName, AddTo, false, false );
-		if ( AddTo.size() > 0 )
+		GetDirListing("Packages/" + m_sEndName, AddTo, false, false);
+		if (AddTo.size() > 0)
 		{
 			m_sStatus = "File Already Exists";
 			UpdateProgress();
 			return;
 		}
 
-		if( !m_fOutputFile.Open( "Packages/"+m_sEndName, RageFile::WRITE | RageFile::STREAMED ) )
+		if (!m_fOutputFile.Open("Packages/" + m_sEndName, RageFile::WRITE | RageFile::STREAMED))
 		{
 			m_sStatus = m_fOutputFile.GetError();
 			UpdateProgress();
@@ -525,9 +481,9 @@ void ScreenPackages::EnterURL( const CString & sURL )
 	}
 	//Continue...
 
-	sAddress = URLEncode( sAddress );
+	sAddress = HTTPHelper::URLEncode(sAddress);
 
-	if ( sAddress != "/" )
+	if (sAddress != "/")
 		sAddress = "/" + sAddress;
 
 	m_wSocket.close();
@@ -535,22 +491,22 @@ void ScreenPackages::EnterURL( const CString & sURL )
 
 	m_wSocket.blocking = true;
 
-	if( !m_wSocket.connect( Server, (short) Port ) )
+	if (!m_wSocket.connect(Server, (short)Port))
 	{
 		m_sStatus = "Failed to connect.";
 		UpdateProgress();
 		return;
 	}
-	
+
 	//Produce HTTP header
 
-	CString Header="";
+	CString Header = "";
 
-	Header = "GET "+sAddress+" HTTP/1.0\r\n";
-	Header+= "Host: " + Server + "\r\n";
-	Header+= "Connection: closed\r\n\r\n";
+	Header = "GET " + sAddress + " HTTP/1.0\r\n";
+	Header += "Host: " + Server + "\r\n";
+	Header += "Connection: closed\r\n\r\n";
 
-	m_wSocket.SendData( Header.c_str(), Header.length() );
+	m_wSocket.SendData(Header.c_str(), Header.length());
 	m_sStatus = "Header Sent.";
 	m_wSocket.blocking = false;
 	m_bIsDownloading = true;
@@ -560,14 +516,14 @@ void ScreenPackages::EnterURL( const CString & sURL )
 	return;
 }
 
-static size_t FindEndOfHeaders( const CString &buf )
+static size_t FindEndOfHeaders(const CString &buf)
 {
-	size_t iPos1 = buf.find( "\n\n" );
-	size_t iPos2 = buf.find( "\r\n\r\n" );
+	size_t iPos1 = buf.find("\n\n");
+	size_t iPos2 = buf.find("\r\n\r\n");
 	LOG->Trace("end: %u, %u", unsigned(iPos1), unsigned(iPos2));
-	if( iPos1 != string::npos && (iPos2 == string::npos || iPos2 > iPos1) )
+	if (iPos1 != string::npos && (iPos2 == string::npos || iPos2 > iPos1))
 		return iPos1 + 2;
-	else if( iPos2 != string::npos && (iPos1 == string::npos || iPos1 > iPos2) )
+	else if (iPos2 != string::npos && (iPos1 == string::npos || iPos1 > iPos2))
 		return iPos2 + 4;
 	else
 		return string::npos;
@@ -575,62 +531,62 @@ static size_t FindEndOfHeaders( const CString &buf )
 
 void ScreenPackages::HTTPUpdate()
 {
-	if( !m_bIsDownloading )
+	if (!m_bIsDownloading)
 		return;
 
-	int BytesGot=0;
+	int BytesGot = 0;
 	//Keep this as a code block
 	//as there may be need to "if" it out some time.
 	/* If you need a conditional for a large block of code, stick it in
-	 * a function and return. */
-	while(1)
+	* a function and return. */
+	while (1)
 	{
 		char Buffer[1024];
-		int iSize = m_wSocket.ReadData( Buffer, 1024 );
-		if( iSize <= 0 )
+		int iSize = m_wSocket.ReadData(Buffer, 1024);
+		if (iSize <= 0)
 			break;
 
-		m_sBUFFER.append( Buffer, iSize );
+		m_sBUFFER.append(Buffer, iSize);
 		BytesGot += iSize;
 	}
 
-	if( !m_bGotHeader )
+	if (!m_bGotHeader)
 	{
 		m_sStatus = "Waiting for header.";
 		//We don't know if we are using unix-style or dos-style
-		size_t iHeaderEnd = FindEndOfHeaders( m_sBUFFER );
-		if( iHeaderEnd == m_sBUFFER.npos )
+		size_t iHeaderEnd = FindEndOfHeaders(m_sBUFFER);
+		if (iHeaderEnd == m_sBUFFER.npos)
 			return;
 
 		// "HTTP/1.1 200 OK"
 		size_t i = m_sBUFFER.find(" ");
-		size_t j = m_sBUFFER.find(" ",i+1);
-		size_t k = m_sBUFFER.find("\n",j+1);
-		if ( i == string::npos || j == string::npos || k == string::npos )
+		size_t j = m_sBUFFER.find(" ", i + 1);
+		size_t k = m_sBUFFER.find("\n", j + 1);
+		if (i == string::npos || j == string::npos || k == string::npos)
 		{
 			m_iResponseCode = -100;
 			m_sResponseName = "Malformed response.";
 			return;
 		}
-		m_iResponseCode = atoi(m_sBUFFER.substr(i+1,j-i).c_str());
-		m_sResponseName = m_sBUFFER.substr( j+1, k-j );
+		m_iResponseCode = atoi(m_sBUFFER.substr(i + 1, j - i).c_str());
+		m_sResponseName = m_sBUFFER.substr(j + 1, k - j);
 
 		i = m_sBUFFER.find("Content-Length:");
-		j = m_sBUFFER.find("\n", i+1 );
+		j = m_sBUFFER.find("\n", i + 1);
 
-		if( i != string::npos )
-			m_iTotalBytes = atoi(m_sBUFFER.substr(i+16,j-i).c_str());
+		if (i != string::npos)
+			m_iTotalBytes = atoi(m_sBUFFER.substr(i + 16, j - i).c_str());
 		else
 			m_iTotalBytes = -1;	//We don't know, so go until disconnect
 
 		m_bGotHeader = true;
-		m_sBUFFER.erase( 0, iHeaderEnd );
+		m_sBUFFER.erase(0, iHeaderEnd);
 	}
 
-	if( m_bIsPackage )
+	if (m_bIsPackage)
 	{
 		m_iDownloaded += m_sBUFFER.length();
-		m_fOutputFile.Write( m_sBUFFER );
+		m_fOutputFile.Write(m_sBUFFER);
 		m_sBUFFER = "";
 	}
 	else
@@ -638,25 +594,25 @@ void ScreenPackages::HTTPUpdate()
 		m_iDownloaded = m_sBUFFER.length();
 	}
 
-	if ( ( m_iTotalBytes <= m_iDownloaded && m_iTotalBytes != -1 ) ||
-					//We have the full doc. (And we knew how big it was)
-		( m_iTotalBytes == -1 && 
-			( m_wSocket.state == EzSockets::skERROR || m_wSocket.state == EzSockets::skDISCONNECTED ) ) )
-				//We didn't know how big it was, and were disconnected
-				//So that means we have it all.
+	if ((m_iTotalBytes <= m_iDownloaded && m_iTotalBytes != -1) ||
+		//We have the full doc. (And we knew how big it was)
+		(m_iTotalBytes == -1 &&
+		(m_wSocket.state == EzSockets::skERROR || m_wSocket.state == EzSockets::skDISCONNECTED)))
+		//We didn't know how big it was, and were disconnected
+		//So that means we have it all.
 	{
 		m_wSocket.close();
 		m_bIsDownloading = false;
-		m_bGotHeader=false;
-		m_sStatus = ssprintf( "Done;%dB", int(m_iDownloaded) );
+		m_bGotHeader = false;
+		m_sStatus = ssprintf("Done;%dB", int(m_iDownloaded));
 
-		if( m_iResponseCode < 200 || m_iResponseCode >= 400 )
+		if (m_iResponseCode < 200 || m_iResponseCode >= 400)
 		{
-			m_sStatus = ssprintf( "%ld", m_iResponseCode ) + m_sResponseName;
+			m_sStatus = ssprintf("%ld", m_iResponseCode) + m_sResponseName;
 		}
 		else
 		{
-			if( m_bIsPackage && m_iResponseCode < 300 )
+			if (m_bIsPackage && m_iResponseCode < 300)
 			{
 				m_fOutputFile.Close();
 				FlushDirCache();
@@ -669,58 +625,30 @@ void ScreenPackages::HTTPUpdate()
 	}
 }
 
-bool ScreenPackages::ParseHTTPAddress( const CString &URL, CString &sProto, CString &sServer, int &iPort, CString &sAddress )
-{
-	// [PROTO://]SERVER[:PORT][/URL]
 
-	Regex re(
-		"^([A-Z]+)://" // [0]: HTTP://
-		"([^/:]+)"     // [1]: a.b.com
-		"(:([0-9]+))?" // [2], [3]: :1234 (optional, default 80)
-		"(/(.*))?$");    // [4], [5]: /foo.html (optional)
-	vector<CString> asMatches;
-	if( !re.Compare( URL, asMatches ) )
-		return false;
-	ASSERT( asMatches.size() == 6 );
-
-	sProto = asMatches[0];
-	sServer = asMatches[1];
-	if( asMatches[3] != "" )
-	{
-		iPort = atoi(asMatches[3]);
-		if( iPort == 0 )
-			return false;
-	}
-	else
-		iPort = 80;
-
-	sAddress = asMatches[5];
-
-	return true;
-}
 
 #endif
 /*
- * (c) 2004 Charles Lohr
- * All rights reserved.
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons to
- * whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies of
- * the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
- * THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
- * INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
- * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
- * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
- * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
- * PERFORMANCE OF THIS SOFTWARE.
- */
+* (c) 2004 Charles Lohr
+* All rights reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, and/or sell copies of the Software, and to permit persons to
+* whom the Software is furnished to do so, provided that the above
+* copyright notice(s) and this permission notice appear in all copies of
+* the Software and that both the above copyright notice(s) and this
+* permission notice appear in supporting documentation.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+* THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
+* INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
+* OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+* OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+* OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+* PERFORMANCE OF THIS SOFTWARE.
+*/

--- a/src/ScreenPackages.cpp
+++ b/src/ScreenPackages.cpp
@@ -18,138 +18,138 @@
 #define	NUM_PACKAGES_SHOW			THEME->GetMetricI(m_sName,"NumPackagesShow")
 #define NUM_LINKS_SHOW				THEME->GetMetricI(m_sName,"NumLinksShow")
 
-AutoScreenMessage(SM_BackFromURL)
+AutoScreenMessage( SM_BackFromURL )
 
-REGISTER_SCREEN_CLASS(ScreenPackages);
-ScreenPackages::ScreenPackages(CString sClassName) : ScreenWithMenuElements(sClassName)
+REGISTER_SCREEN_CLASS( ScreenPackages );
+ScreenPackages::ScreenPackages( CString sClassName ) : ScreenWithMenuElements( sClassName )
 {
 }
 
 void ScreenPackages::Init()
 {
 	ScreenWithMenuElements::Init();
-
+	
 	m_iPackagesPos = 0;
 	m_iLinksPos = 0;
 	m_iDLorLST = 0;
 	m_bIsDownloading = false;
-	m_bCanDL = THEME->GetMetricB(m_sName, "CanDL");
+	m_bCanDL = THEME->GetMetricB( m_sName, "CanDL" );
 	m_sStatus = "";
 	m_fLastUpdate = 0;
 	m_iTotalBytes = 0;
 	m_iDownloaded = 0;
 
-	FOREACH_PlayerNumber(pn)
+	FOREACH_PlayerNumber( pn )
 		GAMESTATE->m_bSideIsJoined[pn] = true;
 
-	m_sprExistingBG.SetName("PackagesBG");
-	m_sprExistingBG.Load(THEME->GetPathG(m_sName, "PackagesBG"));
-	SET_XY_AND_ON_COMMAND(m_sprExistingBG);
-	this->AddChild(&m_sprExistingBG);
+	m_sprExistingBG.SetName( "PackagesBG" );
+	m_sprExistingBG.Load( THEME->GetPathG( m_sName, "PackagesBG" ) );
+	SET_XY_AND_ON_COMMAND( m_sprExistingBG );
+	this->AddChild( &m_sprExistingBG );
 
-	m_sprWebBG.SetName("WebBG");
-	m_sprWebBG.Load(THEME->GetPathG(m_sName, "WebBG"));
-	SET_XY_AND_ON_COMMAND(m_sprWebBG);
-	this->AddChild(&m_sprWebBG);
+	m_sprWebBG.SetName( "WebBG" );
+	m_sprWebBG.Load( THEME->GetPathG( m_sName, "WebBG" ) );
+	SET_XY_AND_ON_COMMAND( m_sprWebBG );
+	this->AddChild( &m_sprWebBG );
 
-	COMMAND(m_sprExistingBG, "Back");
-	COMMAND(m_sprWebBG, "Away");
+	COMMAND( m_sprExistingBG, "Back" );
+	COMMAND( m_sprWebBG, "Away" );
 
-	//	m_fOutputFile.
-	m_textPackages.LoadFromFont(THEME->GetPathF(m_sName, "default"));
-	m_textPackages.SetShadowLength(0);
-	m_textPackages.SetName("Packages");
-	m_textPackages.SetMaxWidth(EXISTINGBG_WIDTH);
-	SET_XY_AND_ON_COMMAND(m_textPackages);
-	this->AddChild(&m_textPackages);
+//	m_fOutputFile.
+	m_textPackages.LoadFromFont( THEME->GetPathF(m_sName,"default") );
+	m_textPackages.SetShadowLength( 0 );
+	m_textPackages.SetName( "Packages" );
+	m_textPackages.SetMaxWidth( EXISTINGBG_WIDTH );
+	SET_XY_AND_ON_COMMAND( m_textPackages );
+	this->AddChild( &m_textPackages );
 	RefreshPackages();
 
-	m_textWeb.LoadFromFont(THEME->GetPathF(m_sName, "default"));
-	m_textWeb.SetShadowLength(0);
-	m_textWeb.SetName("Web");
-	m_textWeb.SetMaxWidth(WEBBG_WIDTH);
-	SET_XY_AND_ON_COMMAND(m_textWeb);
-	this->AddChild(&m_textWeb);
-	m_Links.push_back(" ");
-	m_LinkTitles.push_back("--Visit URL--");
+	m_textWeb.LoadFromFont( THEME->GetPathF(m_sName,"default") );
+	m_textWeb.SetShadowLength( 0 );
+	m_textWeb.SetName( "Web" );
+	m_textWeb.SetMaxWidth( WEBBG_WIDTH );
+	SET_XY_AND_ON_COMMAND( m_textWeb );
+	this->AddChild( &m_textWeb);
+	m_Links.push_back( " " );
+	m_LinkTitles.push_back( "--Visit URL--" );
 
-	m_textURL.LoadFromFont(THEME->GetPathF(m_sName, "default"));
-	m_textURL.SetShadowLength(0);
-	m_textURL.SetName("WebURL");
-	SET_XY_AND_ON_COMMAND(m_textURL);
-	this->AddChild(&m_textURL);
+	m_textURL.LoadFromFont( THEME->GetPathF( m_sName,"default") );
+	m_textURL.SetShadowLength( 0 );
+	m_textURL.SetName( "WebURL" );
+	SET_XY_AND_ON_COMMAND( m_textURL );
+	this->AddChild( &m_textURL );
 	UpdateLinksList();
+	
+	m_sprWebSel.SetName( "WebSel" );
+	m_sprWebSel.Load( THEME->GetPathG( m_sName, "WebSel" ) );
+	SET_XY_AND_ON_COMMAND( m_sprWebSel );
+	this->AddChild( &m_sprWebSel );
 
-	m_sprWebSel.SetName("WebSel");
-	m_sprWebSel.Load(THEME->GetPathG(m_sName, "WebSel"));
-	SET_XY_AND_ON_COMMAND(m_sprWebSel);
-	this->AddChild(&m_sprWebSel);
-
-	m_sprDLBG.SetName("Download");
-	m_sprDLBG.Load(THEME->GetPathG(m_sName, "DownloadBG"));
-	SET_XY_AND_ON_COMMAND(m_sprDLBG);
-	this->AddChild(&m_sprDLBG);
+	m_sprDLBG.SetName( "Download" );
+	m_sprDLBG.Load( THEME->GetPathG( m_sName, "DownloadBG" ) );
+	SET_XY_AND_ON_COMMAND( m_sprDLBG );
+	this->AddChild( &m_sprDLBG );
 
 	//(HTTP ELEMENTS)
-	m_sprDL.SetName("Download");
-	m_sprDL.Load(THEME->GetPathG(m_sName, "Download"));
-	SET_XY_AND_ON_COMMAND(m_sprDL);
-	this->AddChild(&m_sprDL);
-	m_sprDL.SetDiffuse(THEME->GetMetricC(m_sName, "DownloadProgressColor"));
+	m_sprDL.SetName( "Download" );
+	m_sprDL.Load( THEME->GetPathG( m_sName, "Download" ) );
+	SET_XY_AND_ON_COMMAND( m_sprDL );
+	this->AddChild( &m_sprDL );
+	m_sprDL.SetDiffuse( THEME->GetMetricC( m_sName, "DownloadProgressColor" ) );
 
-	m_textStatus.LoadFromFont(THEME->GetPathF(m_sName, "default"));
-	m_textStatus.SetShadowLength(0);
-	m_textStatus.SetName("DownloadStatus");
-	SET_XY_AND_ON_COMMAND(m_textStatus);
-	this->AddChild(&m_textStatus);
+	m_textStatus.LoadFromFont( THEME->GetPathF(m_sName,"default") );
+	m_textStatus.SetShadowLength( 0 );
+	m_textStatus.SetName( "DownloadStatus" );
+	SET_XY_AND_ON_COMMAND( m_textStatus );
+	this->AddChild( &m_textStatus );
 
 	UpdateProgress();
 
 	//Workaround:  For some reason, the first download sometimes
 	//corrupts; by opening and closing the rage file, this 
 	//problem does not occour.  Go figure?
-
+	
 	//XXX:  This is a really dirty work around!
 	//Why does RageFile do this?
 
 	//It's always some strange number of bytes at the end of the
 	//file when it corrupts.
-	m_fOutputFile.Open("Packages/dummy.txt", RageFile::WRITE);
+	m_fOutputFile.Open( "Packages/dummy.txt", RageFile::WRITE );
 	m_fOutputFile.Close();
 }
 
-void ScreenPackages::HandleScreenMessage(const ScreenMessage SM)
+void ScreenPackages::HandleScreenMessage( const ScreenMessage SM )
 {
-	if (SM == SM_GoToPrevScreen)
+	if( SM == SM_GoToPrevScreen )
 	{
-		SCREENMAN->SetNewScreen(THEME->GetMetric(m_sName, "PrevScreen"));
+		SCREENMAN->SetNewScreen( THEME->GetMetric (m_sName, "PrevScreen") );
 	}
-	else if (SM == SM_GoToNextScreen)
+	else if( SM ==SM_GoToNextScreen )
 	{
-		SCREENMAN->SetNewScreen(THEME->GetMetric(m_sName, "NextScreen"));
+		SCREENMAN->SetNewScreen( THEME->GetMetric (m_sName, "NextScreen") );
 	}
-	else if (SM == SM_BackFromURL)
+	else if( SM == SM_BackFromURL )
 	{
-		if (!ScreenTextEntry::s_bCancelledLast)
-			EnterURL(ScreenTextEntry::s_sLastAnswer);
+		if ( !ScreenTextEntry::s_bCancelledLast )
+			EnterURL( ScreenTextEntry::s_sLastAnswer );
 	}
-	ScreenWithMenuElements::HandleScreenMessage(SM);
+	ScreenWithMenuElements::HandleScreenMessage( SM );
 }
 
-void ScreenPackages::Input(const DeviceInput& DeviceI, const InputEventType type, const GameInput &GameI, const MenuInput &MenuI, const StyleInput &StyleI)
+void ScreenPackages::Input( const DeviceInput& DeviceI, const InputEventType type, const GameInput &GameI, const MenuInput &MenuI, const StyleInput &StyleI )
 {
-	ScreenWithMenuElements::Input(DeviceI, type, GameI, MenuI, StyleI);
+	ScreenWithMenuElements::Input( DeviceI, type, GameI, MenuI, StyleI );
 }
 
-void ScreenPackages::Update(float fDeltaTime)
+void ScreenPackages::Update( float fDeltaTime )
 {
 	HTTPUpdate();
 
 	m_fLastUpdate += fDeltaTime;
-	if (m_fLastUpdate >= 1.0)
+	if ( m_fLastUpdate >= 1.0 )
 	{
-		if (m_bIsDownloading && m_bGotHeader)
-			m_sStatus = ssprintf("DL @ %d KB/s", int((m_iDownloaded - m_bytesLastUpdate) / 1024));
+		if ( m_bIsDownloading && m_bGotHeader )
+			m_sStatus = ssprintf( "DL @ %d KB/s", int((m_iDownloaded-m_bytesLastUpdate)/1024) );
 
 		m_bytesLastUpdate = m_iDownloaded;
 		UpdateProgress();
@@ -159,25 +159,25 @@ void ScreenPackages::Update(float fDeltaTime)
 	ScreenWithMenuElements::Update(fDeltaTime);
 }
 
-void ScreenPackages::MenuStart(PlayerNumber pn)
+void ScreenPackages::MenuStart( PlayerNumber pn )
 {
-	if (m_iDLorLST == 1)
+	if ( m_iDLorLST == 1 )
 	{
-		if (m_iLinksPos == 0)
-			SCREENMAN->TextEntry(SM_BackFromURL, "Enter URL:", "http://", 255);
+		if ( m_iLinksPos == 0 )
+			SCREENMAN->TextEntry( SM_BackFromURL, "Enter URL:", "http://", 255 );
 		else
-			EnterURL(m_Links[m_iLinksPos]);
+			EnterURL( m_Links[m_iLinksPos] );
 	}
-	ScreenWithMenuElements::MenuStart(pn);
+	ScreenWithMenuElements::MenuStart( pn );
 }
 
-void ScreenPackages::MenuUp(PlayerNumber pn, const InputEventType type)
+void ScreenPackages::MenuUp( PlayerNumber pn, const InputEventType type )
 {
-	if (m_bIsDownloading)
+	if ( m_bIsDownloading )
 		return;
-	if (m_iDLorLST == 0)
+	if ( m_iDLorLST == 0)
 	{
-		if (m_iPackagesPos > 0)
+		if ( m_iPackagesPos > 0)
 		{
 			m_iPackagesPos--;
 			UpdatePackagesList();
@@ -185,23 +185,23 @@ void ScreenPackages::MenuUp(PlayerNumber pn, const InputEventType type)
 	}
 	else
 	{
-		if (m_iLinksPos > 0)
+		if ( m_iLinksPos > 0 )
 		{
 			m_iLinksPos--;
 			UpdateLinksList();
 		}
 	}
-	ScreenWithMenuElements::MenuUp(pn, type);
+	ScreenWithMenuElements::MenuUp( pn, type );
 }
 
-void ScreenPackages::MenuDown(PlayerNumber pn, const InputEventType type)
+void ScreenPackages::MenuDown( PlayerNumber pn, const InputEventType type )
 {
-	if (m_bIsDownloading)
+	if ( m_bIsDownloading )
 		return;
-
-	if (m_iDLorLST == 0)
+	
+	if ( m_iDLorLST == 0)
 	{
-		if ((unsigned)m_iPackagesPos < m_Packages.size() - 1)
+		if( (unsigned) m_iPackagesPos < m_Packages.size() - 1 )
 		{
 			m_iPackagesPos++;
 			UpdatePackagesList();
@@ -209,84 +209,84 @@ void ScreenPackages::MenuDown(PlayerNumber pn, const InputEventType type)
 	}
 	else
 	{
-		if ((unsigned)m_iLinksPos < m_LinkTitles.size() - 1)
+		if( (unsigned) m_iLinksPos < m_LinkTitles.size() - 1 )
 		{
 			m_iLinksPos++;
 			UpdateLinksList();
 		}
 	}
-	ScreenWithMenuElements::MenuDown(pn, type);
+	ScreenWithMenuElements::MenuDown( pn, type );
 }
 
-void ScreenPackages::MenuLeft(PlayerNumber pn, const InputEventType type)
+void ScreenPackages::MenuLeft( PlayerNumber pn, const InputEventType type )
 {
-	if (m_bIsDownloading)
+	if ( m_bIsDownloading )
 		return;
-	if (!m_bCanDL)
+	if ( !m_bCanDL )
 		return;
-
-	m_sprExistingBG.StopTweening();
-	m_sprWebBG.StopTweening();
-
-	if (m_iDLorLST == 0)
+	
+	m_sprExistingBG.StopTweening( );
+	m_sprWebBG.StopTweening( );
+	
+	if ( m_iDLorLST == 0 )
 	{
 		m_iDLorLST = 1;
-		COMMAND(m_sprExistingBG, "Away");
-		COMMAND(m_sprWebBG, "Back");
+		COMMAND( m_sprExistingBG, "Away" );
+		COMMAND( m_sprWebBG, "Back" );
 	}
-	else
-	{
+	else 
+	{	
 		m_iDLorLST = 0;
-		COMMAND(m_sprExistingBG, "Back");
-		COMMAND(m_sprWebBG, "Away");
+		COMMAND( m_sprExistingBG, "Back" );
+		COMMAND( m_sprWebBG, "Away" );
 	}
-	ScreenWithMenuElements::MenuLeft(pn, type);
+	ScreenWithMenuElements::MenuLeft( pn, type );
 }
 
-void ScreenPackages::MenuRight(PlayerNumber pn, const InputEventType type)
+void ScreenPackages::MenuRight( PlayerNumber pn, const InputEventType type )
 {
-	if (m_bIsDownloading)
+	if ( m_bIsDownloading )
 		return;
-	MenuLeft(pn, type);
-	ScreenWithMenuElements::MenuRight(pn, type);
+	MenuLeft( pn, type );
+	ScreenWithMenuElements::MenuRight( pn, type );
 }
 
-void ScreenPackages::MenuBack(PlayerNumber pn)
+void ScreenPackages::MenuBack( PlayerNumber pn )
 {
-	if (m_bIsDownloading)
+	if ( m_bIsDownloading )
 	{
-		SCREENMAN->SystemMessage("Download Cancelled.");
-		CancelDownload();
+		SCREENMAN->SystemMessage( "Download Cancelled." );
+		CancelDownload( );
 		return;
 	}
 
 	TweenOffScreen();
-	Cancel(SM_GoToPrevScreen);
-	ScreenWithMenuElements::MenuBack(pn);
+	Cancel( SM_GoToPrevScreen );
+	ScreenWithMenuElements::MenuBack( pn );
 }
 
-void ScreenPackages::TweenOffScreen()
+void ScreenPackages::TweenOffScreen( )
 {
-	OFF_COMMAND(m_sprExistingBG);
-	OFF_COMMAND(m_sprWebBG);
-	OFF_COMMAND(m_sprWebSel);
-	OFF_COMMAND(m_textPackages);
-	OFF_COMMAND(m_textWeb);
-	OFF_COMMAND(m_sprDL);
-	OFF_COMMAND(m_sprDLBG);
-	OFF_COMMAND(m_textStatus);
+	OFF_COMMAND( m_sprExistingBG );
+	OFF_COMMAND( m_sprWebBG );
+	OFF_COMMAND( m_sprWebSel );
+	OFF_COMMAND( m_textPackages );
+	OFF_COMMAND( m_textWeb );
+	OFF_COMMAND( m_sprDL );
+	OFF_COMMAND( m_sprDLBG );
+	OFF_COMMAND( m_textStatus );
 
 	m_fOutputFile.Close();
 }
 
 void ScreenPackages::RefreshPackages()
 {
-	GetDirListing("Packages/*.*zip", m_Packages, false, false);
-
-	if (m_iPackagesPos < 0)
+	GetDirListing( "Packages/*.*zip", m_Packages, false, false );
+	
+	if ( m_iPackagesPos < 0 )
 		m_iPackagesPos = 0;
-
-	if ((unsigned)m_iPackagesPos >= m_Packages.size())
+	
+	if( (unsigned) m_iPackagesPos >= m_Packages.size() )
 		m_iPackagesPos = m_Packages.size() - 1;
 
 	UpdatePackagesList();
@@ -294,95 +294,95 @@ void ScreenPackages::RefreshPackages()
 
 void ScreenPackages::UpdatePackagesList()
 {
-	CString TempText = "";
-	int min = m_iPackagesPos - NUM_PACKAGES_SHOW;
-	int max = m_iPackagesPos + NUM_PACKAGES_SHOW;
-	for (int i = min; i<max; i++)
+	CString TempText="";
+	int min = m_iPackagesPos-NUM_PACKAGES_SHOW;
+	int max = m_iPackagesPos+NUM_PACKAGES_SHOW;
+	for (int i=min; i<max; i++ )
 	{
-		if (i >= 0 && (unsigned)i < m_Packages.size())
+		if ( i >= 0 && (unsigned) i < m_Packages.size() )
 			TempText += m_Packages[i] + '\n';
 		else
 			TempText += '\n';
 	}
-	m_textPackages.SetText(TempText);
+	m_textPackages.SetText( TempText );
 }
 
 void ScreenPackages::UpdateLinksList()
 {
-	CString TempText = "";
-	if ((unsigned)m_iLinksPos >= m_LinkTitles.size())
+	CString TempText="";
+	if( (unsigned) m_iLinksPos >= m_LinkTitles.size() )
 		m_iLinksPos = m_LinkTitles.size() - 1;
-	int min = m_iLinksPos - NUM_LINKS_SHOW;
-	int max = m_iLinksPos + NUM_LINKS_SHOW;
-	for (int i = min; i<max; i++)
+	int min = m_iLinksPos-NUM_LINKS_SHOW;
+	int max = m_iLinksPos+NUM_LINKS_SHOW;
+	for (int i=min; i<max; i++ )
 	{
-		if (i >= 0 && (unsigned)i < m_LinkTitles.size())
+		if( i >= 0 && (unsigned) i < m_LinkTitles.size() )
 			TempText += m_LinkTitles[i] + '\n';
 		else
 			TempText += '\n';
 	}
-	m_textWeb.SetText(TempText);
-	if (m_iLinksPos >= 0 && (unsigned)m_iLinksPos < m_Links.size())
-		m_textURL.SetText(m_Links[m_iLinksPos]);
+	m_textWeb.SetText( TempText );
+	if ( m_iLinksPos >= 0 && (unsigned) m_iLinksPos < m_Links.size() )
+		m_textURL.SetText( m_Links[m_iLinksPos] );
 	else
-		m_textURL.SetText(" ");
+		m_textURL.SetText( " " );
 }
 
 void ScreenPackages::HTMLParse()
 {
 	m_Links.clear();
 	m_LinkTitles.clear();
-	m_Links.push_back(" ");
-	m_LinkTitles.push_back("--Visit URL--");
+	m_Links.push_back( " " );
+	m_LinkTitles.push_back( "--Visit URL--" );
 
 	//XXX: VERY DIRTY HTML PARSER!
 	//Only designed to find links on websites.
-	int i = m_sBUFFER.find("<A ");
+	int i = m_sBUFFER.find( "<A " );
 	int j = 0;
 	int k = 0;
 	int l = 0;
 	int m = 0;
 
-	for (int mode = 0; mode < 2; mode++)
+	for ( int mode = 0; mode < 2; mode++ )
 	{
-		while (i >= 0)
+		while ( i>=0 )
 		{
-			k = m_sBUFFER.find(">", i + 1);
-			l = m_sBUFFER.find("HREF", i + 1);
-			m = m_sBUFFER.find("=", l);
+			k = m_sBUFFER.find( ">", i+1 );
+			l = m_sBUFFER.find( "HREF", i+1);
+			m = m_sBUFFER.find( "=", l );
 
-			if ((l > k) || (m > k))	//no "href" in this tag.
+			if ( ( l > k ) || ( m > k ) )	//no "href" in this tag.
 			{
-				if (mode == 0)
-					i = m_sBUFFER.find("<A ", i + 1);
+				if ( mode == 0 )
+					i = m_sBUFFER.find( "<A ", i+1 );
 				else
-					i = m_sBUFFER.find("<a ", i + 1);
+					i = m_sBUFFER.find( "<a ", i+1 );
 				continue;
 			}
 
-			l = m_sBUFFER.find("</", m + 1);
+			l = m_sBUFFER.find( "</", m+1 );
 
 			//Special case: There is exactly one extra tag in the link.
-			j = m_sBUFFER.find(">", k + 1);
-			if (j < l)
+			j = m_sBUFFER.find( ">", k+1 );
+			if ( j < l )
 				k = j;
 
-			CString TempLink = HTTPHelper::StripOutContainers(m_sBUFFER.substr(m + 1, k - m - 1));
-			if (TempLink.substr(0, 7).compare("http://") != 0)
+			CString TempLink = HTTPHelper::StripOutContainers( m_sBUFFER.substr(m+1,k-m-1) );
+			if ( TempLink.substr(0,7).compare("http://") != 0 )
 				TempLink = m_sBaseAddress + TempLink;
 
-			CString TempTitle = m_sBUFFER.substr(k + 1, l - k - 1);
+			CString TempTitle = m_sBUFFER.substr( k+1, l-k-1 );
 
-			m_Links.push_back(TempLink);
-			m_LinkTitles.push_back(TempTitle);
+			m_Links.push_back( TempLink );
+			m_LinkTitles.push_back( TempTitle );
 
-			if (mode == 0)
-				i = m_sBUFFER.find("<A ", i + 1);
+			if ( mode == 0 )
+				i = m_sBUFFER.find( "<A ", i+1 );
 			else
-				i = m_sBUFFER.find("<a ", i + 1);
+				i = m_sBUFFER.find( "<a ", i+1 );
 		}
-		if (mode == 0)
-			i = m_sBUFFER.find("<a ");
+		if ( mode == 0 )
+			i = m_sBUFFER.find( "<a " );
 	}
 	UpdateLinksList();
 }
@@ -393,20 +393,20 @@ void ScreenPackages::UpdateProgress()
 {
 	float DownloadedRatio;
 
-	if (m_iTotalBytes < 1)
+	if( m_iTotalBytes < 1 )
 		DownloadedRatio = 0;
 	else
 		DownloadedRatio = float(m_iDownloaded) / float(m_iTotalBytes);
 
 	float dLY = DownloadedRatio / 2 * m_sprDLBG.GetUnzoomedWidth();
 
-	m_sprDL.SetX(m_sprDLBG.GetX() - m_sprDLBG.GetUnzoomedWidth() / 2.0f + dLY);
-	m_sprDL.SetWidth(dLY * 2);
+	m_sprDL.SetX( m_sprDLBG.GetX() - m_sprDLBG.GetUnzoomedWidth() / 2.0f + dLY );
+	m_sprDL.SetWidth( dLY * 2 );
 
-	m_textStatus.SetText(m_sStatus);
+	m_textStatus.SetText( m_sStatus );
 }
 
-void ScreenPackages::CancelDownload()
+void ScreenPackages::CancelDownload( )
 {
 	m_wSocket.close();
 	m_bIsDownloading = false;
@@ -415,17 +415,17 @@ void ScreenPackages::CancelDownload()
 	m_fOutputFile.Close();
 	m_sStatus = "Failed.";
 	m_sBUFFER = "";
-	if (!FILEMAN->Remove("Packages/" + m_sEndName))
-		SCREENMAN->SystemMessage("Packages/" + m_sEndName);
+	if( !FILEMAN->Remove( "Packages/" + m_sEndName ) )
+		SCREENMAN->SystemMessage( "Packages/" + m_sEndName );
 }
-void ScreenPackages::EnterURL(const CString & sURL)
+void ScreenPackages::EnterURL( const CString & sURL )
 {
 	CString Proto;
 	CString Server;
-	int Port = 80;
+	int Port=80;
 	CString sAddress;
 
-	if (!HTTPHelper::ParseHTTPAddress(sURL, Proto, Server, Port, sAddress))
+	if( !HTTPHelper::ParseHTTPAddress( sURL, Proto, Server, Port, sAddress ) )
 	{
 		m_sStatus = "Invalid URL.";
 		UpdateProgress();
@@ -434,20 +434,20 @@ void ScreenPackages::EnterURL(const CString & sURL)
 
 	//Determine if this is a website, or a package?
 	//Criteria: does it end with *zip?
-	if (sAddress.Right(3).CompareNoCase("zip") == 0)
-		m_bIsPackage = true;
+	if( sAddress.Right(3).CompareNoCase("zip") == 0 )
+		m_bIsPackage=true;
 	else
 		m_bIsPackage = false;
 
 	m_sBaseAddress = "http://" + Server;
-	if (Port != 80)
-		m_sBaseAddress += ssprintf(":%d", Port);
+	if( Port != 80 )
+		m_sBaseAddress += ssprintf( ":%d", Port );
 	m_sBaseAddress += "/";
 
-	if (sAddress.Right(1) != "/")
+	if( sAddress.Right(1) != "/" )
 	{
-		m_sEndName = Basename(sAddress);
-		m_sBaseAddress += Dirname(sAddress);
+		m_sEndName = Basename( sAddress );
+		m_sBaseAddress += Dirname( sAddress );
 	}
 	else
 	{
@@ -461,18 +461,18 @@ void ScreenPackages::EnterURL(const CString & sURL)
 	//XXX: This should be fixed by a prompt or something?
 
 	//if we are not talking about a file, let's not worry
-	if (m_sEndName != "" && m_bIsPackage)
+	if( m_sEndName != "" && m_bIsPackage )
 	{
 		CStringArray AddTo;
-		GetDirListing("Packages/" + m_sEndName, AddTo, false, false);
-		if (AddTo.size() > 0)
+		GetDirListing( "Packages/"+m_sEndName, AddTo, false, false );
+		if ( AddTo.size() > 0 )
 		{
 			m_sStatus = "File Already Exists";
 			UpdateProgress();
 			return;
 		}
 
-		if (!m_fOutputFile.Open("Packages/" + m_sEndName, RageFile::WRITE | RageFile::STREAMED))
+		if( !m_fOutputFile.Open( "Packages/"+m_sEndName, RageFile::WRITE | RageFile::STREAMED ) )
 		{
 			m_sStatus = m_fOutputFile.GetError();
 			UpdateProgress();
@@ -481,9 +481,9 @@ void ScreenPackages::EnterURL(const CString & sURL)
 	}
 	//Continue...
 
-	sAddress = HTTPHelper::URLEncode(sAddress);
+	sAddress = HTTPHelper::URLEncode( sAddress );
 
-	if (sAddress != "/")
+	if ( sAddress != "/" )
 		sAddress = "/" + sAddress;
 
 	m_wSocket.close();
@@ -491,22 +491,22 @@ void ScreenPackages::EnterURL(const CString & sURL)
 
 	m_wSocket.blocking = true;
 
-	if (!m_wSocket.connect(Server, (short)Port))
+	if( !m_wSocket.connect( Server, (short) Port ) )
 	{
 		m_sStatus = "Failed to connect.";
 		UpdateProgress();
 		return;
 	}
-
+	
 	//Produce HTTP header
 
-	CString Header = "";
+	CString Header="";
 
-	Header = "GET " + sAddress + " HTTP/1.0\r\n";
-	Header += "Host: " + Server + "\r\n";
-	Header += "Connection: closed\r\n\r\n";
+	Header = "GET "+sAddress+" HTTP/1.0\r\n";
+	Header+= "Host: " + Server + "\r\n";
+	Header+= "Connection: closed\r\n\r\n";
 
-	m_wSocket.SendData(Header.c_str(), Header.length());
+	m_wSocket.SendData( Header.c_str(), Header.length() );
 	m_sStatus = "Header Sent.";
 	m_wSocket.blocking = false;
 	m_bIsDownloading = true;
@@ -516,14 +516,14 @@ void ScreenPackages::EnterURL(const CString & sURL)
 	return;
 }
 
-static size_t FindEndOfHeaders(const CString &buf)
+static size_t FindEndOfHeaders( const CString &buf )
 {
-	size_t iPos1 = buf.find("\n\n");
-	size_t iPos2 = buf.find("\r\n\r\n");
+	size_t iPos1 = buf.find( "\n\n" );
+	size_t iPos2 = buf.find( "\r\n\r\n" );
 	LOG->Trace("end: %u, %u", unsigned(iPos1), unsigned(iPos2));
-	if (iPos1 != string::npos && (iPos2 == string::npos || iPos2 > iPos1))
+	if( iPos1 != string::npos && (iPos2 == string::npos || iPos2 > iPos1) )
 		return iPos1 + 2;
-	else if (iPos2 != string::npos && (iPos1 == string::npos || iPos1 > iPos2))
+	else if( iPos2 != string::npos && (iPos1 == string::npos || iPos1 > iPos2) )
 		return iPos2 + 4;
 	else
 		return string::npos;
@@ -531,62 +531,62 @@ static size_t FindEndOfHeaders(const CString &buf)
 
 void ScreenPackages::HTTPUpdate()
 {
-	if (!m_bIsDownloading)
+	if( !m_bIsDownloading )
 		return;
 
-	int BytesGot = 0;
+	int BytesGot=0;
 	//Keep this as a code block
 	//as there may be need to "if" it out some time.
 	/* If you need a conditional for a large block of code, stick it in
-	* a function and return. */
-	while (1)
+	 * a function and return. */
+	while(1)
 	{
 		char Buffer[1024];
-		int iSize = m_wSocket.ReadData(Buffer, 1024);
-		if (iSize <= 0)
+		int iSize = m_wSocket.ReadData( Buffer, 1024 );
+		if( iSize <= 0 )
 			break;
 
-		m_sBUFFER.append(Buffer, iSize);
+		m_sBUFFER.append( Buffer, iSize );
 		BytesGot += iSize;
 	}
 
-	if (!m_bGotHeader)
+	if( !m_bGotHeader )
 	{
 		m_sStatus = "Waiting for header.";
 		//We don't know if we are using unix-style or dos-style
-		size_t iHeaderEnd = FindEndOfHeaders(m_sBUFFER);
-		if (iHeaderEnd == m_sBUFFER.npos)
+		size_t iHeaderEnd = FindEndOfHeaders( m_sBUFFER );
+		if( iHeaderEnd == m_sBUFFER.npos )
 			return;
 
 		// "HTTP/1.1 200 OK"
 		size_t i = m_sBUFFER.find(" ");
-		size_t j = m_sBUFFER.find(" ", i + 1);
-		size_t k = m_sBUFFER.find("\n", j + 1);
-		if (i == string::npos || j == string::npos || k == string::npos)
+		size_t j = m_sBUFFER.find(" ",i+1);
+		size_t k = m_sBUFFER.find("\n",j+1);
+		if ( i == string::npos || j == string::npos || k == string::npos )
 		{
 			m_iResponseCode = -100;
 			m_sResponseName = "Malformed response.";
 			return;
 		}
-		m_iResponseCode = atoi(m_sBUFFER.substr(i + 1, j - i).c_str());
-		m_sResponseName = m_sBUFFER.substr(j + 1, k - j);
+		m_iResponseCode = atoi(m_sBUFFER.substr(i+1,j-i).c_str());
+		m_sResponseName = m_sBUFFER.substr( j+1, k-j );
 
 		i = m_sBUFFER.find("Content-Length:");
-		j = m_sBUFFER.find("\n", i + 1);
+		j = m_sBUFFER.find("\n", i+1 );
 
-		if (i != string::npos)
-			m_iTotalBytes = atoi(m_sBUFFER.substr(i + 16, j - i).c_str());
+		if( i != string::npos )
+			m_iTotalBytes = atoi(m_sBUFFER.substr(i+16,j-i).c_str());
 		else
 			m_iTotalBytes = -1;	//We don't know, so go until disconnect
 
 		m_bGotHeader = true;
-		m_sBUFFER.erase(0, iHeaderEnd);
+		m_sBUFFER.erase( 0, iHeaderEnd );
 	}
 
-	if (m_bIsPackage)
+	if( m_bIsPackage )
 	{
 		m_iDownloaded += m_sBUFFER.length();
-		m_fOutputFile.Write(m_sBUFFER);
+		m_fOutputFile.Write( m_sBUFFER );
 		m_sBUFFER = "";
 	}
 	else
@@ -594,25 +594,25 @@ void ScreenPackages::HTTPUpdate()
 		m_iDownloaded = m_sBUFFER.length();
 	}
 
-	if ((m_iTotalBytes <= m_iDownloaded && m_iTotalBytes != -1) ||
-		//We have the full doc. (And we knew how big it was)
-		(m_iTotalBytes == -1 &&
-		(m_wSocket.state == EzSockets::skERROR || m_wSocket.state == EzSockets::skDISCONNECTED)))
-		//We didn't know how big it was, and were disconnected
-		//So that means we have it all.
+	if ( ( m_iTotalBytes <= m_iDownloaded && m_iTotalBytes != -1 ) ||
+					//We have the full doc. (And we knew how big it was)
+		( m_iTotalBytes == -1 && 
+			( m_wSocket.state == EzSockets::skERROR || m_wSocket.state == EzSockets::skDISCONNECTED ) ) )
+				//We didn't know how big it was, and were disconnected
+				//So that means we have it all.
 	{
 		m_wSocket.close();
 		m_bIsDownloading = false;
-		m_bGotHeader = false;
-		m_sStatus = ssprintf("Done;%dB", int(m_iDownloaded));
+		m_bGotHeader=false;
+		m_sStatus = ssprintf( "Done;%dB", int(m_iDownloaded) );
 
-		if (m_iResponseCode < 200 || m_iResponseCode >= 400)
+		if( m_iResponseCode < 200 || m_iResponseCode >= 400 )
 		{
-			m_sStatus = ssprintf("%ld", m_iResponseCode) + m_sResponseName;
+			m_sStatus = ssprintf( "%ld", m_iResponseCode ) + m_sResponseName;
 		}
 		else
 		{
-			if (m_bIsPackage && m_iResponseCode < 300)
+			if( m_bIsPackage && m_iResponseCode < 300 )
 			{
 				m_fOutputFile.Close();
 				FlushDirCache();
@@ -629,26 +629,26 @@ void ScreenPackages::HTTPUpdate()
 
 #endif
 /*
-* (c) 2004 Charles Lohr
-* All rights reserved.
-*
-* Permission is hereby granted, free of charge, to any person obtaining a
-* copy of this software and associated documentation files (the
-* "Software"), to deal in the Software without restriction, including
-* without limitation the rights to use, copy, modify, merge, publish,
-* distribute, and/or sell copies of the Software, and to permit persons to
-* whom the Software is furnished to do so, provided that the above
-* copyright notice(s) and this permission notice appear in all copies of
-* the Software and that both the above copyright notice(s) and this
-* permission notice appear in supporting documentation.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
-* THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
-* INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
-* OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
-* OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
-* OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-* PERFORMANCE OF THIS SOFTWARE.
-*/
+ * (c) 2004 Charles Lohr
+ * All rights reserved.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, provided that the above
+ * copyright notice(s) and this permission notice appear in all copies of
+ * the Software and that both the above copyright notice(s) and this
+ * permission notice appear in supporting documentation.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+ * THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
+ * INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
+ * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */

--- a/src/ScreenPackages.h
+++ b/src/ScreenPackages.h
@@ -3,29 +3,35 @@
 
 #include "ScreenWithMenuElements.h"
 #include "BitmapText.h"
-#include "ezsockets.h"
 #include "RageFileManager.h"
 
 #if !defined(WITHOUT_NETWORKING)
+#include "HTTPHelper.h"
+#include "ezsockets.h"
+
+
 
 class ScreenPackages : public ScreenWithMenuElements
 {
 public:
-	ScreenPackages( CString sName );
+	ScreenPackages(CString sName);
 	virtual void Init();
 
-	virtual void Input( const DeviceInput& DeviceI, const InputEventType type, const GameInput &GameI, const MenuInput &MenuI, const StyleInput &StyleI );
-	virtual void HandleScreenMessage( const ScreenMessage SM );
+	virtual void Input(const DeviceInput& DeviceI, const InputEventType type, const GameInput &GameI, const MenuInput &MenuI, const StyleInput &StyleI);
+	virtual void HandleScreenMessage(const ScreenMessage SM);
 
-	virtual void MenuStart( PlayerNumber pn );
-	virtual void MenuUp( PlayerNumber pn, const InputEventType type );
-	virtual void MenuDown( PlayerNumber pn, const InputEventType type );
-	virtual void MenuLeft( PlayerNumber pn, const InputEventType type );
-	virtual void MenuRight( PlayerNumber pn, const InputEventType type );
-	virtual void MenuBack( PlayerNumber pn );
+	virtual void MenuStart(PlayerNumber pn);
+	virtual void MenuUp(PlayerNumber pn, const InputEventType type);
+	virtual void MenuDown(PlayerNumber pn, const InputEventType type);
+	virtual void MenuLeft(PlayerNumber pn, const InputEventType type);
+	virtual void MenuRight(PlayerNumber pn, const InputEventType type);
+	virtual void MenuBack(PlayerNumber pn);
 
-	virtual void TweenOffScreen( );
+	virtual void TweenOffScreen();
 	virtual void Update(float f);
+
+
+
 
 private:
 	void UpdatePackagesList();
@@ -34,8 +40,6 @@ private:
 
 	void HTMLParse();
 
-	CString URLEncode( const CString &URL );			//Encode any string in URL-style
-	CString StripOutContainers( const CString & In );	//Strip off "'s and ''s
 
 	Sprite	m_sprExistingBG;
 	Sprite	m_sprWebBG;
@@ -58,12 +62,11 @@ private:
 	int m_bCanDL;
 
 	//HTTP portion
-	void CancelDownload( );
-	void EnterURL( const CString & sURL );
-	void HTTPUpdate( );
+	void CancelDownload();
+	void EnterURL(const CString & sURL);
+	void HTTPUpdate();
 
-	//True if proper string, false if improper
-	bool ParseHTTPAddress( const CString & URL, CString & Proto, CString & Server, int & Port, CString & Addy );
+
 
 	Sprite	m_sprDL;
 	Sprite	m_sprDLBG;
@@ -100,26 +103,26 @@ private:
 
 #endif 
 /*
- * (c) 2004 Charles Lohr
- * All rights reserved.
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons to
- * whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies of
- * the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
- * THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
- * INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
- * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
- * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
- * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
- * PERFORMANCE OF THIS SOFTWARE.
- */
+* (c) 2004 Charles Lohr
+* All rights reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, and/or sell copies of the Software, and to permit persons to
+* whom the Software is furnished to do so, provided that the above
+* copyright notice(s) and this permission notice appear in all copies of
+* the Software and that both the above copyright notice(s) and this
+* permission notice appear in supporting documentation.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+* THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
+* INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
+* OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+* OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+* OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+* PERFORMANCE OF THIS SOFTWARE.
+*/

--- a/src/ScreenPackages.h
+++ b/src/ScreenPackages.h
@@ -14,20 +14,20 @@
 class ScreenPackages : public ScreenWithMenuElements
 {
 public:
-	ScreenPackages(CString sName);
+	ScreenPackages( CString sName );
 	virtual void Init();
 
-	virtual void Input(const DeviceInput& DeviceI, const InputEventType type, const GameInput &GameI, const MenuInput &MenuI, const StyleInput &StyleI);
-	virtual void HandleScreenMessage(const ScreenMessage SM);
+	virtual void Input( const DeviceInput& DeviceI, const InputEventType type, const GameInput &GameI, const MenuInput &MenuI, const StyleInput &StyleI );
+	virtual void HandleScreenMessage( const ScreenMessage SM );
 
-	virtual void MenuStart(PlayerNumber pn);
-	virtual void MenuUp(PlayerNumber pn, const InputEventType type);
-	virtual void MenuDown(PlayerNumber pn, const InputEventType type);
-	virtual void MenuLeft(PlayerNumber pn, const InputEventType type);
-	virtual void MenuRight(PlayerNumber pn, const InputEventType type);
-	virtual void MenuBack(PlayerNumber pn);
+	virtual void MenuStart( PlayerNumber pn );
+	virtual void MenuUp( PlayerNumber pn, const InputEventType type );
+	virtual void MenuDown( PlayerNumber pn, const InputEventType type );
+	virtual void MenuLeft( PlayerNumber pn, const InputEventType type );
+	virtual void MenuRight( PlayerNumber pn, const InputEventType type );
+	virtual void MenuBack( PlayerNumber pn );
 
-	virtual void TweenOffScreen();
+	virtual void TweenOffScreen( );
 	virtual void Update(float f);
 
 
@@ -62,11 +62,11 @@ private:
 	int m_bCanDL;
 
 	//HTTP portion
-	void CancelDownload();
-	void EnterURL(const CString & sURL);
-	void HTTPUpdate();
+	void CancelDownload( );
+	void EnterURL( const CString & sURL );
+	void HTTPUpdate( );
 
-
+	
 
 	Sprite	m_sprDL;
 	Sprite	m_sprDLBG;
@@ -103,26 +103,26 @@ private:
 
 #endif 
 /*
-* (c) 2004 Charles Lohr
-* All rights reserved.
-*
-* Permission is hereby granted, free of charge, to any person obtaining a
-* copy of this software and associated documentation files (the
-* "Software"), to deal in the Software without restriction, including
-* without limitation the rights to use, copy, modify, merge, publish,
-* distribute, and/or sell copies of the Software, and to permit persons to
-* whom the Software is furnished to do so, provided that the above
-* copyright notice(s) and this permission notice appear in all copies of
-* the Software and that both the above copyright notice(s) and this
-* permission notice appear in supporting documentation.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
-* THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
-* INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
-* OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
-* OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
-* OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-* PERFORMANCE OF THIS SOFTWARE.
-*/
+ * (c) 2004 Charles Lohr
+ * All rights reserved.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, provided that the above
+ * copyright notice(s) and this permission notice appear in all copies of
+ * the Software and that both the above copyright notice(s) and this
+ * permission notice appear in supporting documentation.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+ * THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
+ * INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
+ * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */

--- a/src/StepMania-net2010.vcxproj
+++ b/src/StepMania-net2010.vcxproj
@@ -494,6 +494,7 @@ cl /Zl /nologo /c verstub.cpp /Fo"$(IntDir)/verstub.obj"</Command>
     <ClCompile Include="arch\Lights\LightsDriver_EXTIO.cpp" />
     <ClCompile Include="arch\Lights\LightsDriver_Satellite.cpp" />
     <ClCompile Include="arch\MovieTexture\FFMpeg_Helper.cpp" />
+    <ClCompile Include="HTTPHelper.cpp" />
     <ClCompile Include="ibutton\crcutil.c">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='FastDebug|Win32'">NotUsing</PrecompiledHeader>
@@ -1228,6 +1229,7 @@ cl /Zl /nologo /c verstub.cpp /Fo"$(IntDir)/verstub.obj"</Command>
     <ClInclude Include="arch\Lights\LightsDriver_EXTIO.h" />
     <ClInclude Include="arch\Lights\LightsDriver_Satellite.h" />
     <ClInclude Include="arch\MovieTexture\FFMpeg_Helper.h" />
+    <ClInclude Include="HTTPHelper.h" />
     <ClInclude Include="ibutton\ds2480.h" />
     <ClInclude Include="ibutton\owfile.h" />
     <ClInclude Include="ibutton\ownet.h" />

--- a/src/StepMania-net2010.vcxproj.filters
+++ b/src/StepMania-net2010.vcxproj.filters
@@ -1457,6 +1457,7 @@
     <ClCompile Include="arch\ACIO\ACIO.cpp" />
     <ClCompile Include="io\MiniMaid.cpp" />
     <ClCompile Include="arch\InputHandler\InputHandler_MiniMaid.cpp" />
+    <ClCompile Include="HTTPHelper.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Screen.h">
@@ -2784,6 +2785,7 @@
     <ClInclude Include="io\P3IO.h" />
     <ClInclude Include="io\MiniMaid.h" />
     <ClInclude Include="arch\InputHandler\InputHandler_MiniMaid.h" />
+    <ClInclude Include="HTTPHelper.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="archutils\Win32\StepMania.ico">

--- a/src/arch/MemoryCard/MemoryCardDriverThreaded_Windows.cpp
+++ b/src/arch/MemoryCard/MemoryCardDriverThreaded_Windows.cpp
@@ -124,8 +124,13 @@ void MemoryCardDriverThreaded_Windows::GetUSBStorageDevices( vector<UsbStorageDe
 		bool bIsSpecifiedMountPoint = false;
 		FOREACH_PlayerNumber( p )
 		{
-			LOG->Trace("MemoryCardOsMountPointP%d: %s", (int)(p+1), MEMCARDMAN->m_sMemoryCardOsMountPoint[p].Get().c_str());
-			bIsSpecifiedMountPoint |= bool( !(MEMCARDMAN->m_sMemoryCardOsMountPoint[p].Get().CompareNoCase(sDrive)) );
+			CString sPointWithoutSlash = "" + MEMCARDMAN->m_sMemoryCardOsMountPoint[p].Get();
+			while (sPointWithoutSlash.c_str()[sPointWithoutSlash.length()]=='\\' || sPointWithoutSlash.c_str()[sPointWithoutSlash.length()]=='/')
+			{
+				sPointWithoutSlash = sPointWithoutSlash.Left(sPointWithoutSlash.length()-1);
+			}
+			LOG->Trace("MemoryCardOsMountPointP%d: %s", (int)(p+1), sPointWithoutSlash.c_str());
+			bIsSpecifiedMountPoint |= bool( !(sPointWithoutSlash.CompareNoCase(sDrive)) );
 		}
 
 		CString sDrivePath = sDrive + "\\";

--- a/src/arch/MemoryCard/MemoryCardDriverThreaded_Windows.cpp
+++ b/src/arch/MemoryCard/MemoryCardDriverThreaded_Windows.cpp
@@ -125,7 +125,7 @@ void MemoryCardDriverThreaded_Windows::GetUSBStorageDevices( vector<UsbStorageDe
 		FOREACH_PlayerNumber( p )
 		{
 			CString sPointWithoutSlash = "" + MEMCARDMAN->m_sMemoryCardOsMountPoint[p].Get();
-			while (sPointWithoutSlash.c_str()[sPointWithoutSlash.length()]=='\\' || sPointWithoutSlash.c_str()[sPointWithoutSlash.length()]=='/')
+			while (sPointWithoutSlash.length() > 1 && (sPointWithoutSlash.c_str()[sPointWithoutSlash.length()] == '\\' || sPointWithoutSlash.c_str()[sPointWithoutSlash.length()] == '/'))
 			{
 				sPointWithoutSlash = sPointWithoutSlash.Left(sPointWithoutSlash.length()-1);
 			}

--- a/src/ezsockets.cpp
+++ b/src/ezsockets.cpp
@@ -146,10 +146,10 @@ void EzSockets::setBlocking(bool b)
 	if (!b)	iMode=1;
 	ioctlsocket(sock, FIONBIO, &iMode);
 	#else
-	const int flags = fcntl(socket, F_GETFL, 0);
+	const int flags = fcntl(sock, F_GETFL, 0);
     if ((flags & O_NONBLOCK) && !b) { return; }
     if (!(flags & O_NONBLOCK) && b) { return; }
-    fcntl(sock, F_SETFL, b ? flags ^ O_NONBLOCK : flags | O_NONBLOCK));
+    fcntl(sock, F_SETFL, (b ? flags ^ O_NONBLOCK : flags | O_NONBLOCK));
 	#endif
 	blocking=b;
 }

--- a/src/ezsockets.cpp
+++ b/src/ezsockets.cpp
@@ -36,12 +36,12 @@
 EzSockets::EzSockets()
 {
 	MAXCON = 5;
-	memset(&addr, 0, sizeof(addr)); //Clear the sockaddr_in structure
-
+	memset (&addr,0,sizeof(addr)); //Clear the sockaddr_in structure
+	
 #if defined(_WINDOWS) || defined(_XBOX) // Windows REQUIRES WinSock Startup
-	WSAStartup(MAKEWORD(1, 1), &wsda);
+	WSAStartup( MAKEWORD(1,1), &wsda );
 #endif
-
+	
 	sock = INVALID_SOCKET;
 	blocking = true;
 	scks = new fd_set;
@@ -81,7 +81,7 @@ bool EzSockets::create()
 
 bool EzSockets::create(int Protocol)
 {
-	switch (Protocol)
+	switch(Protocol)
 	{
 	case IPPROTO_TCP:
 		return create(IPPROTO_TCP, SOCK_STREAM);
@@ -96,7 +96,7 @@ bool EzSockets::create(int Protocol)
 #else
 		return create(Protocol, SOCK_RAW);
 #endif
-
+			
 	}
 }
 
@@ -115,13 +115,13 @@ bool EzSockets::create(int Protocol, int Type)
 
 bool EzSockets::bind(unsigned short port)
 {
-	if (!check())
+	if(!check())
 		return false;
-
-	addr.sin_family = AF_INET;
+	
+	addr.sin_family      = AF_INET;
 	addr.sin_addr.s_addr = htonl(INADDR_ANY);
-	addr.sin_port = htons(port);
-	lastCode = ::bind(sock, (struct sockaddr*)&addr, sizeof(addr));
+	addr.sin_port        = htons(port);
+	lastCode = ::bind(sock,(struct sockaddr*)&addr, sizeof(addr));
 	return !lastCode;
 }
 
@@ -130,7 +130,7 @@ bool EzSockets::listen()
 	lastCode = ::listen(sock, MAXCON);
 	if (lastCode == SOCKET_ERROR)
 		return false;
-
+	
 	state = skLISTENING;
 	return true;
 }
@@ -145,26 +145,26 @@ bool EzSockets::accept(EzSockets& socket)
 	if (!blocking && !CanRead())
 		return false;
 
-#if defined(HAVE_INET_NTOP)
-	char buf[INET_ADDRSTRLEN];
+	#if defined(HAVE_INET_NTOP)
+		char buf[INET_ADDRSTRLEN];
 
-	inet_ntop(AF_INET, &addr.sin_addr, buf, INET_ADDRSTRLEN);
-	address = buf;
+		inet_ntop(AF_INET, &addr.sin_addr, buf, INET_ADDRSTRLEN);
+		address = buf;
 
-#elif defined(HAVE_INET_NTOA)
-	address = inet_ntoa(addr.sin_addr);
-#endif
-
+	#elif defined(HAVE_INET_NTOA)
+		address = inet_ntoa(addr.sin_addr);
+	#endif
+	
 	int length = sizeof(socket);
-
-	socket.sock = ::accept(sock, (struct sockaddr*) &socket.addr,
-		(socklen_t*)&length);
-
+	
+	socket.sock = ::accept(sock,(struct sockaddr*) &socket.addr, 
+						   (socklen_t*) &length);
+	
 	lastCode = socket.sock;
 
-	if (socket.sock == SOCKET_ERROR)
+	if ( socket.sock == SOCKET_ERROR )
 		return false;
-
+	
 	socket.state = skCONNECTED;
 	return true;
 }
@@ -174,7 +174,7 @@ void EzSockets::close()
 	state = skDISCONNECTED;
 	inBuffer = "";
 	outBuffer = "";
-
+	
 #if defined(WIN32) // The close socket command is different in Windows
 	::closesocket(sock);
 #else
@@ -190,11 +190,11 @@ long EzSockets::uAddr()
 
 bool EzSockets::connect(const std::string& host, unsigned short port)
 {
-	if (!check())
+	if(!check())
 		return false;
-
+	
 #if defined(_XBOX)
-	if (!isdigit(host[0])) // don't do a DNS lookup for an IP address
+	if(!isdigit(host[0])) // don't do a DNS lookup for an IP address
 	{
 		XNDNS *pxndns = NULL;
 		XNetDnsLookup(host.c_str(), NULL, &pxndns);
@@ -202,12 +202,12 @@ bool EzSockets::connect(const std::string& host, unsigned short port)
 		{
 			// Do something else while lookup is in progress
 		}
-
+		
 		if (pxndns->iStatus == 0)
 			memcpy(&addr.sin_addr, &pxndns->aina[0], sizeof(struct in_addr));
 		else
 			return false;
-
+		
 		XNetDnsRelease(pxndns);
 	}
 	else
@@ -220,11 +220,11 @@ bool EzSockets::connect(const std::string& host, unsigned short port)
 	memcpy(&addr.sin_addr, phe->h_addr, sizeof(struct in_addr));
 #endif 
 	addr.sin_family = AF_INET;
-	addr.sin_port = htons(port);
-
-	if (::connect(sock, (struct sockaddr*)&addr, sizeof(addr)) == SOCKET_ERROR)
+	addr.sin_port   = htons(port);
+	
+	if(::connect(sock, (struct sockaddr*)&addr, sizeof(addr)) == SOCKET_ERROR)
 		return false;
-
+	
 	state = skCONNECTED;
 	return true;
 }
@@ -233,21 +233,21 @@ bool EzSockets::CanRead()
 {
 	FD_ZERO(scks);
 	FD_SET((unsigned)sock, scks);
-
-	return select(sock + 1, scks, NULL, NULL, times) > 0;
+	
+	return select(sock+1,scks,NULL,NULL,times) > 0;
 }
 
 bool EzSockets::IsError()
 {
 	if (state == skERROR)
 		return true;
-
+	
 	FD_ZERO(scks);
 	FD_SET((unsigned)sock, scks);
-
-	if (select(sock + 1, NULL, NULL, scks, times) >= 0)
+	
+	if (select(sock+1, NULL, NULL, scks, times) >=0 )
 		return false;
-
+	
 	state = skERROR;
 	return true;
 }
@@ -256,19 +256,19 @@ bool EzSockets::CanWrite()
 {
 	FD_ZERO(scks);
 	FD_SET((unsigned)sock, scks);
-
-	return select(sock + 1, NULL, scks, NULL, times) > 0;
+	
+	return select(sock+1, NULL, scks, NULL, times) > 0;
 }
 
 void EzSockets::update()
 {
 	if (IsError()) //If socket is in error, don't bother.
 		return;
-
+	
 	while (CanRead() && !IsError()) //Check for Reading
 		if (pUpdateRead() < 1)
 			break;
-
+	
 	if (CanWrite() && (outBuffer.length()>0))
 		pUpdateWrite();
 }
@@ -280,7 +280,7 @@ void EzSockets::update()
 void EzSockets::SendData(const string& outData)
 {
 	outBuffer.append(outData);
-	if (blocking)
+	if(blocking)
 		while ((outBuffer.length()>0) && !IsError())
 			pUpdateWrite();
 	else
@@ -290,7 +290,7 @@ void EzSockets::SendData(const string& outData)
 void EzSockets::SendData(const char *data, unsigned int bytes)
 {
 	outBuffer.append(data, bytes);
-	if (blocking)
+	if(blocking)
 		while ((outBuffer.length()>0) && !IsError())
 			pUpdateWrite();
 	else
@@ -298,8 +298,8 @@ void EzSockets::SendData(const char *data, unsigned int bytes)
 }
 
 int EzSockets::ReadData(char *data, unsigned int bytes)
-{
-	int bytesRead = PeekData(data, bytes);
+{	
+	int bytesRead = PeekData(data,bytes);
 	inBuffer = inBuffer.substr(bytesRead);
 	return bytesRead;
 }
@@ -313,12 +313,12 @@ int EzSockets::PeekData(char *data, unsigned int bytes)
 		while (CanRead() && !IsError())
 			if (pUpdateRead()<1)
 				break;
-
+	
 	int bytesRead = bytes;
 	if (inBuffer.length()<bytes)
 		bytesRead = inBuffer.length();
-	memcpy(data, inBuffer.c_str(), bytesRead);
-
+	memcpy(data,inBuffer.c_str(), bytesRead);
+	
 	return bytesRead;
 }
 
@@ -329,17 +329,17 @@ int EzSockets::PeekData(char *data, unsigned int bytes)
 void EzSockets::SendPack(const char *data, unsigned int bytes)
 {
 	unsigned int SendSize = htonl(bytes);
-	outBuffer.append((const char *)& SendSize, 4);	//Add size to buffer, but don't send yet.
+	outBuffer.append( (const char *) & SendSize, 4);	//Add size to buffer, but don't send yet.
 	SendData(data, bytes);
 }
 
 int EzSockets::ReadPack(char *data, unsigned int max)
 {
 	int size = PeekPack(data, max);
-
+	
 	if (size != -1)
-		inBuffer = inBuffer.substr(size + 4);
-
+		inBuffer = inBuffer.substr(size+4);
+	
 	return size;
 }
 
@@ -347,39 +347,39 @@ int EzSockets::PeekPack(char *data, unsigned int max)
 {
 	if (CanRead())
 		pUpdateRead();
-
+	
 	if (blocking)
 	{
 		while ((inBuffer.length()<4) && !IsError())
 			pUpdateRead();
-
+		
 		if (IsError())
 			return -1;
 	}
-
+	
 	if (inBuffer.length()<4)
 		return -1;
-
+	
 	unsigned int size;
 	PeekData((char*)&size, 4);
 	size = ntohl(size);
-
+	
 	if (blocking)
-		while (inBuffer.length()<(size + 4) && !IsError())
+		while (inBuffer.length()<(size+4) && !IsError())
 			pUpdateRead();
 	else
-		if (inBuffer.length()<(size + 4) || inBuffer.length() <= 4)
+		if (inBuffer.length()<(size+4) || inBuffer.length()<=4)
 			return -1;
-
+	
 	if (IsError())
-		return -1;
+		return -1; 
 	//What if we get disconnected while waiting for data?
-
+	
 	string tBuff(inBuffer.substr(4, size));
 	if (tBuff.length() > max)
 		tBuff.substr(0, max);
-
-	memcpy(data, tBuff.c_str(), tBuff.length());
+	
+	memcpy (data, tBuff.c_str(),tBuff.length());
 	return size;
 }
 
@@ -399,13 +399,13 @@ int EzSockets::ReadStr(string& data, char delim)
 {
 	int t = PeekStr(data, delim);
 	if (t >= 0)
-		inBuffer = inBuffer.substr(t + 1);
+		inBuffer = inBuffer.substr(t+1);
 	return t;
 }
 
 int EzSockets::PeekStr(string& data, char delim)
 {
-	int t = inBuffer.find(delim, 0);
+	int t = inBuffer.find(delim,0);
 	if (blocking)
 	{
 		while (t == -1 && !IsError())
@@ -415,8 +415,8 @@ int EzSockets::PeekStr(string& data, char delim)
 		}
 		data = inBuffer.substr(0, t);
 	}
-
-	if (t >= 0)
+	
+	if(t >= 0)
 		data = inBuffer.substr(0, t);
 	return t;
 }
@@ -449,12 +449,12 @@ int EzSockets::pUpdateRead()
 {
 	char tempData[1024];
 	int bytes = pReadData(tempData);
-
+	
 	if (bytes > 0)
 		inBuffer.append(tempData, bytes);
 	else if (bytes <= 0)
 		/* To get her I think CanRead was called at least once.
-		So if length equals 0 and can read says there is data than
+		So if length equals 0 and can read says there is data than 
 		the socket was closed.*/
 		state = skERROR;
 	return bytes;
@@ -463,7 +463,7 @@ int EzSockets::pUpdateRead()
 int EzSockets::pUpdateWrite()
 {
 	int bytes = pWriteData(outBuffer.c_str(), outBuffer.length());
-
+	
 	if (bytes > 0)
 		outBuffer = outBuffer.substr(bytes);
 	else if (bytes < 0)
@@ -474,12 +474,12 @@ int EzSockets::pUpdateWrite()
 
 int EzSockets::pReadData(char* data)
 {
-	if (state == skCONNECTED || state == skLISTENING)
+	if(state == skCONNECTED || state == skLISTENING)
 		return recv(sock, data, 1024, 0);
-
+	
 	fromAddr_len = sizeof(sockaddr_in);
 	return recvfrom(sock, data, 1024, 0, (sockaddr*)&fromAddr,
-		(socklen_t*)&fromAddr_len);
+					(socklen_t*)&fromAddr_len);
 }
 
 int EzSockets::pWriteData(const char* data, int dataSize)
@@ -487,27 +487,28 @@ int EzSockets::pWriteData(const char* data, int dataSize)
 	return send(sock, data, dataSize, 0);
 }
 
-/*
-* (c) 2003-2004 Josh Allen, Charles Lohr, and Adam Lowman
-* All rights reserved.
-*
-* Permission is hereby granted, free of charge, to any person obtaining a
-* copy of this software and associated documentation files (the
-* "Software"), to deal in the Software without restriction, including
-* without limitation the rights to use, copy, modify, merge, publish,
-* distribute, and/or sell copies of the Software, and to permit persons to
-* whom the Software is furnished to do so, provided that the above
-* copyright notice(s) and this permission notice appear in all copies of
-* the Software and that both the above copyright notice(s) and this
-* permission notice appear in supporting documentation.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
-* THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
-* INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
-* OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
-* OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
-* OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-* PERFORMANCE OF THIS SOFTWARE.
-*/
+
+/* 
+ * (c) 2003-2004 Josh Allen, Charles Lohr, and Adam Lowman
+ * All rights reserved.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, provided that the above
+ * copyright notice(s) and this permission notice appear in all copies of
+ * the Software and that both the above copyright notice(s) and this
+ * permission notice appear in supporting documentation.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+ * THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
+ * INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
+ * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */

--- a/src/ezsockets.cpp
+++ b/src/ezsockets.cpp
@@ -151,6 +151,7 @@ void EzSockets::setBlocking(bool b)
     if (!(flags & O_NONBLOCK) && b) { return; }
     fcntl(sock, F_SETFL, b ? flags ^ O_NONBLOCK : flags | O_NONBLOCK));
 	#endif
+	blocking=b;
 }
 
 bool EzSockets::accept(EzSockets& socket)

--- a/src/ezsockets.h
+++ b/src/ezsockets.h
@@ -5,7 +5,7 @@
 |   Modified by Charles Lohr for use with Windows-Based OSes.       |
 |   UDP/NON-TCP Support by Adam Lowman.                             |
 \*******************************************************************/
- 
+
 #ifndef EZSOCKETS_H
 #define EZSOCKETS_H
 
@@ -47,6 +47,9 @@ public:
 	bool create(int Protocol);
 	bool create(int Protocol, int Type);
 
+	//set socket timeout
+	void setTimeout(int sec, int usec);
+
 	//Bind Socket to local port
 	bool bind(unsigned short port);
 
@@ -68,10 +71,10 @@ public:
 	long uAddr();
 
 	bool CanRead();
-	bool DataAvailable() { return ( ( inBuffer.length()>0 ) || CanRead() ); }
+	bool DataAvailable() { return ((inBuffer.length()>0) || CanRead()); }
 	bool IsError();
 	bool CanWrite();
-	
+
 	void update();
 
 	//Raw data system 
@@ -81,7 +84,7 @@ public:
 	int PeekData(char *data, unsigned int bytes);
 
 	//Packet system (for structures and classes)
-	void SendPack(const char *data, unsigned int bytes); 
+	void SendPack(const char *data, unsigned int bytes);
 	int ReadPack(char *data, unsigned int max);
 	int PeekPack(char *data, unsigned int max);
 
@@ -98,18 +101,18 @@ public:
 
 	bool blocking;
 	enum SockState
-	{ 
-		skDISCONNECTED = 0, 
+	{
+		skDISCONNECTED = 0,
 		skUNDEF1, //Not implemented
-		skLISTENING, 
+		skLISTENING,
 		skUNDEF3, //Not implemented
 		skUNDEF4, //Not implemented
 		skUNDEF5, //Not implemented
 		skUNDEF6, //Not implemented
-		skCONNECTED, 
-		skERROR 
+		skCONNECTED,
+		skERROR
 	};
-    struct sockaddr_in fromAddr;
+	struct sockaddr_in fromAddr;
 	unsigned long fromAddr_len;
 
 	//The following possibly should be private.
@@ -154,26 +157,26 @@ ostream& operator<<(ostream& os, EzSockets& obj);
 #endif
 
 /*
- * (c) 2003-2004 Josh Allen, Charles Lohr, and Adam Lowman
- * All rights reserved.
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons to
- * whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies of
- * the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
- * THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
- * INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
- * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
- * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
- * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
- * PERFORMANCE OF THIS SOFTWARE.
- */
+* (c) 2003-2004 Josh Allen, Charles Lohr, and Adam Lowman
+* All rights reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, and/or sell copies of the Software, and to permit persons to
+* whom the Software is furnished to do so, provided that the above
+* copyright notice(s) and this permission notice appear in all copies of
+* the Software and that both the above copyright notice(s) and this
+* permission notice appear in supporting documentation.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+* THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
+* INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
+* OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+* OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+* OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+* PERFORMANCE OF THIS SOFTWARE.
+*/

--- a/src/ezsockets.h
+++ b/src/ezsockets.h
@@ -5,7 +5,7 @@
 |   Modified by Charles Lohr for use with Windows-Based OSes.       |
 |   UDP/NON-TCP Support by Adam Lowman.                             |
 \*******************************************************************/
-
+ 
 #ifndef EZSOCKETS_H
 #define EZSOCKETS_H
 
@@ -71,10 +71,10 @@ public:
 	long uAddr();
 
 	bool CanRead();
-	bool DataAvailable() { return ((inBuffer.length()>0) || CanRead()); }
+	bool DataAvailable() { return ( ( inBuffer.length()>0 ) || CanRead() ); }
 	bool IsError();
 	bool CanWrite();
-
+	
 	void update();
 
 	//Raw data system 
@@ -84,7 +84,7 @@ public:
 	int PeekData(char *data, unsigned int bytes);
 
 	//Packet system (for structures and classes)
-	void SendPack(const char *data, unsigned int bytes);
+	void SendPack(const char *data, unsigned int bytes); 
 	int ReadPack(char *data, unsigned int max);
 	int PeekPack(char *data, unsigned int max);
 
@@ -101,18 +101,18 @@ public:
 
 	bool blocking;
 	enum SockState
-	{
-		skDISCONNECTED = 0,
+	{ 
+		skDISCONNECTED = 0, 
 		skUNDEF1, //Not implemented
-		skLISTENING,
+		skLISTENING, 
 		skUNDEF3, //Not implemented
 		skUNDEF4, //Not implemented
 		skUNDEF5, //Not implemented
 		skUNDEF6, //Not implemented
-		skCONNECTED,
-		skERROR
+		skCONNECTED, 
+		skERROR 
 	};
-	struct sockaddr_in fromAddr;
+    struct sockaddr_in fromAddr;
 	unsigned long fromAddr_len;
 
 	//The following possibly should be private.
@@ -130,6 +130,8 @@ public:
 	int lastCode;	//Used for debugging purposes
 
 	CString address;
+
+
 
 private:
 
@@ -157,26 +159,26 @@ ostream& operator<<(ostream& os, EzSockets& obj);
 #endif
 
 /*
-* (c) 2003-2004 Josh Allen, Charles Lohr, and Adam Lowman
-* All rights reserved.
-*
-* Permission is hereby granted, free of charge, to any person obtaining a
-* copy of this software and associated documentation files (the
-* "Software"), to deal in the Software without restriction, including
-* without limitation the rights to use, copy, modify, merge, publish,
-* distribute, and/or sell copies of the Software, and to permit persons to
-* whom the Software is furnished to do so, provided that the above
-* copyright notice(s) and this permission notice appear in all copies of
-* the Software and that both the above copyright notice(s) and this
-* permission notice appear in supporting documentation.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
-* THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
-* INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
-* OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
-* OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
-* OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-* PERFORMANCE OF THIS SOFTWARE.
-*/
+ * (c) 2003-2004 Josh Allen, Charles Lohr, and Adam Lowman
+ * All rights reserved.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, provided that the above
+ * copyright notice(s) and this permission notice appear in all copies of
+ * the Software and that both the above copyright notice(s) and this
+ * permission notice appear in supporting documentation.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+ * THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
+ * INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
+ * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */

--- a/src/ezsockets.h
+++ b/src/ezsockets.h
@@ -73,6 +73,7 @@ public:
 	bool CanRead();
 	bool DataAvailable() { return ( ( inBuffer.length()>0 ) || CanRead() ); }
 	bool IsError();
+	bool IsErrorNoSelect();
 	bool CanWrite();
 	
 	void update();
@@ -82,6 +83,8 @@ public:
 	void SendData(const char *data, unsigned int bytes);
 	int ReadData(char *data, unsigned int bytes);
 	int PeekData(char *data, unsigned int bytes);
+	int ReadDataNoSelect(char *data, unsigned int bytes);
+	int PeekDataNoSelect(char *data, unsigned int bytes);
 
 	//Packet system (for structures and classes)
 	void SendPack(const char *data, unsigned int bytes); 
@@ -92,6 +95,8 @@ public:
 	void SendStr(const string& data, char delim = '\0');
 	int ReadStr(string& data, char delim = '\0');
 	int PeekStr(string& data, char delim = '\0');
+
+	void setBlocking(bool b=true);
 
 
 	//Operators

--- a/src/io/P3IO.cpp
+++ b/src/io/P3IO.cpp
@@ -41,9 +41,9 @@ bool m_bConnected = false;
 uint8_t P3IO::p3io_request[256];
 uint8_t P3IO::p3io_response[256];
 char debug_message[2048];
-int bulk_reply_size=0;
-bool baud_pass=false;
-bool hdxb_ready=false;
+int bulk_reply_size = 0;
+bool baud_pass = false;
+bool hdxb_ready = false;
 
 
 
@@ -52,7 +52,7 @@ bool P3IO::DeviceMatches(int iVID, int iPID)
 
 	for (unsigned i = 0; i < NUM_P3IO_CHECKS_IDS; ++i)
 		if (iVID == P3IO_VENDOR_ID[i] && iPID == P3IO_PRODUCT_ID[i])
-			return true;	
+			return true;
 
 	return false;
 }
@@ -62,7 +62,7 @@ bool P3IO::Open()
 
 	if (m_COM4PORT.Get().length()>1)
 	{
-		COM4SET=true;
+		COM4SET = true;
 		com4.setPort(m_COM4PORT.Get().c_str());
 	}
 
@@ -95,24 +95,24 @@ bool P3IO::Open()
 			//ExitGame();
 
 
-			baud_pass=spamBaudCheck();
-			
-			// say the baud check passed anyway
-			baud_pass=true;
+			baud_pass = spamBaudCheck();
 
-			
-			if(baud_pass)
+			// say the baud check passed anyway
+			baud_pass = true;
+
+
+			if (baud_pass)
 			{
 				nodeCount();
-				getVersion(); 
-				initHDXB2(); 
-				initHDXB3(); 
-				initHDXB4(); 
+				getVersion();
+				initHDXB2();
+				initHDXB3();
+				initHDXB4();
 				pingHDXB();
 				HDXBAllOnTest();
-				hdxb_ready=true;
+				hdxb_ready = true;
 			}
-			
+
 			return m_bConnected;
 		}
 	m_bConnected = false;
@@ -121,20 +121,20 @@ bool P3IO::Open()
 
 void P3IO::HDXBAllOnTest()
 {
-	uint8_t all_on[0x0d]={
-	0x00,
-	0xff,
-	0xff,
-	0xff,
-	0xff,
-	0xff,
-	0xff,
-	0x7f,
-	0x7f,
-	0x7f,
-	0x7f,
-	0x7f,
-	0x7f
+	uint8_t all_on[0x0d] = {
+		0x00,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0x7f,
+		0x7f,
+		0x7f,
+		0x7f,
+		0x7f,
+		0x7f
 	};
 	LOG->Info("**************HDXB ALL ON TEST:");
 	writeHDXB(all_on, 0xd, HDXB_SET_LIGHTS);
@@ -318,24 +318,24 @@ bool P3IO::sendUnknownCommand()
 {
 	if (COM4SET) return true;
 	uint8_t unknown[] = {
-	0xaa,
-	0x04,
-	0x0a,
-	0x32,
-	0x01,
-	0x00
+		0xaa,
+		0x04,
+		0x0a,
+		0x32,
+		0x01,
+		0x00
 	};
-	LOG->Info("**************HDXB UNKNOWN COMMAND:");
-	return WriteToBulkWithExpectedReply( unknown, false, true);
+	//LOG->Info("**************HDXB UNKNOWN COMMAND:");
+	return WriteToBulkWithExpectedReply(unknown, false, true);
 }
 
 
 //sent every 78125us...
 bool P3IO::pingHDXB()
 {
-if (COM4SET)
+	if (COM4SET)
 	{
-		LOG->Info("**************HDXB Serial PING:");
+		//LOG->Info("**************HDXB Serial PING:");
 		uint8_t hdxb_ping_command[] = {
 			0xaa,//ACIO_PACKET_START
 			0x03,//HDXB
@@ -345,9 +345,9 @@ if (COM4SET)
 			0x00,
 			0x14//CHECKSUM
 		};
-		com4.write(hdxb_ping_command,7);
+		com4.write(hdxb_ping_command, 7);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4,acio_response);
+		ACIO::read_acio_packet(com4, acio_response);
 	}
 	else
 	{
@@ -366,7 +366,7 @@ if (COM4SET)
 			0x00,
 			0x14//CHECKSUM
 		};
-		LOG->Info("**************HDXB P3IO PING:");
+		//LOG->Info("**************HDXB P3IO PING:");
 		WriteToBulkWithExpectedReply(hdxb_ping_command, false, true);
 		return readHDXB(0x7e); // now flush it according to captures
 	}
@@ -376,44 +376,44 @@ if (COM4SET)
 
 bool P3IO::spamBaudCheck()
 {
-	bool found_baud=false;
+	bool found_baud = false;
 	if (COM4SET)
 	{
-		LOG->Info("**************HDXB Serial BAUD Routine:");
-		found_baud= ACIO::baudCheck(com4);
+		//LOG->Info("**************HDXB Serial BAUD Routine:");
+		found_baud = ACIO::baudCheck(com4);
 	}
 	else
 	{
 		uint8_t com_baud_command[] = {
-		0xaa, // packet start
-		0x0f, // length
-		0x05, // sequence
-		0x3a, // com write
-		0x00, // virtual com port
-		0x0b, // num bytes
-		0xaa, // baud check, escaped 0xaa
-		0xaa,	0xaa,	0xaa,	0xaa,	0xaa,	0xaa,	0xaa,	0xaa,	0xaa,	0xaa	};
+			0xaa, // packet start
+			0x0f, // length
+			0x05, // sequence
+			0x3a, // com write
+			0x00, // virtual com port
+			0x0b, // num bytes
+			0xaa, // baud check, escaped 0xaa
+			0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa };
 
-		for (int i=0;i<50;i++)
+		for (int i = 0; i<50; i++)
 		{
-			LOG->Info("**************HDXB P3IO BAUD:");
+			//LOG->Info("**************HDXB P3IO BAUD:");
 			WriteToBulkWithExpectedReply(com_baud_command, false, true);
 			readHDXB(0x40);
-			if (bulk_reply_size>=16 && p3io_response[1]==0x0F && p3io_response[4]==0x0B &&  p3io_response[5]==0xAA && p3io_response[6]==0xAA && p3io_response[7]==0xAA && p3io_response[8]==0xAA && p3io_response[9]==0xAA && p3io_response[10]==0xAA && p3io_response[11]==0xAA && p3io_response[12]==0xAA && p3io_response[13]==0xAA && p3io_response[14]==0xAA && p3io_response[15]==0xAA)
+			if (bulk_reply_size >= 16 && p3io_response[1] == 0x0F && p3io_response[4] == 0x0B && p3io_response[5] == 0xAA && p3io_response[6] == 0xAA && p3io_response[7] == 0xAA && p3io_response[8] == 0xAA && p3io_response[9] == 0xAA && p3io_response[10] == 0xAA && p3io_response[11] == 0xAA && p3io_response[12] == 0xAA && p3io_response[13] == 0xAA && p3io_response[14] == 0xAA && p3io_response[15] == 0xAA)
 			{
-			
-				LOG->Info("**************HDXB P3IO GOT BAUD RATE! Flushing...");
+
+				//LOG->Info("**************HDXB P3IO GOT BAUD RATE! Flushing...");
 				readHDXB(0x40); // now flush it
-			
+
 				readHDXB(0x40); // now flush it
-				found_baud=true;
+				found_baud = true;
 				break;
 			}
 		}
 	}
 
 	return found_baud;
-	
+
 
 }
 
@@ -421,19 +421,19 @@ bool P3IO::nodeCount()
 {
 	if (COM4SET)
 	{
-		uint8_t nodes[]={0xaa,0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x02}; 
-		com4.write(nodes,8);
+		uint8_t nodes[] = { 0xaa, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x02 };
+		com4.write(nodes, 8);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4,acio_response);
+		ACIO::read_acio_packet(com4, acio_response);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4,acio_response);//flush
+		ACIO::read_acio_packet(com4, acio_response);//flush
 		return true;
 	}
 	else
 	{
 		// 00    00    01    00    PP    07    CC -- 01 is the command for enumeration, PP is 01 (payload length), 07 is the payload with a reply of 7 in it, CC is checksum
-		uint8_t nodes[]={0xaa,0x0e,0x01,0x3a,0x00,0x08,0xaa,0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x02}; 
-		LOG->Info("**************HDXB P3IO Get Node Count:");
+		uint8_t nodes[] = { 0xaa, 0x0e, 0x01, 0x3a, 0x00, 0x08, 0xaa, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x02 };
+		//LOG->Info("**************HDXB P3IO Get Node Count:");
 		WriteToBulkWithExpectedReply(nodes, false, true);
 		readHDXB(0x40);
 		return readHDXB(0x40); // now flush it
@@ -442,9 +442,9 @@ bool P3IO::nodeCount()
 
 bool P3IO::getVersion()
 {
-	if(COM4SET)
+	if (COM4SET)
 	{
-		uint8_t ICCB_1[]={
+		uint8_t ICCB_1[] = {
 			0xaa,//ACIO START
 			0x01,//ICCB1
 			0x00,//TYPE?
@@ -453,7 +453,7 @@ bool P3IO::getVersion()
 			0x00,
 			0x03,
 		};
-		uint8_t ICCB_2[]={
+		uint8_t ICCB_2[] = {
 			0xaa,//ACIO START
 			0x02,//ICCB2
 			0x00,//TYPE?
@@ -462,7 +462,7 @@ bool P3IO::getVersion()
 			0x00,
 			0x04,
 		};
-		uint8_t HDXB[]={
+		uint8_t HDXB[] = {
 			0xaa,//ACIO START
 			0x03,//HDXB
 			0x00,//TYPE?
@@ -471,31 +471,31 @@ bool P3IO::getVersion()
 			0x00,
 			0x05,
 		};
-		LOG->Info("**************ICCB1 Serial Get Version:");
+		//LOG->Info("**************ICCB1 Serial Get Version:");
 
-		com4.write(ICCB_1,7);
+		com4.write(ICCB_1, 7);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4,acio_response);
+		ACIO::read_acio_packet(com4, acio_response);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4,acio_response);
-		LOG->Info("**************ICCB2 Serial Get Version:");
-		com4.write(ICCB_2,7);
+		ACIO::read_acio_packet(com4, acio_response);
+		//LOG->Info("**************ICCB2 Serial Get Version:");
+		com4.write(ICCB_2, 7);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4,acio_response);
+		ACIO::read_acio_packet(com4, acio_response);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4,acio_response);
-		LOG->Info("**************HDXB Serial Get Version:");
-		com4.write(HDXB,7);
+		ACIO::read_acio_packet(com4, acio_response);
+		//LOG->Info("**************HDXB Serial Get Version:");
+		com4.write(HDXB, 7);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4,acio_response);
+		ACIO::read_acio_packet(com4, acio_response);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4,acio_response);
+		ACIO::read_acio_packet(com4, acio_response);
 		return true;
 	}
 	else
 	{
 		//should build this but.. meh... lazy, manually define it
-		uint8_t ICCB_1[]={
+		uint8_t ICCB_1[] = {
 			0xaa,
 			0x0d,
 			0x01,
@@ -510,7 +510,7 @@ bool P3IO::getVersion()
 			0x00,
 			0x03,
 		};
-		uint8_t ICCB_2[]={
+		uint8_t ICCB_2[] = {
 			0xaa,
 			0x0d,
 			0x01,
@@ -525,7 +525,7 @@ bool P3IO::getVersion()
 			0x00,
 			0x04,
 		};
-		uint8_t HDXB[]={
+		uint8_t HDXB[] = {
 			0xaa,
 			0x0d,
 			0x01,
@@ -540,15 +540,15 @@ bool P3IO::getVersion()
 			0x00,
 			0x05,
 		};
-		LOG->Info("**************ICCB1 P3IO Get Version:");
+		//LOG->Info("**************ICCB1 P3IO Get Version:");
 		WriteToBulkWithExpectedReply(ICCB_1, false, true);
 		readHDXB(0x7e);
 		readHDXB(0x7e);
-		LOG->Info("**************ICCB2 P3IO Get Version:");
+		//LOG->Info("**************ICCB2 P3IO Get Version:");
 		WriteToBulkWithExpectedReply(ICCB_2, false, true);
 		readHDXB(0x7e);
 		readHDXB(0x7e);
-		LOG->Info("**************HDXB P3IO Get Version:");
+		//LOG->Info("**************HDXB P3IO Get Version:");
 		WriteToBulkWithExpectedReply(HDXB, false, true);
 		readHDXB(0x7e);
 		return readHDXB(0x7e);
@@ -557,11 +557,11 @@ bool P3IO::getVersion()
 
 bool P3IO::initHDXB2()
 {
-	if(COM4SET)
+	if (COM4SET)
 	{
 		//should build this but.. meh... lazy, manually define it
 		//init into opcode 3?
-		uint8_t hdxb_op3[]={
+		uint8_t hdxb_op3[] = {
 			0xaa,//ACIO START
 			0x03,//HDXB
 			0x00,//TYPE?
@@ -571,30 +571,30 @@ bool P3IO::initHDXB2()
 			0x06,
 		};
 
-		uint8_t ICCB1_op3[]={0xaa,0x01,0x00,0x03,0x00,0x00,0x04};
-		uint8_t ICCB2_op3[]={0xaa,0x02,0x00,0x03,0x00,0x00,0x05};
-	
-		LOG->Info("**************ICCB1 Serial INIT mode 3:");
-		com4.write(ICCB1_op3,7);
+		uint8_t ICCB1_op3[] = { 0xaa, 0x01, 0x00, 0x03, 0x00, 0x00, 0x04 };
+		uint8_t ICCB2_op3[] = { 0xaa, 0x02, 0x00, 0x03, 0x00, 0x00, 0x05 };
+
+		//LOG->Info("**************ICCB1 Serial INIT mode 3:");
+		com4.write(ICCB1_op3, 7);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4,acio_response);
-		LOG->Info("**************ICCB2 Serial INIT mode 3:");
-		com4.write(ICCB2_op3,7);
+		ACIO::read_acio_packet(com4, acio_response);
+		//LOG->Info("**************ICCB2 Serial INIT mode 3:");
+		com4.write(ICCB2_op3, 7);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4,acio_response);
-		LOG->Info("**************HDXB Serial INIT mode 3:");
-		com4.write(hdxb_op3,7);
+		ACIO::read_acio_packet(com4, acio_response);
+		//LOG->Info("**************HDXB Serial INIT mode 3:");
+		com4.write(hdxb_op3, 7);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4,acio_response);
+		ACIO::read_acio_packet(com4, acio_response);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4,acio_response);// now flush it according to captures
-		return true; 
+		ACIO::read_acio_packet(com4, acio_response);// now flush it according to captures
+		return true;
 	}
 	else
 	{
 		//should build this but.. meh... lazy, manually define it
 		//init into opcode 3?
-		uint8_t hdxb_op3[]={
+		uint8_t hdxb_op3[] = {
 			0xaa,
 			0x0d,
 			0x01,
@@ -610,16 +610,16 @@ bool P3IO::initHDXB2()
 			0x06,
 		};
 
-		uint8_t ICCB1_op3[]={0xaa,0x0d,0x02,0x3a,0x00,0x07,0xaa,0x01,0x00,0x03,0x00,0x00,0x04};
-		uint8_t ICCB2_op3[]={0xaa,0x0d,0x03,0x3a,0x00,0x07,0xaa,0x02,0x00,0x03,0x00,0x00,0x05};
-	
-		LOG->Info("**************ICCB1 P3IO INIT mode 3:");
+		uint8_t ICCB1_op3[] = { 0xaa, 0x0d, 0x02, 0x3a, 0x00, 0x07, 0xaa, 0x01, 0x00, 0x03, 0x00, 0x00, 0x04 };
+		uint8_t ICCB2_op3[] = { 0xaa, 0x0d, 0x03, 0x3a, 0x00, 0x07, 0xaa, 0x02, 0x00, 0x03, 0x00, 0x00, 0x05 };
+
+		//LOG->Info("**************ICCB1 P3IO INIT mode 3:");
 		WriteToBulkWithExpectedReply(ICCB1_op3, false, true);
 		readHDXB(0x7e);
-		LOG->Info("**************ICCB2 P3IO INIT mode 3:");
+		//LOG->Info("**************ICCB2 P3IO INIT mode 3:");
 		WriteToBulkWithExpectedReply(ICCB2_op3, false, true);
 		readHDXB(0x7e);
-		LOG->Info("**************HDXB P3IO INIT mode 3:");
+		//LOG->Info("**************HDXB P3IO INIT mode 3:");
 		WriteToBulkWithExpectedReply(hdxb_op3, false, true);
 		readHDXB(0x7e);
 		return readHDXB(0x7e); // now flush it according to captures
@@ -629,10 +629,10 @@ bool P3IO::initHDXB2()
 
 bool P3IO::initHDXB3()
 {
-	if(COM4SET)
+	if (COM4SET)
 	{
 		//should build this but.. meh... lazy, manually define it
-		uint8_t hdxb_type[]={
+		uint8_t hdxb_type[] = {
 			0xaa,//ACIO START
 			0x03,//HDXB
 			0x01,//TYPE?
@@ -641,34 +641,34 @@ bool P3IO::initHDXB3()
 			0x00,
 			0x04,
 		};
-		uint8_t iccb1_type[]={0xaa,0x01,0x01,0x00,0x00,0x00,0x02};
-		uint8_t iccb2_type[]={0xaa,0x02,0x01,0x00,0x00,0x00,0x03};
-	
-		LOG->Info("**************ICCB1 Serial INIT type 0:");
-		com4.write(iccb1_type,7);
+		uint8_t iccb1_type[] = { 0xaa, 0x01, 0x01, 0x00, 0x00, 0x00, 0x02 };
+		uint8_t iccb2_type[] = { 0xaa, 0x02, 0x01, 0x00, 0x00, 0x00, 0x03 };
+
+		//LOG->Info("**************ICCB1 Serial INIT type 0:");
+		com4.write(iccb1_type, 7);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4,acio_response);
+		ACIO::read_acio_packet(com4, acio_response);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4,acio_response);
-		LOG->Info("**************ICCB2 Serial  INIT type 0:");
-		com4.write(iccb2_type,7);
+		ACIO::read_acio_packet(com4, acio_response);
+		//LOG->Info("**************ICCB2 Serial  INIT type 0:");
+		com4.write(iccb2_type, 7);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4,acio_response);
+		ACIO::read_acio_packet(com4, acio_response);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4,acio_response);
-		LOG->Info("**************HDXB Serial  INIT type 0:");
-		com4.write(hdxb_type,7);
+		ACIO::read_acio_packet(com4, acio_response);
+		//LOG->Info("**************HDXB Serial  INIT type 0:");
+		com4.write(hdxb_type, 7);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4,acio_response);
+		ACIO::read_acio_packet(com4, acio_response);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4,acio_response);
+		ACIO::read_acio_packet(com4, acio_response);
 		return true;
 	}
 	else
 	{
 
 		//should build this but.. meh... lazy, manually define it
-		uint8_t hdxb_type[]={
+		uint8_t hdxb_type[] = {
 			0xaa,
 			0x0d,
 			0x01,
@@ -683,18 +683,18 @@ bool P3IO::initHDXB3()
 			0x00,
 			0x04,
 		};
-		uint8_t iccb1_type[]={0xaa,0x0b,0x0a,0x3a,0x00,0x07,0xaa,0x01,0x01,0x00,0x00,0x00,0x02};
-		uint8_t iccb2_type[]={0xaa,0x0b,0x0e,0x3a,0x00,0x07,0xaa,0x02,0x01,0x00,0x00,0x00,0x03};
-	
-		LOG->Info("**************ICCB1 P3IO INIT type 0:");
+		uint8_t iccb1_type[] = { 0xaa, 0x0b, 0x0a, 0x3a, 0x00, 0x07, 0xaa, 0x01, 0x01, 0x00, 0x00, 0x00, 0x02 };
+		uint8_t iccb2_type[] = { 0xaa, 0x0b, 0x0e, 0x3a, 0x00, 0x07, 0xaa, 0x02, 0x01, 0x00, 0x00, 0x00, 0x03 };
+
+		//LOG->Info("**************ICCB1 P3IO INIT type 0:");
 		WriteToBulkWithExpectedReply(iccb1_type, false, true);
 		readHDXB(0x7e);
 		readHDXB(0x7e); // now flush it according to captures
-		LOG->Info("**************ICCB2 P3IO INIT type 0:");
+		//LOG->Info("**************ICCB2 P3IO INIT type 0:");
 		WriteToBulkWithExpectedReply(iccb2_type, false, true);
 		readHDXB(0x7e);
 		readHDXB(0x7e); // now flush it according to captures
-		LOG->Info("**************HDXB P3IO INIT type 0:");
+		//LOG->Info("**************HDXB P3IO INIT type 0:");
 		WriteToBulkWithExpectedReply(hdxb_type, false, true);
 		readHDXB(0x7e);
 		return readHDXB(0x7e); // now flush it according to captures
@@ -704,10 +704,10 @@ bool P3IO::initHDXB3()
 
 bool P3IO::initHDXB4()
 {
-	if(COM4SET)
+	if (COM4SET)
 	{
 		//should build this but.. meh... lazy, manually define it
-		uint8_t breath_of_life[]={
+		uint8_t breath_of_life[] = {
 			0xaa,//ACIO START
 			0x03,//HDXB
 			0x01,//TYPE?
@@ -718,16 +718,16 @@ bool P3IO::initHDXB4()
 			0x00,
 			0x2e
 		};
-		LOG->Info("**************HDXB Serial INIT4:");
-		com4.write(breath_of_life,9);
+		//LOG->Info("**************HDXB Serial INIT4:");
+		com4.write(breath_of_life, 9);
 		usleep(72000); // 36 ms wait
-		ACIO::read_acio_packet(com4,acio_response);
+		ACIO::read_acio_packet(com4, acio_response);
 		return true;
 	}
 	else
 	{
 		//should build this but.. meh... lazy, manually define it
-		uint8_t breath_of_life[]={
+		uint8_t breath_of_life[] = {
 			0xaa,
 			0x0d,
 			0x01,
@@ -744,7 +744,7 @@ bool P3IO::initHDXB4()
 			0x00,
 			0x2e
 		};
-		LOG->Info("**************HDXB P3IO INIT4:");
+		//LOG->Info("**************HDXB P3IO INIT4:");
 		return WriteToBulkWithExpectedReply(breath_of_life, false, true);
 		//We are NOT reading because the capture says we don't at this point!
 	}
@@ -757,23 +757,23 @@ bool P3IO::openHDXB()
 	{
 		com4.open();
 		com4.setBaudrate(38400);
-		LOG->Info("**************HDXB SERIAL OPEN:");
+		//LOG->Info("**************HDXB SERIAL OPEN:");
 		return true;
 	}
 	else
 	{
 
-	
+
 		uint8_t com_open_command[] = {
-		0xaa, // packet start
-		0x05, // length
-		0x06, // sequence
-		0x38, // com open opcode
-		0x00, // virtual com port
-		0x00, // @ baud
-		0x03  // choose speed: ?, ?, 19200, 38400, 57600
+			0xaa, // packet start
+			0x05, // length
+			0x06, // sequence
+			0x38, // com open opcode
+			0x00, // virtual com port
+			0x00, // @ baud
+			0x03  // choose speed: ?, ?, 19200, 38400, 57600
 		};
-		LOG->Info("**************HDXB P3IO OPEN:");
+		//LOG->Info("**************HDXB P3IO OPEN:");
 		return WriteToBulkWithExpectedReply(com_open_command, false, true);
 	}
 }
@@ -789,28 +789,28 @@ bool P3IO::readHDXB(int len)
 		0x00, // virtual com port
 		0x7e  // 7e is 126 bytes to read
 	};
-	com_read_command[5]=len&0xFF; // plug in passed in len
-	LOG->Info("**************HDXB P3IO Read:");
+	com_read_command[5] = len & 0xFF; // plug in passed in len
+	//LOG->Info("**************HDXB P3IO Read:");
 	return WriteToBulkWithExpectedReply(com_read_command, false, true);
 }
 
 //pass in a raw payload only
 bool P3IO::writeHDXB(uint8_t* payload, int len, uint8_t opcode)
 {
-	if(COM4SET)
+	if (COM4SET)
 	{
-	
+
 		//frame: 03:01:12:00:0d
 		//payload consists of 00:ff:ff:ff:ff:ff:ff:7f:7f:7f:7f:7f:7f
 		//must also accomodate acio packet of: aa:03:01:28:00:02:00:00:2e
-		acio_request[0]=0x03; // hdxb device id
-		acio_request[1]=0x01; // type?
-		acio_request[2]=opcode; // set lights?
-		acio_request[3]=0x00; //
-		acio_request[4]=len & 0xFF; // length
-	
+		acio_request[0] = 0x03; // hdxb device id
+		acio_request[1] = 0x01; // type?
+		acio_request[2] = opcode; // set lights?
+		acio_request[3] = 0x00; //
+		acio_request[4] = len & 0xFF; // length
+
 		//len should be 0x0d
-		memcpy( &acio_request[5],  payload, len * sizeof( uint8_t ) );
+		memcpy(&acio_request[5], payload, len * sizeof(uint8_t));
 
 		//03:01:12:00:0d:00:ff:ff:ff:ff:ff:ff:7f:7f:7f:7f:7f:7f
 		len++; // add checksum to length of payload
@@ -819,25 +819,25 @@ bool P3IO::writeHDXB(uint8_t* payload, int len, uint8_t opcode)
 		//uint8_t unescaped_acio_length = len & 0xFF; // but we dont need this, we need number of bytes to write to acio bus
 
 		//get escaped packet and length
-		len+=5; //acio frame bytes added
-		len = ACIO::prep_acio_packet_for_transmission(acio_request,len); 
-		com4.write(acio_request,len);
+		len += 5; //acio frame bytes added
+		len = ACIO::prep_acio_packet_for_transmission(acio_request, len);
+		com4.write(acio_request, len);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4,acio_response);
+		ACIO::read_acio_packet(com4, acio_response);
 	}
 	else
 	{
 		//frame: 03:01:12:00:0d
 		//payload consists of 00:ff:ff:ff:ff:ff:ff:7f:7f:7f:7f:7f:7f
 		//must also accomodate acio packet of: aa:03:01:28:00:02:00:00:2e
-		p3io_request[0]=0x03; // hdxb device id
-		p3io_request[1]=0x01; // type?
-		p3io_request[2]=opcode; // set lights?
-		p3io_request[3]=0x00; //
-		p3io_request[4]=len & 0xFF; // length
-	
+		p3io_request[0] = 0x03; // hdxb device id
+		p3io_request[1] = 0x01; // type?
+		p3io_request[2] = opcode; // set lights?
+		p3io_request[3] = 0x00; //
+		p3io_request[4] = len & 0xFF; // length
+
 		//len should be 0x0d
-		memcpy( &p3io_request[5],  payload, len * sizeof( uint8_t ) );
+		memcpy(&p3io_request[5], payload, len * sizeof(uint8_t));
 
 		//03:01:12:00:0d:00:ff:ff:ff:ff:ff:ff:7f:7f:7f:7f:7f:7f
 		len++; // add checksum to length of payload
@@ -846,22 +846,22 @@ bool P3IO::writeHDXB(uint8_t* payload, int len, uint8_t opcode)
 		//uint8_t unescaped_acio_length = len & 0xFF; // but we dont need this, we need number of bytes to write to acio bus
 
 		//get escaped packet and length
-		len+=5; //acio frame bytes added
-		len = ACIO::prep_acio_packet_for_transmission(p3io_request,len); 
+		len += 5; //acio frame bytes added
+		len = ACIO::prep_acio_packet_for_transmission(p3io_request, len);
 
 		//we are now ready to transmit over p3io channels...
 		uint8_t p3io_acio_message[256];
-		p3io_acio_message[0]=0xaa;
-		p3io_acio_message[1]=(len+4) & 0xFF;
-		p3io_acio_message[2]=0;
-		p3io_acio_message[3]=0x3a; //com port write
-		p3io_acio_message[4]=0; // actual virtual com port number to use
-		p3io_acio_message[5]=len&0xFF; //num bytes to write on the acio bus
-		memcpy( &p3io_acio_message[6],  p3io_request, len * sizeof( uint8_t ) ); // stuff in a p3io wrapper
-		LOG->Info("**************HDXB P3IO LIGHT Write:");
+		p3io_acio_message[0] = 0xaa;
+		p3io_acio_message[1] = (len + 4) & 0xFF;
+		p3io_acio_message[2] = 0;
+		p3io_acio_message[3] = 0x3a; //com port write
+		p3io_acio_message[4] = 0; // actual virtual com port number to use
+		p3io_acio_message[5] = len & 0xFF; //num bytes to write on the acio bus
+		memcpy(&p3io_acio_message[6], p3io_request, len * sizeof(uint8_t)); // stuff in a p3io wrapper
+		//LOG->Info("**************HDXB P3IO LIGHT Write:");
 		WriteToBulkWithExpectedReply(p3io_acio_message, false, true);
-		LOG->Info("**************HDXB P3IO Get Ping:");
-	
+		//LOG->Info("**************HDXB P3IO Get Ping:");
+
 	}
 	return pingHDXB();
 }
@@ -880,16 +880,16 @@ bool P3IO::writeLights(uint8_t* payload)
 	//arbitrary keep alive signal. maybe can dial this back? send one evry 4 attempts
 	//lights are CONSTANTLY sending in this architecture
 	packets_since_keepalive %= 6;
-	
 
-	
+
+
 	//compare last payload with this payload -- prevent useless chatter on USB so input has best poll rate
-	if ( (memcmp(p_light_payload, payload, sizeof(p_light_payload))!=0) || (packets_since_keepalive == 0) )
+	if ((memcmp(p_light_payload, payload, sizeof(p_light_payload)) != 0) || (packets_since_keepalive == 0))
 	{	//if they dont match...
-		
+
 		//copy new payload to previous payload so I can check it next round
 		memcpy(p_light_payload, payload, sizeof(p_light_payload));
-	
+
 		//make a light message
 		uint8_t light_message[] = { 0xaa, 0x07, 0x00, 0x24, ~payload[4], payload[3], payload[2], payload[1], payload[0] };
 		//LOG->Info("P3io driver Sending light message: %02X %02X %02X %02X %02X %02X %02X %02X %02X", light_message[0],light_message[1],light_message[2],light_message[3],light_message[4],light_message[5],light_message[6],light_message[7],light_message[8]);
@@ -919,12 +919,12 @@ bool P3IO::WriteToBulkWithExpectedReply(uint8_t* message, bool init_packet, bool
 
 	//max packet size is 64 bytes * 2 for escaped packets
 	uint8_t response[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-						   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
 	int message_length = 5;
 	int expected_response_size = 3; // handles packet start, length, sequence.. everything should be long than this though. Updates in the function
 
-	message_length = message[1]+2;
+	message_length = message[1] + 2;
 
 
 
@@ -938,63 +938,63 @@ bool P3IO::WriteToBulkWithExpectedReply(uint8_t* message, bool init_packet, bool
 	{
 
 
-		case 0x01: // version query
-			expected_response_size = 11;
-			break;
+	case 0x01: // version query
+	expected_response_size = 11;
+	break;
 
-		case 0x31: //coin query
-			expected_response_size = 9;
-			break;
-	
-		case 0x2f:// some query
-			expected_response_size = 5;
-			break;
+	case 0x31: //coin query
+	expected_response_size = 9;
+	break;
 
-		case 0x27: //cabinet type query
-			expected_response_size = 5;
-			break;
+	case 0x2f:// some query
+	expected_response_size = 5;
+	break;
+
+	case 0x27: //cabinet type query
+	expected_response_size = 5;
+	break;
 
 
-		case 0x24: //set light state?
-			expected_response_size = 6;
-			break;
+	case 0x24: //set light state?
+	expected_response_size = 6;
+	break;
 
-		case 0x25: //get dongle
-			expected_response_size = 45;
-			break;
-		case 0x3a: // com write
-			expected_response_size = 5; /// basically an ack
-			break;
-	
-		default:
-			expected_response_size = 5;
+	case 0x25: //get dongle
+	expected_response_size = 45;
+	break;
+	case 0x3a: // com write
+	expected_response_size = 5; /// basically an ack
+	break;
+
+	default:
+	expected_response_size = 5;
 	}
 	*/
 	//End horribly wrong segment
-	
-	
+
+
 	//LOG->Info("Expected response size is %d", expected_response_size);
 	//actually send our message with the parameters we determined
 	//but first we need to escape our shit
 
 
 	//LOG->Info("Escaping our shit");
-	int bytes_to_write=message_length;
+	int bytes_to_write = message_length;
 	uint8_t message2[258];
-	message2[0]=message[0];
-	int old_stream_position=1;
-	for (int new_stream_position=1;new_stream_position<bytes_to_write;new_stream_position++)
+	message2[0] = message[0];
+	int old_stream_position = 1;
+	for (int new_stream_position = 1; new_stream_position<bytes_to_write; new_stream_position++)
 	{
-		if (message[old_stream_position]==0xAA || message[old_stream_position]==0xFF)
+		if (message[old_stream_position] == 0xAA || message[old_stream_position] == 0xFF)
 		{
-			message2[new_stream_position]=0xFF;
+			message2[new_stream_position] = 0xFF;
 			new_stream_position++;
 			bytes_to_write++;
-			message2[new_stream_position]=~message[old_stream_position];
+			message2[new_stream_position] = ~message[old_stream_position];
 		}
 		else
 		{
-			message2[new_stream_position]=message[old_stream_position];
+			message2[new_stream_position] = message[old_stream_position];
 		}
 		old_stream_position++;
 	}
@@ -1002,55 +1002,55 @@ bool P3IO::WriteToBulkWithExpectedReply(uint8_t* message, bool init_packet, bool
 
 
 	//prepare debug line
-	for (int i=0;i<bytes_to_write;i++)
+	for (int i = 0; i<bytes_to_write; i++)
 	{
-		sprintf (debug_message+(i*3), "%02X ", message2[i]);
+		sprintf(debug_message + (i * 3), "%02X ", message2[i]);
 	}
-	if(output_to_log) LOG->Info("Send %d bytes - %s", bytes_to_write, debug_message);
+	//if(output_to_log) LOG->Info("Send %d bytes - %s", bytes_to_write, debug_message);
 
 	int iResult = m_pDriver->BulkWrite(bulk_write_to_ep, (char*)message2, bytes_to_write, REQ_TIMEOUT);
 
 	if (iResult != bytes_to_write)
 	{
-		LOG->Info("P3IO message to send was truncated. Sent %d/%d bytes", iResult,bytes_to_write);
+		LOG->Info("P3IO message to send was truncated. Sent %d/%d bytes", iResult, bytes_to_write);
 	}
 
 	//get ready for the response
 	//LOG->Info("Asking for reply...");
 	iResult = GetResponseFromBulk(response, expected_response_size, output_to_log); //do a potentially fragmented read
-	bulk_reply_size=iResult;
+	bulk_reply_size = iResult;
 
 
 	//prepare debug line
-	debug_message[0]=0;
-	for (int i=0;i<bulk_reply_size;i++)
+	debug_message[0] = 0;
+	for (int i = 0; i<bulk_reply_size; i++)
 	{
-		sprintf (debug_message+(i*3), "%02X ", response[i]);
+		sprintf(debug_message + (i * 3), "%02X ", response[i]);
 	}
-	if(output_to_log) LOG->Info("Full response is %d/%d bytes - %s", bulk_reply_size,response[1]+2, debug_message);
-	
+	//if(output_to_log) LOG->Info("Full response is %d/%d bytes - %s", bulk_reply_size,response[1]+2, debug_message);
+
 
 	//if the unescaped data is too small according to the packet length byte...
-	if (bulk_reply_size<(response[1]+2))
+	if (bulk_reply_size<(response[1] + 2))
 	{
-		if(output_to_log) LOG->Info("Something is fishy, asking again...");
-		bool overrider=false; //probably make this override more rubust but it is a giant hack anyway... hopefully not needed anymore
-		if (iResult>1 && response[1]!=0xaa) overrider=true; // if we have something that looks like the start of the packet start vaguely
+		if (output_to_log) LOG->Info("Something is fishy, asking again...");
+		bool overrider = false; //probably make this override more rubust but it is a giant hack anyway... hopefully not needed anymore
+		if (iResult>1 && response[1] != 0xaa) overrider = true; // if we have something that looks like the start of the packet start vaguely
 		//tell it to override looking for packet start, trimming off the leading 0xAAs and length.
-		iResult += GetResponseFromBulk(response+iResult, response[1]-bulk_reply_size, output_to_log,overrider); //do a potentially fragmented read
-		bulk_reply_size=iResult;
+		iResult += GetResponseFromBulk(response + iResult, response[1] - bulk_reply_size, output_to_log, overrider); //do a potentially fragmented read
+		bulk_reply_size = iResult;
 
 		//prepare debug line
-		debug_message[0]=0;
-		for (int i=0;i<bulk_reply_size;i++)
+		debug_message[0] = 0;
+		for (int i = 0; i<bulk_reply_size; i++)
 		{
-			sprintf (debug_message+(i*3), "%02X ", response[i]);
+			sprintf(debug_message + (i * 3), "%02X ", response[i]);
 		}
-		if(output_to_log) LOG->Info("2nd attempt full response is %d/%d bytes - %s", bulk_reply_size,response[1]+2, debug_message);
+		if (output_to_log) LOG->Info("2nd attempt full response is %d/%d bytes - %s", bulk_reply_size, response[1] + 2, debug_message);
 	}
-	for (int i=0;i<bulk_reply_size;i++)
+	for (int i = 0; i<bulk_reply_size; i++)
 	{
-		p3io_response[i]=response[i];
+		p3io_response[i] = response[i];
 	}
 	return true;
 }
@@ -1059,69 +1059,69 @@ bool P3IO::WriteToBulkWithExpectedReply(uint8_t* message, bool init_packet, bool
 //this is a giant hack because data can be escaped which really fucks with length
 int P3IO::GetResponseFromBulk(uint8_t* response, int expected_response_length, bool output_to_log, bool force_override)
 {
-	int totalBytesRead=0;
-	int num_reads=0;
-	int num_failed_reads=0;
-	int escaped_bytes=0;
-	bool flag_has_start_of_packet=false;
-	bool flag_has_response_length=false;
+	int totalBytesRead = 0;
+	int num_reads = 0;
+	int num_failed_reads = 0;
+	int escaped_bytes = 0;
+	bool flag_has_start_of_packet = false;
+	bool flag_has_response_length = false;
 	if (force_override)
 	{
-			flag_has_start_of_packet=true;
-			flag_has_response_length=true;
+		flag_has_start_of_packet = true;
+		flag_has_response_length = true;
 	}
 	//int responseLength = m_pDriver->BulkRead(bulk_read_from_ep, (char*)response, 128, REQ_TIMEOUT);
 	//LOG->Info("begin while loop");
-	while (totalBytesRead < (expected_response_length+2)) //sometimes a response is fragmented over multiple requests, try a another time
+	while (totalBytesRead < (expected_response_length + 2)) //sometimes a response is fragmented over multiple requests, try a another time
 	{
-		if(output_to_log) LOG->Info("GETTING BULK OF EXPECTED SIZE: %02X/%02x",totalBytesRead,expected_response_length);
-		int i=0;
+		//if(output_to_log) LOG->Info("GETTING BULK OF EXPECTED SIZE: %02X/%02x",totalBytesRead,expected_response_length);
+		int i = 0;
 		num_reads++;
 
-		uint8_t response2[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+		uint8_t response2[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 		int bytesReadThisRound = m_pDriver->BulkRead(bulk_read_from_ep, (char*)response2, 64, REQ_TIMEOUT);
-		int escapedBytesThisRound=0;
+		int escapedBytesThisRound = 0;
 		if (bytesReadThisRound <1) num_failed_reads++; //note that we got nothing from the read
 
 		//DEBUG
-		debug_message[0]=0;
-		for (i=0;i<bytesReadThisRound;i++)
+		debug_message[0] = 0;
+		for (i = 0; i<bytesReadThisRound; i++)
 		{
-			sprintf (debug_message+(i*3), "%02X ", response2[i]);
+			sprintf(debug_message + (i * 3), "%02X ", response2[i]);
 		}
-		if(output_to_log) LOG->Info("Bulk read round %d is %d bytes - %s", num_reads, bytesReadThisRound, debug_message);
+		//if(output_to_log) LOG->Info("Bulk read round %d is %d bytes - %s", num_reads, bytesReadThisRound, debug_message);
 		//END DEBUG
 
 
 		if (bytesReadThisRound<1 && num_failed_reads>1)
 		{
-			LOG->Info("P3IO must have given up sending data we need (%d/%d bytes)",totalBytesRead,expected_response_length);
+			LOG->Info("P3IO must have given up sending data we need (%d/%d bytes)", totalBytesRead, expected_response_length);
 			break;
 		}
 
 		//unescape the bytes
-		i=0;
+		i = 0;
 
 
 		//Try and find start of packet in the data we read
 		if (!flag_has_start_of_packet)
 		{
 			//LOG->Info("P3io not escaping sop");
-			while(response2[0]!=0xAA && bytesReadThisRound>0)
+			while (response2[0] != 0xAA && bytesReadThisRound>0)
 			{
-				LOG->Info("Response buffer does NOT start with 0xAA, it starts with %02X. Shifting buffer left by one.",response2[0]);
+				//LOG->Info("Response buffer does NOT start with 0xAA, it starts with %02X. Shifting buffer left by one.",response2[0]);
 				//shift everything over until we do
-				for (i=0;i<bytesReadThisRound-1;i++)
+				for (i = 0; i<bytesReadThisRound - 1; i++)
 				{
-					response2[i]=response2[i+1];
-					response2[i+1]=0;
+					response2[i] = response2[i + 1];
+					response2[i + 1] = 0;
 				}
 				bytesReadThisRound--;
 			}
-			if (response2[0]==0xaa) flag_has_start_of_packet=true;
+			if (response2[0] == 0xaa) flag_has_start_of_packet = true;
 
 		}
-		
+
 		//if we dont have start of packet, lets try to read again
 		if (!flag_has_start_of_packet)
 		{
@@ -1133,32 +1133,32 @@ int P3IO::GetResponseFromBulk(uint8_t* response, int expected_response_length, b
 		//So now the next non-0xAA byte is the length of the packet
 
 		//EDGE CASE! We read a 0xAA in a previous round (reflected in total bytes read)
-		i=0; //assume start of packet is in main read buffer
-		if (totalBytesRead<1) i=1; // if we have nothing in the main buffer and the flag_has_start_of_packet is set, it means the start of packet is in the current read buffer
+		i = 0; //assume start of packet is in main read buffer
+		if (totalBytesRead<1) i = 1; // if we have nothing in the main buffer and the flag_has_start_of_packet is set, it means the start of packet is in the current read buffer
 
-		for (i;i<bytesReadThisRound;i++) //lets look at EVERYTHING we read
+		for (i; i<bytesReadThisRound; i++) //lets look at EVERYTHING we read
 		{
 			//response length is not set...
 			if (!flag_has_response_length)
 			{
 				//if we see ANY character that is not AA... we have a response length at some point
-				if (response2[i]!=0xAA)
+				if (response2[i] != 0xAA)
 				{
-					if(output_to_log) LOG->Info("Expected response length found! Setting new length to %02X",response2[i]);
-					flag_has_response_length=true;
-					expected_response_length=response2[i];
+					//if(output_to_log) LOG->Info("Expected response length found! Setting new length to %02X",response2[i]);
+					flag_has_response_length = true;
+					expected_response_length = response2[i];
 					i--;
 					continue;
 				}
 
 				//if we haven't seen any other data and AA is present in slot 2
-				if (response2[i]==0xAA)
+				if (response2[i] == 0xAA)
 				{
 					bytesReadThisRound--;
 					//shift all bytes in the array after this char to the left
-					for (int j=i;j<bytesReadThisRound;j++)
+					for (int j = i; j<bytesReadThisRound; j++)
 					{
-						response2[j]=response2[j+1];
+						response2[j] = response2[j + 1];
 					}
 					i--;
 					continue;
@@ -1167,7 +1167,7 @@ int P3IO::GetResponseFromBulk(uint8_t* response, int expected_response_length, b
 			else //we have the first 2 bytes of a packet such that we know the response length
 			{
 				//if we hit an escaped character in the payload
-				if (response2[i]==0xAA || response2[i]==0xFF)
+				if (response2[i] == 0xAA || response2[i] == 0xFF)
 				{
 					//LOG->Info("P3io  escape char at %d",i);
 					//decrease the actual number of bytes we read since it needs to be escaped and it doesn't count to expected reply length
@@ -1178,48 +1178,48 @@ int P3IO::GetResponseFromBulk(uint8_t* response, int expected_response_length, b
 				}
 			}
 
-			
+
 		}
 
 		//todo: bounds checking
 		//LOG->Info("P3IO MEMCOP %d",num_reads);
-		for(int j=0;j<bytesReadThisRound+escapedBytesThisRound;j++)
+		for (int j = 0; j<bytesReadThisRound + escapedBytesThisRound; j++)
 		{
-			response[totalBytesRead+j]=response2[j];
+			response[totalBytesRead + j] = response2[j];
 		}
 		//memcpy(response+totalBytesRead, response2, bytesReadThisRound);
 
-		if ((bytesReadThisRound+escapedBytesThisRound)>0)
+		if ((bytesReadThisRound + escapedBytesThisRound)>0)
 		{
 
 			//LOG->Info("P3io adding %d bytes to %d",bytesReadThisRound,totalBytesRead);
-			totalBytesRead+=bytesReadThisRound;
-			escaped_bytes+=escapedBytesThisRound;
+			totalBytesRead += bytesReadThisRound;
+			escaped_bytes += escapedBytesThisRound;
 
 		}
 
 
-	
+
 	}
 
 	//reading complete, time to unescape
 	//shift all bytes in the array after this char to the left, overwriting the escaped character
-	int bytesCountToEscape=totalBytesRead+escaped_bytes;
-	for (int i=2;i<bytesCountToEscape;i++)
+	int bytesCountToEscape = totalBytesRead + escaped_bytes;
+	for (int i = 2; i<bytesCountToEscape; i++)
 	{
-		if (response[i]==0xAA || response[i]==0xFF)
+		if (response[i] == 0xAA || response[i] == 0xFF)
 		{
 			bytesCountToEscape--;
-			for (int j=i;j<bytesCountToEscape;j++)
+			for (int j = i; j<bytesCountToEscape; j++)
 			{
-				response[j]=response[j+1];
+				response[j] = response[j + 1];
 			}
 
 			//zero out the last character
-			response[bytesCountToEscape]=0;
+			response[bytesCountToEscape] = 0;
 
 			//unescape the escaped character
-			response[i]=~response[i];
+			response[i] = ~response[i];
 		}
 	}
 	//LOG->Info("End P3IO get bulk  message");
@@ -1238,8 +1238,8 @@ void P3IO::Reconnect()
 	m_sInputError = m_sInputError.assign(temp);
 	Close();
 	m_bConnected = false;
-	baud_pass=false;
-	hdxb_ready=false;
+	baud_pass = false;
+	hdxb_ready = false;
 	Open();
 	m_sInputError = "";
 }
@@ -1280,7 +1280,7 @@ static uint8_t p3io_init_hd_and_watchdog[21][45] = {
 	{ 0xaa, 0x2b, 0x0d, 0x25, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
 	{ 0xaa, 0x2b, 0x0e, 0x25, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
 	//end read sec plug
-	
+
 	{ 0xaa, 0x03, 0x0f, 0x05, 0x00 },//these next 4 clearly set some parameters. no idea what they are
 	{ 0xaa, 0x03, 0x00, 0x2b, 0x01 },
 	{ 0xaa, 0x03, 0x01, 0x29, 0x05 },
@@ -1300,7 +1300,7 @@ void P3IO::InitHDAndWatchDog()
 		WriteToBulkWithExpectedReply(p3io_init_hd_and_watchdog[i], true);
 		usleep(16666);
 	}
-	
+
 
 	// now lets flush any open reads:
 	FlushBulkReadBuffer();
@@ -1309,7 +1309,7 @@ void P3IO::InitHDAndWatchDog()
 void P3IO::FlushBulkReadBuffer()
 {
 	uint8_t response3[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-						   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 	LOG->Info("P3IO Flushing Read buffer. Expect it to give up");
-	bulk_reply_size=GetResponseFromBulk(response3, 3, true); //do a potentially fragmented read
+	bulk_reply_size = GetResponseFromBulk(response3, 3, true); //do a potentially fragmented read
 }

--- a/src/io/P3IO.cpp
+++ b/src/io/P3IO.cpp
@@ -41,9 +41,9 @@ bool m_bConnected = false;
 uint8_t P3IO::p3io_request[256];
 uint8_t P3IO::p3io_response[256];
 char debug_message[2048];
-int bulk_reply_size = 0;
-bool baud_pass = false;
-bool hdxb_ready = false;
+int bulk_reply_size=0;
+bool baud_pass=false;
+bool hdxb_ready=false;
 
 
 
@@ -52,7 +52,7 @@ bool P3IO::DeviceMatches(int iVID, int iPID)
 
 	for (unsigned i = 0; i < NUM_P3IO_CHECKS_IDS; ++i)
 		if (iVID == P3IO_VENDOR_ID[i] && iPID == P3IO_PRODUCT_ID[i])
-			return true;
+			return true;	
 
 	return false;
 }
@@ -62,7 +62,7 @@ bool P3IO::Open()
 
 	if (m_COM4PORT.Get().length()>1)
 	{
-		COM4SET = true;
+		COM4SET=true;
 		com4.setPort(m_COM4PORT.Get().c_str());
 	}
 
@@ -95,24 +95,24 @@ bool P3IO::Open()
 			//ExitGame();
 
 
-			baud_pass = spamBaudCheck();
-
+			baud_pass=spamBaudCheck();
+			
 			// say the baud check passed anyway
-			baud_pass = true;
+			baud_pass=true;
 
-
-			if (baud_pass)
+			
+			if(baud_pass)
 			{
 				nodeCount();
-				getVersion();
-				initHDXB2();
-				initHDXB3();
-				initHDXB4();
+				getVersion(); 
+				initHDXB2(); 
+				initHDXB3(); 
+				initHDXB4(); 
 				pingHDXB();
 				HDXBAllOnTest();
-				hdxb_ready = true;
+				hdxb_ready=true;
 			}
-
+			
 			return m_bConnected;
 		}
 	m_bConnected = false;
@@ -121,20 +121,20 @@ bool P3IO::Open()
 
 void P3IO::HDXBAllOnTest()
 {
-	uint8_t all_on[0x0d] = {
-		0x00,
-		0xff,
-		0xff,
-		0xff,
-		0xff,
-		0xff,
-		0xff,
-		0x7f,
-		0x7f,
-		0x7f,
-		0x7f,
-		0x7f,
-		0x7f
+	uint8_t all_on[0x0d]={
+	0x00,
+	0xff,
+	0xff,
+	0xff,
+	0xff,
+	0xff,
+	0xff,
+	0x7f,
+	0x7f,
+	0x7f,
+	0x7f,
+	0x7f,
+	0x7f
 	};
 	LOG->Info("**************HDXB ALL ON TEST:");
 	writeHDXB(all_on, 0xd, HDXB_SET_LIGHTS);
@@ -318,22 +318,22 @@ bool P3IO::sendUnknownCommand()
 {
 	if (COM4SET) return true;
 	uint8_t unknown[] = {
-		0xaa,
-		0x04,
-		0x0a,
-		0x32,
-		0x01,
-		0x00
+	0xaa,
+	0x04,
+	0x0a,
+	0x32,
+	0x01,
+	0x00
 	};
 	//LOG->Info("**************HDXB UNKNOWN COMMAND:");
-	return WriteToBulkWithExpectedReply(unknown, false, true);
+	return WriteToBulkWithExpectedReply( unknown, false, true);
 }
 
 
 //sent every 78125us...
 bool P3IO::pingHDXB()
 {
-	if (COM4SET)
+if (COM4SET)
 	{
 		//LOG->Info("**************HDXB Serial PING:");
 		uint8_t hdxb_ping_command[] = {
@@ -345,9 +345,9 @@ bool P3IO::pingHDXB()
 			0x00,
 			0x14//CHECKSUM
 		};
-		com4.write(hdxb_ping_command, 7);
+		com4.write(hdxb_ping_command,7);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4, acio_response);
+		ACIO::read_acio_packet(com4,acio_response);
 	}
 	else
 	{
@@ -376,44 +376,44 @@ bool P3IO::pingHDXB()
 
 bool P3IO::spamBaudCheck()
 {
-	bool found_baud = false;
+	bool found_baud=false;
 	if (COM4SET)
 	{
 		//LOG->Info("**************HDXB Serial BAUD Routine:");
-		found_baud = ACIO::baudCheck(com4);
+		found_baud= ACIO::baudCheck(com4);
 	}
 	else
 	{
 		uint8_t com_baud_command[] = {
-			0xaa, // packet start
-			0x0f, // length
-			0x05, // sequence
-			0x3a, // com write
-			0x00, // virtual com port
-			0x0b, // num bytes
-			0xaa, // baud check, escaped 0xaa
-			0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa };
+		0xaa, // packet start
+		0x0f, // length
+		0x05, // sequence
+		0x3a, // com write
+		0x00, // virtual com port
+		0x0b, // num bytes
+		0xaa, // baud check, escaped 0xaa
+		0xaa,	0xaa,	0xaa,	0xaa,	0xaa,	0xaa,	0xaa,	0xaa,	0xaa,	0xaa	};
 
-		for (int i = 0; i<50; i++)
+		for (int i=0;i<50;i++)
 		{
 			//LOG->Info("**************HDXB P3IO BAUD:");
 			WriteToBulkWithExpectedReply(com_baud_command, false, true);
 			readHDXB(0x40);
-			if (bulk_reply_size >= 16 && p3io_response[1] == 0x0F && p3io_response[4] == 0x0B && p3io_response[5] == 0xAA && p3io_response[6] == 0xAA && p3io_response[7] == 0xAA && p3io_response[8] == 0xAA && p3io_response[9] == 0xAA && p3io_response[10] == 0xAA && p3io_response[11] == 0xAA && p3io_response[12] == 0xAA && p3io_response[13] == 0xAA && p3io_response[14] == 0xAA && p3io_response[15] == 0xAA)
+			if (bulk_reply_size>=16 && p3io_response[1]==0x0F && p3io_response[4]==0x0B &&  p3io_response[5]==0xAA && p3io_response[6]==0xAA && p3io_response[7]==0xAA && p3io_response[8]==0xAA && p3io_response[9]==0xAA && p3io_response[10]==0xAA && p3io_response[11]==0xAA && p3io_response[12]==0xAA && p3io_response[13]==0xAA && p3io_response[14]==0xAA && p3io_response[15]==0xAA)
 			{
-
+			
 				//LOG->Info("**************HDXB P3IO GOT BAUD RATE! Flushing...");
 				readHDXB(0x40); // now flush it
-
+			
 				readHDXB(0x40); // now flush it
-				found_baud = true;
+				found_baud=true;
 				break;
 			}
 		}
 	}
 
 	return found_baud;
-
+	
 
 }
 
@@ -421,18 +421,18 @@ bool P3IO::nodeCount()
 {
 	if (COM4SET)
 	{
-		uint8_t nodes[] = { 0xaa, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x02 };
-		com4.write(nodes, 8);
+		uint8_t nodes[]={0xaa,0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x02}; 
+		com4.write(nodes,8);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4, acio_response);
+		ACIO::read_acio_packet(com4,acio_response);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4, acio_response);//flush
+		ACIO::read_acio_packet(com4,acio_response);//flush
 		return true;
 	}
 	else
 	{
 		// 00    00    01    00    PP    07    CC -- 01 is the command for enumeration, PP is 01 (payload length), 07 is the payload with a reply of 7 in it, CC is checksum
-		uint8_t nodes[] = { 0xaa, 0x0e, 0x01, 0x3a, 0x00, 0x08, 0xaa, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x02 };
+		uint8_t nodes[]={0xaa,0x0e,0x01,0x3a,0x00,0x08,0xaa,0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x02}; 
 		//LOG->Info("**************HDXB P3IO Get Node Count:");
 		WriteToBulkWithExpectedReply(nodes, false, true);
 		readHDXB(0x40);
@@ -442,9 +442,9 @@ bool P3IO::nodeCount()
 
 bool P3IO::getVersion()
 {
-	if (COM4SET)
+	if(COM4SET)
 	{
-		uint8_t ICCB_1[] = {
+		uint8_t ICCB_1[]={
 			0xaa,//ACIO START
 			0x01,//ICCB1
 			0x00,//TYPE?
@@ -453,7 +453,7 @@ bool P3IO::getVersion()
 			0x00,
 			0x03,
 		};
-		uint8_t ICCB_2[] = {
+		uint8_t ICCB_2[]={
 			0xaa,//ACIO START
 			0x02,//ICCB2
 			0x00,//TYPE?
@@ -462,7 +462,7 @@ bool P3IO::getVersion()
 			0x00,
 			0x04,
 		};
-		uint8_t HDXB[] = {
+		uint8_t HDXB[]={
 			0xaa,//ACIO START
 			0x03,//HDXB
 			0x00,//TYPE?
@@ -473,29 +473,29 @@ bool P3IO::getVersion()
 		};
 		//LOG->Info("**************ICCB1 Serial Get Version:");
 
-		com4.write(ICCB_1, 7);
+		com4.write(ICCB_1,7);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4, acio_response);
+		ACIO::read_acio_packet(com4,acio_response);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4, acio_response);
+		ACIO::read_acio_packet(com4,acio_response);
 		//LOG->Info("**************ICCB2 Serial Get Version:");
-		com4.write(ICCB_2, 7);
+		com4.write(ICCB_2,7);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4, acio_response);
+		ACIO::read_acio_packet(com4,acio_response);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4, acio_response);
+		ACIO::read_acio_packet(com4,acio_response);
 		//LOG->Info("**************HDXB Serial Get Version:");
-		com4.write(HDXB, 7);
+		com4.write(HDXB,7);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4, acio_response);
+		ACIO::read_acio_packet(com4,acio_response);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4, acio_response);
+		ACIO::read_acio_packet(com4,acio_response);
 		return true;
 	}
 	else
 	{
 		//should build this but.. meh... lazy, manually define it
-		uint8_t ICCB_1[] = {
+		uint8_t ICCB_1[]={
 			0xaa,
 			0x0d,
 			0x01,
@@ -510,7 +510,7 @@ bool P3IO::getVersion()
 			0x00,
 			0x03,
 		};
-		uint8_t ICCB_2[] = {
+		uint8_t ICCB_2[]={
 			0xaa,
 			0x0d,
 			0x01,
@@ -525,7 +525,7 @@ bool P3IO::getVersion()
 			0x00,
 			0x04,
 		};
-		uint8_t HDXB[] = {
+		uint8_t HDXB[]={
 			0xaa,
 			0x0d,
 			0x01,
@@ -557,11 +557,11 @@ bool P3IO::getVersion()
 
 bool P3IO::initHDXB2()
 {
-	if (COM4SET)
+	if(COM4SET)
 	{
 		//should build this but.. meh... lazy, manually define it
 		//init into opcode 3?
-		uint8_t hdxb_op3[] = {
+		uint8_t hdxb_op3[]={
 			0xaa,//ACIO START
 			0x03,//HDXB
 			0x00,//TYPE?
@@ -571,30 +571,30 @@ bool P3IO::initHDXB2()
 			0x06,
 		};
 
-		uint8_t ICCB1_op3[] = { 0xaa, 0x01, 0x00, 0x03, 0x00, 0x00, 0x04 };
-		uint8_t ICCB2_op3[] = { 0xaa, 0x02, 0x00, 0x03, 0x00, 0x00, 0x05 };
-
+		uint8_t ICCB1_op3[]={0xaa,0x01,0x00,0x03,0x00,0x00,0x04};
+		uint8_t ICCB2_op3[]={0xaa,0x02,0x00,0x03,0x00,0x00,0x05};
+	
 		//LOG->Info("**************ICCB1 Serial INIT mode 3:");
-		com4.write(ICCB1_op3, 7);
+		com4.write(ICCB1_op3,7);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4, acio_response);
+		ACIO::read_acio_packet(com4,acio_response);
 		//LOG->Info("**************ICCB2 Serial INIT mode 3:");
-		com4.write(ICCB2_op3, 7);
+		com4.write(ICCB2_op3,7);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4, acio_response);
+		ACIO::read_acio_packet(com4,acio_response);
 		//LOG->Info("**************HDXB Serial INIT mode 3:");
-		com4.write(hdxb_op3, 7);
+		com4.write(hdxb_op3,7);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4, acio_response);
+		ACIO::read_acio_packet(com4,acio_response);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4, acio_response);// now flush it according to captures
-		return true;
+		ACIO::read_acio_packet(com4,acio_response);// now flush it according to captures
+		return true; 
 	}
 	else
 	{
 		//should build this but.. meh... lazy, manually define it
 		//init into opcode 3?
-		uint8_t hdxb_op3[] = {
+		uint8_t hdxb_op3[]={
 			0xaa,
 			0x0d,
 			0x01,
@@ -610,9 +610,9 @@ bool P3IO::initHDXB2()
 			0x06,
 		};
 
-		uint8_t ICCB1_op3[] = { 0xaa, 0x0d, 0x02, 0x3a, 0x00, 0x07, 0xaa, 0x01, 0x00, 0x03, 0x00, 0x00, 0x04 };
-		uint8_t ICCB2_op3[] = { 0xaa, 0x0d, 0x03, 0x3a, 0x00, 0x07, 0xaa, 0x02, 0x00, 0x03, 0x00, 0x00, 0x05 };
-
+		uint8_t ICCB1_op3[]={0xaa,0x0d,0x02,0x3a,0x00,0x07,0xaa,0x01,0x00,0x03,0x00,0x00,0x04};
+		uint8_t ICCB2_op3[]={0xaa,0x0d,0x03,0x3a,0x00,0x07,0xaa,0x02,0x00,0x03,0x00,0x00,0x05};
+	
 		//LOG->Info("**************ICCB1 P3IO INIT mode 3:");
 		WriteToBulkWithExpectedReply(ICCB1_op3, false, true);
 		readHDXB(0x7e);
@@ -629,10 +629,10 @@ bool P3IO::initHDXB2()
 
 bool P3IO::initHDXB3()
 {
-	if (COM4SET)
+	if(COM4SET)
 	{
 		//should build this but.. meh... lazy, manually define it
-		uint8_t hdxb_type[] = {
+		uint8_t hdxb_type[]={
 			0xaa,//ACIO START
 			0x03,//HDXB
 			0x01,//TYPE?
@@ -641,34 +641,34 @@ bool P3IO::initHDXB3()
 			0x00,
 			0x04,
 		};
-		uint8_t iccb1_type[] = { 0xaa, 0x01, 0x01, 0x00, 0x00, 0x00, 0x02 };
-		uint8_t iccb2_type[] = { 0xaa, 0x02, 0x01, 0x00, 0x00, 0x00, 0x03 };
-
+		uint8_t iccb1_type[]={0xaa,0x01,0x01,0x00,0x00,0x00,0x02};
+		uint8_t iccb2_type[]={0xaa,0x02,0x01,0x00,0x00,0x00,0x03};
+	
 		//LOG->Info("**************ICCB1 Serial INIT type 0:");
-		com4.write(iccb1_type, 7);
+		com4.write(iccb1_type,7);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4, acio_response);
+		ACIO::read_acio_packet(com4,acio_response);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4, acio_response);
+		ACIO::read_acio_packet(com4,acio_response);
 		//LOG->Info("**************ICCB2 Serial  INIT type 0:");
-		com4.write(iccb2_type, 7);
+		com4.write(iccb2_type,7);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4, acio_response);
+		ACIO::read_acio_packet(com4,acio_response);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4, acio_response);
+		ACIO::read_acio_packet(com4,acio_response);
 		//LOG->Info("**************HDXB Serial  INIT type 0:");
-		com4.write(hdxb_type, 7);
+		com4.write(hdxb_type,7);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4, acio_response);
+		ACIO::read_acio_packet(com4,acio_response);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4, acio_response);
+		ACIO::read_acio_packet(com4,acio_response);
 		return true;
 	}
 	else
 	{
 
 		//should build this but.. meh... lazy, manually define it
-		uint8_t hdxb_type[] = {
+		uint8_t hdxb_type[]={
 			0xaa,
 			0x0d,
 			0x01,
@@ -683,9 +683,9 @@ bool P3IO::initHDXB3()
 			0x00,
 			0x04,
 		};
-		uint8_t iccb1_type[] = { 0xaa, 0x0b, 0x0a, 0x3a, 0x00, 0x07, 0xaa, 0x01, 0x01, 0x00, 0x00, 0x00, 0x02 };
-		uint8_t iccb2_type[] = { 0xaa, 0x0b, 0x0e, 0x3a, 0x00, 0x07, 0xaa, 0x02, 0x01, 0x00, 0x00, 0x00, 0x03 };
-
+		uint8_t iccb1_type[]={0xaa,0x0b,0x0a,0x3a,0x00,0x07,0xaa,0x01,0x01,0x00,0x00,0x00,0x02};
+		uint8_t iccb2_type[]={0xaa,0x0b,0x0e,0x3a,0x00,0x07,0xaa,0x02,0x01,0x00,0x00,0x00,0x03};
+	
 		//LOG->Info("**************ICCB1 P3IO INIT type 0:");
 		WriteToBulkWithExpectedReply(iccb1_type, false, true);
 		readHDXB(0x7e);
@@ -704,10 +704,10 @@ bool P3IO::initHDXB3()
 
 bool P3IO::initHDXB4()
 {
-	if (COM4SET)
+	if(COM4SET)
 	{
 		//should build this but.. meh... lazy, manually define it
-		uint8_t breath_of_life[] = {
+		uint8_t breath_of_life[]={
 			0xaa,//ACIO START
 			0x03,//HDXB
 			0x01,//TYPE?
@@ -719,15 +719,15 @@ bool P3IO::initHDXB4()
 			0x2e
 		};
 		//LOG->Info("**************HDXB Serial INIT4:");
-		com4.write(breath_of_life, 9);
+		com4.write(breath_of_life,9);
 		usleep(72000); // 36 ms wait
-		ACIO::read_acio_packet(com4, acio_response);
+		ACIO::read_acio_packet(com4,acio_response);
 		return true;
 	}
 	else
 	{
 		//should build this but.. meh... lazy, manually define it
-		uint8_t breath_of_life[] = {
+		uint8_t breath_of_life[]={
 			0xaa,
 			0x0d,
 			0x01,
@@ -763,15 +763,15 @@ bool P3IO::openHDXB()
 	else
 	{
 
-
+	
 		uint8_t com_open_command[] = {
-			0xaa, // packet start
-			0x05, // length
-			0x06, // sequence
-			0x38, // com open opcode
-			0x00, // virtual com port
-			0x00, // @ baud
-			0x03  // choose speed: ?, ?, 19200, 38400, 57600
+		0xaa, // packet start
+		0x05, // length
+		0x06, // sequence
+		0x38, // com open opcode
+		0x00, // virtual com port
+		0x00, // @ baud
+		0x03  // choose speed: ?, ?, 19200, 38400, 57600
 		};
 		//LOG->Info("**************HDXB P3IO OPEN:");
 		return WriteToBulkWithExpectedReply(com_open_command, false, true);
@@ -789,7 +789,7 @@ bool P3IO::readHDXB(int len)
 		0x00, // virtual com port
 		0x7e  // 7e is 126 bytes to read
 	};
-	com_read_command[5] = len & 0xFF; // plug in passed in len
+	com_read_command[5]=len&0xFF; // plug in passed in len
 	//LOG->Info("**************HDXB P3IO Read:");
 	return WriteToBulkWithExpectedReply(com_read_command, false, true);
 }
@@ -797,20 +797,20 @@ bool P3IO::readHDXB(int len)
 //pass in a raw payload only
 bool P3IO::writeHDXB(uint8_t* payload, int len, uint8_t opcode)
 {
-	if (COM4SET)
+	if(COM4SET)
 	{
-
+	
 		//frame: 03:01:12:00:0d
 		//payload consists of 00:ff:ff:ff:ff:ff:ff:7f:7f:7f:7f:7f:7f
 		//must also accomodate acio packet of: aa:03:01:28:00:02:00:00:2e
-		acio_request[0] = 0x03; // hdxb device id
-		acio_request[1] = 0x01; // type?
-		acio_request[2] = opcode; // set lights?
-		acio_request[3] = 0x00; //
-		acio_request[4] = len & 0xFF; // length
-
+		acio_request[0]=0x03; // hdxb device id
+		acio_request[1]=0x01; // type?
+		acio_request[2]=opcode; // set lights?
+		acio_request[3]=0x00; //
+		acio_request[4]=len & 0xFF; // length
+	
 		//len should be 0x0d
-		memcpy(&acio_request[5], payload, len * sizeof(uint8_t));
+		memcpy( &acio_request[5],  payload, len * sizeof( uint8_t ) );
 
 		//03:01:12:00:0d:00:ff:ff:ff:ff:ff:ff:7f:7f:7f:7f:7f:7f
 		len++; // add checksum to length of payload
@@ -819,25 +819,25 @@ bool P3IO::writeHDXB(uint8_t* payload, int len, uint8_t opcode)
 		//uint8_t unescaped_acio_length = len & 0xFF; // but we dont need this, we need number of bytes to write to acio bus
 
 		//get escaped packet and length
-		len += 5; //acio frame bytes added
-		len = ACIO::prep_acio_packet_for_transmission(acio_request, len);
-		com4.write(acio_request, len);
+		len+=5; //acio frame bytes added
+		len = ACIO::prep_acio_packet_for_transmission(acio_request,len); 
+		com4.write(acio_request,len);
 		usleep(36000); // 36 ms wait
-		ACIO::read_acio_packet(com4, acio_response);
+		ACIO::read_acio_packet(com4,acio_response);
 	}
 	else
 	{
 		//frame: 03:01:12:00:0d
 		//payload consists of 00:ff:ff:ff:ff:ff:ff:7f:7f:7f:7f:7f:7f
 		//must also accomodate acio packet of: aa:03:01:28:00:02:00:00:2e
-		p3io_request[0] = 0x03; // hdxb device id
-		p3io_request[1] = 0x01; // type?
-		p3io_request[2] = opcode; // set lights?
-		p3io_request[3] = 0x00; //
-		p3io_request[4] = len & 0xFF; // length
-
+		p3io_request[0]=0x03; // hdxb device id
+		p3io_request[1]=0x01; // type?
+		p3io_request[2]=opcode; // set lights?
+		p3io_request[3]=0x00; //
+		p3io_request[4]=len & 0xFF; // length
+	
 		//len should be 0x0d
-		memcpy(&p3io_request[5], payload, len * sizeof(uint8_t));
+		memcpy( &p3io_request[5],  payload, len * sizeof( uint8_t ) );
 
 		//03:01:12:00:0d:00:ff:ff:ff:ff:ff:ff:7f:7f:7f:7f:7f:7f
 		len++; // add checksum to length of payload
@@ -846,22 +846,22 @@ bool P3IO::writeHDXB(uint8_t* payload, int len, uint8_t opcode)
 		//uint8_t unescaped_acio_length = len & 0xFF; // but we dont need this, we need number of bytes to write to acio bus
 
 		//get escaped packet and length
-		len += 5; //acio frame bytes added
-		len = ACIO::prep_acio_packet_for_transmission(p3io_request, len);
+		len+=5; //acio frame bytes added
+		len = ACIO::prep_acio_packet_for_transmission(p3io_request,len); 
 
 		//we are now ready to transmit over p3io channels...
 		uint8_t p3io_acio_message[256];
-		p3io_acio_message[0] = 0xaa;
-		p3io_acio_message[1] = (len + 4) & 0xFF;
-		p3io_acio_message[2] = 0;
-		p3io_acio_message[3] = 0x3a; //com port write
-		p3io_acio_message[4] = 0; // actual virtual com port number to use
-		p3io_acio_message[5] = len & 0xFF; //num bytes to write on the acio bus
-		memcpy(&p3io_acio_message[6], p3io_request, len * sizeof(uint8_t)); // stuff in a p3io wrapper
+		p3io_acio_message[0]=0xaa;
+		p3io_acio_message[1]=(len+4) & 0xFF;
+		p3io_acio_message[2]=0;
+		p3io_acio_message[3]=0x3a; //com port write
+		p3io_acio_message[4]=0; // actual virtual com port number to use
+		p3io_acio_message[5]=len&0xFF; //num bytes to write on the acio bus
+		memcpy( &p3io_acio_message[6],  p3io_request, len * sizeof( uint8_t ) ); // stuff in a p3io wrapper
 		//LOG->Info("**************HDXB P3IO LIGHT Write:");
 		WriteToBulkWithExpectedReply(p3io_acio_message, false, true);
 		//LOG->Info("**************HDXB P3IO Get Ping:");
-
+	
 	}
 	return pingHDXB();
 }
@@ -880,16 +880,16 @@ bool P3IO::writeLights(uint8_t* payload)
 	//arbitrary keep alive signal. maybe can dial this back? send one evry 4 attempts
 	//lights are CONSTANTLY sending in this architecture
 	packets_since_keepalive %= 6;
+	
 
-
-
+	
 	//compare last payload with this payload -- prevent useless chatter on USB so input has best poll rate
-	if ((memcmp(p_light_payload, payload, sizeof(p_light_payload)) != 0) || (packets_since_keepalive == 0))
+	if ( (memcmp(p_light_payload, payload, sizeof(p_light_payload))!=0) || (packets_since_keepalive == 0) )
 	{	//if they dont match...
-
+		
 		//copy new payload to previous payload so I can check it next round
 		memcpy(p_light_payload, payload, sizeof(p_light_payload));
-
+	
 		//make a light message
 		uint8_t light_message[] = { 0xaa, 0x07, 0x00, 0x24, ~payload[4], payload[3], payload[2], payload[1], payload[0] };
 		//LOG->Info("P3io driver Sending light message: %02X %02X %02X %02X %02X %02X %02X %02X %02X", light_message[0],light_message[1],light_message[2],light_message[3],light_message[4],light_message[5],light_message[6],light_message[7],light_message[8]);
@@ -919,12 +919,12 @@ bool P3IO::WriteToBulkWithExpectedReply(uint8_t* message, bool init_packet, bool
 
 	//max packet size is 64 bytes * 2 for escaped packets
 	uint8_t response[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+						   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
 	int message_length = 5;
 	int expected_response_size = 3; // handles packet start, length, sequence.. everything should be long than this though. Updates in the function
 
-	message_length = message[1] + 2;
+	message_length = message[1]+2;
 
 
 
@@ -938,63 +938,63 @@ bool P3IO::WriteToBulkWithExpectedReply(uint8_t* message, bool init_packet, bool
 	{
 
 
-	case 0x01: // version query
-	expected_response_size = 11;
-	break;
+		case 0x01: // version query
+			expected_response_size = 11;
+			break;
 
-	case 0x31: //coin query
-	expected_response_size = 9;
-	break;
+		case 0x31: //coin query
+			expected_response_size = 9;
+			break;
+	
+		case 0x2f:// some query
+			expected_response_size = 5;
+			break;
 
-	case 0x2f:// some query
-	expected_response_size = 5;
-	break;
-
-	case 0x27: //cabinet type query
-	expected_response_size = 5;
-	break;
+		case 0x27: //cabinet type query
+			expected_response_size = 5;
+			break;
 
 
-	case 0x24: //set light state?
-	expected_response_size = 6;
-	break;
+		case 0x24: //set light state?
+			expected_response_size = 6;
+			break;
 
-	case 0x25: //get dongle
-	expected_response_size = 45;
-	break;
-	case 0x3a: // com write
-	expected_response_size = 5; /// basically an ack
-	break;
-
-	default:
-	expected_response_size = 5;
+		case 0x25: //get dongle
+			expected_response_size = 45;
+			break;
+		case 0x3a: // com write
+			expected_response_size = 5; /// basically an ack
+			break;
+	
+		default:
+			expected_response_size = 5;
 	}
 	*/
 	//End horribly wrong segment
-
-
+	
+	
 	//LOG->Info("Expected response size is %d", expected_response_size);
 	//actually send our message with the parameters we determined
 	//but first we need to escape our shit
 
 
 	//LOG->Info("Escaping our shit");
-	int bytes_to_write = message_length;
+	int bytes_to_write=message_length;
 	uint8_t message2[258];
-	message2[0] = message[0];
-	int old_stream_position = 1;
-	for (int new_stream_position = 1; new_stream_position<bytes_to_write; new_stream_position++)
+	message2[0]=message[0];
+	int old_stream_position=1;
+	for (int new_stream_position=1;new_stream_position<bytes_to_write;new_stream_position++)
 	{
-		if (message[old_stream_position] == 0xAA || message[old_stream_position] == 0xFF)
+		if (message[old_stream_position]==0xAA || message[old_stream_position]==0xFF)
 		{
-			message2[new_stream_position] = 0xFF;
+			message2[new_stream_position]=0xFF;
 			new_stream_position++;
 			bytes_to_write++;
-			message2[new_stream_position] = ~message[old_stream_position];
+			message2[new_stream_position]=~message[old_stream_position];
 		}
 		else
 		{
-			message2[new_stream_position] = message[old_stream_position];
+			message2[new_stream_position]=message[old_stream_position];
 		}
 		old_stream_position++;
 	}
@@ -1002,9 +1002,9 @@ bool P3IO::WriteToBulkWithExpectedReply(uint8_t* message, bool init_packet, bool
 
 
 	//prepare debug line
-	for (int i = 0; i<bytes_to_write; i++)
+	for (int i=0;i<bytes_to_write;i++)
 	{
-		sprintf(debug_message + (i * 3), "%02X ", message2[i]);
+		sprintf (debug_message+(i*3), "%02X ", message2[i]);
 	}
 	//if(output_to_log) LOG->Info("Send %d bytes - %s", bytes_to_write, debug_message);
 
@@ -1012,45 +1012,45 @@ bool P3IO::WriteToBulkWithExpectedReply(uint8_t* message, bool init_packet, bool
 
 	if (iResult != bytes_to_write)
 	{
-		LOG->Info("P3IO message to send was truncated. Sent %d/%d bytes", iResult, bytes_to_write);
+		LOG->Info("P3IO message to send was truncated. Sent %d/%d bytes", iResult,bytes_to_write);
 	}
 
 	//get ready for the response
 	//LOG->Info("Asking for reply...");
 	iResult = GetResponseFromBulk(response, expected_response_size, output_to_log); //do a potentially fragmented read
-	bulk_reply_size = iResult;
+	bulk_reply_size=iResult;
 
 
 	//prepare debug line
-	debug_message[0] = 0;
-	for (int i = 0; i<bulk_reply_size; i++)
+	debug_message[0]=0;
+	for (int i=0;i<bulk_reply_size;i++)
 	{
-		sprintf(debug_message + (i * 3), "%02X ", response[i]);
+		sprintf (debug_message+(i*3), "%02X ", response[i]);
 	}
 	//if(output_to_log) LOG->Info("Full response is %d/%d bytes - %s", bulk_reply_size,response[1]+2, debug_message);
-
+	
 
 	//if the unescaped data is too small according to the packet length byte...
-	if (bulk_reply_size<(response[1] + 2))
+	if (bulk_reply_size<(response[1]+2))
 	{
-		if (output_to_log) LOG->Info("Something is fishy, asking again...");
-		bool overrider = false; //probably make this override more rubust but it is a giant hack anyway... hopefully not needed anymore
-		if (iResult>1 && response[1] != 0xaa) overrider = true; // if we have something that looks like the start of the packet start vaguely
+		if(output_to_log) LOG->Info("Something is fishy, asking again...");
+		bool overrider=false; //probably make this override more rubust but it is a giant hack anyway... hopefully not needed anymore
+		if (iResult>1 && response[1]!=0xaa) overrider=true; // if we have something that looks like the start of the packet start vaguely
 		//tell it to override looking for packet start, trimming off the leading 0xAAs and length.
-		iResult += GetResponseFromBulk(response + iResult, response[1] - bulk_reply_size, output_to_log, overrider); //do a potentially fragmented read
-		bulk_reply_size = iResult;
+		iResult += GetResponseFromBulk(response+iResult, response[1]-bulk_reply_size, output_to_log,overrider); //do a potentially fragmented read
+		bulk_reply_size=iResult;
 
 		//prepare debug line
-		debug_message[0] = 0;
-		for (int i = 0; i<bulk_reply_size; i++)
+		debug_message[0]=0;
+		for (int i=0;i<bulk_reply_size;i++)
 		{
-			sprintf(debug_message + (i * 3), "%02X ", response[i]);
+			sprintf (debug_message+(i*3), "%02X ", response[i]);
 		}
-		if (output_to_log) LOG->Info("2nd attempt full response is %d/%d bytes - %s", bulk_reply_size, response[1] + 2, debug_message);
+		if(output_to_log) LOG->Info("2nd attempt full response is %d/%d bytes - %s", bulk_reply_size,response[1]+2, debug_message);
 	}
-	for (int i = 0; i<bulk_reply_size; i++)
+	for (int i=0;i<bulk_reply_size;i++)
 	{
-		p3io_response[i] = response[i];
+		p3io_response[i]=response[i];
 	}
 	return true;
 }
@@ -1059,35 +1059,35 @@ bool P3IO::WriteToBulkWithExpectedReply(uint8_t* message, bool init_packet, bool
 //this is a giant hack because data can be escaped which really fucks with length
 int P3IO::GetResponseFromBulk(uint8_t* response, int expected_response_length, bool output_to_log, bool force_override)
 {
-	int totalBytesRead = 0;
-	int num_reads = 0;
-	int num_failed_reads = 0;
-	int escaped_bytes = 0;
-	bool flag_has_start_of_packet = false;
-	bool flag_has_response_length = false;
+	int totalBytesRead=0;
+	int num_reads=0;
+	int num_failed_reads=0;
+	int escaped_bytes=0;
+	bool flag_has_start_of_packet=false;
+	bool flag_has_response_length=false;
 	if (force_override)
 	{
-		flag_has_start_of_packet = true;
-		flag_has_response_length = true;
+			flag_has_start_of_packet=true;
+			flag_has_response_length=true;
 	}
 	//int responseLength = m_pDriver->BulkRead(bulk_read_from_ep, (char*)response, 128, REQ_TIMEOUT);
 	//LOG->Info("begin while loop");
-	while (totalBytesRead < (expected_response_length + 2)) //sometimes a response is fragmented over multiple requests, try a another time
+	while (totalBytesRead < (expected_response_length+2)) //sometimes a response is fragmented over multiple requests, try a another time
 	{
 		//if(output_to_log) LOG->Info("GETTING BULK OF EXPECTED SIZE: %02X/%02x",totalBytesRead,expected_response_length);
-		int i = 0;
+		int i=0;
 		num_reads++;
 
-		uint8_t response2[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+		uint8_t response2[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 		int bytesReadThisRound = m_pDriver->BulkRead(bulk_read_from_ep, (char*)response2, 64, REQ_TIMEOUT);
-		int escapedBytesThisRound = 0;
+		int escapedBytesThisRound=0;
 		if (bytesReadThisRound <1) num_failed_reads++; //note that we got nothing from the read
 
 		//DEBUG
-		debug_message[0] = 0;
-		for (i = 0; i<bytesReadThisRound; i++)
+		debug_message[0]=0;
+		for (i=0;i<bytesReadThisRound;i++)
 		{
-			sprintf(debug_message + (i * 3), "%02X ", response2[i]);
+			sprintf (debug_message+(i*3), "%02X ", response2[i]);
 		}
 		//if(output_to_log) LOG->Info("Bulk read round %d is %d bytes - %s", num_reads, bytesReadThisRound, debug_message);
 		//END DEBUG
@@ -1095,33 +1095,33 @@ int P3IO::GetResponseFromBulk(uint8_t* response, int expected_response_length, b
 
 		if (bytesReadThisRound<1 && num_failed_reads>1)
 		{
-			LOG->Info("P3IO must have given up sending data we need (%d/%d bytes)", totalBytesRead, expected_response_length);
+			LOG->Info("P3IO must have given up sending data we need (%d/%d bytes)",totalBytesRead,expected_response_length);
 			break;
 		}
 
 		//unescape the bytes
-		i = 0;
+		i=0;
 
 
 		//Try and find start of packet in the data we read
 		if (!flag_has_start_of_packet)
 		{
 			//LOG->Info("P3io not escaping sop");
-			while (response2[0] != 0xAA && bytesReadThisRound>0)
+			while(response2[0]!=0xAA && bytesReadThisRound>0)
 			{
 				//LOG->Info("Response buffer does NOT start with 0xAA, it starts with %02X. Shifting buffer left by one.",response2[0]);
 				//shift everything over until we do
-				for (i = 0; i<bytesReadThisRound - 1; i++)
+				for (i=0;i<bytesReadThisRound-1;i++)
 				{
-					response2[i] = response2[i + 1];
-					response2[i + 1] = 0;
+					response2[i]=response2[i+1];
+					response2[i+1]=0;
 				}
 				bytesReadThisRound--;
 			}
-			if (response2[0] == 0xaa) flag_has_start_of_packet = true;
+			if (response2[0]==0xaa) flag_has_start_of_packet=true;
 
 		}
-
+		
 		//if we dont have start of packet, lets try to read again
 		if (!flag_has_start_of_packet)
 		{
@@ -1133,32 +1133,32 @@ int P3IO::GetResponseFromBulk(uint8_t* response, int expected_response_length, b
 		//So now the next non-0xAA byte is the length of the packet
 
 		//EDGE CASE! We read a 0xAA in a previous round (reflected in total bytes read)
-		i = 0; //assume start of packet is in main read buffer
-		if (totalBytesRead<1) i = 1; // if we have nothing in the main buffer and the flag_has_start_of_packet is set, it means the start of packet is in the current read buffer
+		i=0; //assume start of packet is in main read buffer
+		if (totalBytesRead<1) i=1; // if we have nothing in the main buffer and the flag_has_start_of_packet is set, it means the start of packet is in the current read buffer
 
-		for (i; i<bytesReadThisRound; i++) //lets look at EVERYTHING we read
+		for (i;i<bytesReadThisRound;i++) //lets look at EVERYTHING we read
 		{
 			//response length is not set...
 			if (!flag_has_response_length)
 			{
 				//if we see ANY character that is not AA... we have a response length at some point
-				if (response2[i] != 0xAA)
+				if (response2[i]!=0xAA)
 				{
 					//if(output_to_log) LOG->Info("Expected response length found! Setting new length to %02X",response2[i]);
-					flag_has_response_length = true;
-					expected_response_length = response2[i];
+					flag_has_response_length=true;
+					expected_response_length=response2[i];
 					i--;
 					continue;
 				}
 
 				//if we haven't seen any other data and AA is present in slot 2
-				if (response2[i] == 0xAA)
+				if (response2[i]==0xAA)
 				{
 					bytesReadThisRound--;
 					//shift all bytes in the array after this char to the left
-					for (int j = i; j<bytesReadThisRound; j++)
+					for (int j=i;j<bytesReadThisRound;j++)
 					{
-						response2[j] = response2[j + 1];
+						response2[j]=response2[j+1];
 					}
 					i--;
 					continue;
@@ -1167,7 +1167,7 @@ int P3IO::GetResponseFromBulk(uint8_t* response, int expected_response_length, b
 			else //we have the first 2 bytes of a packet such that we know the response length
 			{
 				//if we hit an escaped character in the payload
-				if (response2[i] == 0xAA || response2[i] == 0xFF)
+				if (response2[i]==0xAA || response2[i]==0xFF)
 				{
 					//LOG->Info("P3io  escape char at %d",i);
 					//decrease the actual number of bytes we read since it needs to be escaped and it doesn't count to expected reply length
@@ -1178,48 +1178,48 @@ int P3IO::GetResponseFromBulk(uint8_t* response, int expected_response_length, b
 				}
 			}
 
-
+			
 		}
 
 		//todo: bounds checking
 		//LOG->Info("P3IO MEMCOP %d",num_reads);
-		for (int j = 0; j<bytesReadThisRound + escapedBytesThisRound; j++)
+		for(int j=0;j<bytesReadThisRound+escapedBytesThisRound;j++)
 		{
-			response[totalBytesRead + j] = response2[j];
+			response[totalBytesRead+j]=response2[j];
 		}
 		//memcpy(response+totalBytesRead, response2, bytesReadThisRound);
 
-		if ((bytesReadThisRound + escapedBytesThisRound)>0)
+		if ((bytesReadThisRound+escapedBytesThisRound)>0)
 		{
 
 			//LOG->Info("P3io adding %d bytes to %d",bytesReadThisRound,totalBytesRead);
-			totalBytesRead += bytesReadThisRound;
-			escaped_bytes += escapedBytesThisRound;
+			totalBytesRead+=bytesReadThisRound;
+			escaped_bytes+=escapedBytesThisRound;
 
 		}
 
 
-
+	
 	}
 
 	//reading complete, time to unescape
 	//shift all bytes in the array after this char to the left, overwriting the escaped character
-	int bytesCountToEscape = totalBytesRead + escaped_bytes;
-	for (int i = 2; i<bytesCountToEscape; i++)
+	int bytesCountToEscape=totalBytesRead+escaped_bytes;
+	for (int i=2;i<bytesCountToEscape;i++)
 	{
-		if (response[i] == 0xAA || response[i] == 0xFF)
+		if (response[i]==0xAA || response[i]==0xFF)
 		{
 			bytesCountToEscape--;
-			for (int j = i; j<bytesCountToEscape; j++)
+			for (int j=i;j<bytesCountToEscape;j++)
 			{
-				response[j] = response[j + 1];
+				response[j]=response[j+1];
 			}
 
 			//zero out the last character
-			response[bytesCountToEscape] = 0;
+			response[bytesCountToEscape]=0;
 
 			//unescape the escaped character
-			response[i] = ~response[i];
+			response[i]=~response[i];
 		}
 	}
 	//LOG->Info("End P3IO get bulk  message");
@@ -1238,8 +1238,8 @@ void P3IO::Reconnect()
 	m_sInputError = m_sInputError.assign(temp);
 	Close();
 	m_bConnected = false;
-	baud_pass = false;
-	hdxb_ready = false;
+	baud_pass=false;
+	hdxb_ready=false;
 	Open();
 	m_sInputError = "";
 }
@@ -1280,7 +1280,7 @@ static uint8_t p3io_init_hd_and_watchdog[21][45] = {
 	{ 0xaa, 0x2b, 0x0d, 0x25, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
 	{ 0xaa, 0x2b, 0x0e, 0x25, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
 	//end read sec plug
-
+	
 	{ 0xaa, 0x03, 0x0f, 0x05, 0x00 },//these next 4 clearly set some parameters. no idea what they are
 	{ 0xaa, 0x03, 0x00, 0x2b, 0x01 },
 	{ 0xaa, 0x03, 0x01, 0x29, 0x05 },
@@ -1300,7 +1300,7 @@ void P3IO::InitHDAndWatchDog()
 		WriteToBulkWithExpectedReply(p3io_init_hd_and_watchdog[i], true);
 		usleep(16666);
 	}
-
+	
 
 	// now lets flush any open reads:
 	FlushBulkReadBuffer();
@@ -1309,7 +1309,7 @@ void P3IO::InitHDAndWatchDog()
 void P3IO::FlushBulkReadBuffer()
 {
 	uint8_t response3[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+						   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 	LOG->Info("P3IO Flushing Read buffer. Expect it to give up");
-	bulk_reply_size = GetResponseFromBulk(response3, 3, true); //do a potentially fragmented read
+	bulk_reply_size=GetResponseFromBulk(response3, 3, true); //do a potentially fragmented read
 }

--- a/src/io/P3IO.cpp
+++ b/src/io/P3IO.cpp
@@ -25,12 +25,12 @@ uint8_t pchunk[3][4];
 //first set is what a chimera uses, second set is a real ddr io (from an hd black cab), the last set is actually a mouse I use for testing!
 
 //has mouse debugger
-const uint16_t P3IO_VENDOR_ID[3] = { 0x0000, 0x1CCF, 0x046D};
-const uint16_t P3IO_PRODUCT_ID[3] = { 0x5731, 0x8008, 0xC077};
+//const uint16_t P3IO_VENDOR_ID[3] = { 0x0000, 0x1CCF, 0x046D};
+//const uint16_t P3IO_PRODUCT_ID[3] = { 0x5731, 0x8008, 0xC077};
 
 
-//const uint16_t P3IO_VENDOR_ID[2] = { 0x0000, 0x1CCF };
-//const uint16_t P3IO_PRODUCT_ID[2] = { 0x5731, 0x8008 };
+const uint16_t P3IO_VENDOR_ID[2] = { 0x0000, 0x1CCF };
+const uint16_t P3IO_PRODUCT_ID[2] = { 0x5731, 0x8008 };
 uint8_t p_light_payload[] = { 0, 0, 0, 0, 0 };
 const unsigned NUM_P3IO_CHECKS_IDS = ARRAYLEN(P3IO_PRODUCT_ID);
 int interrupt_ep = 0x83;

--- a/src/io/P3IO.h
+++ b/src/io/P3IO.h
@@ -58,8 +58,8 @@ public:
 	bool initHDXB4();
 	bool pingHDXB();
 	bool spamBaudCheck();
-	bool writeHDXB(uint8_t* payload, int len, uint8_t opcode=HDXB_SET_LIGHTS);
-	bool readHDXB(int len=0x7e);
+	bool writeHDXB(uint8_t* payload, int len, uint8_t opcode = HDXB_SET_LIGHTS);
+	bool readHDXB(int len = 0x7e);
 	void HDXBAllOnTest();
 	bool nodeCount();
 
@@ -73,8 +73,8 @@ public:
 
 
 private:
-	int GetResponseFromBulk(uint8_t* response, int response_length, bool output_to_log=false, bool force_override=false);
-	bool WriteToBulkWithExpectedReply(uint8_t* message, bool init_packet, bool output_to_log=true);
+	int GetResponseFromBulk(uint8_t* response, int response_length, bool output_to_log = false, bool force_override = false);
+	bool WriteToBulkWithExpectedReply(uint8_t* message, bool init_packet, bool output_to_log = false);
 	uint8_t checkInput(uint8_t x, uint8_t y);
 	void InitHDAndWatchDog();
 


### PR DESCRIPTION
This PR removes my debug device from the p3io code and makes it less chatty in the log reducing log spam and disk thrashing and io bottlenecking. The statements won't help anyone anyway and were only meant to be temporary. I left them there so people could understand what the code was doing, however, in case someone else wanted to write an IO driver for it.

Also adds the ability to add a defined timeout to ezsockets, abstracts the http logic from screenpackages, and allows it to be used to, for example, broadcast the current song being played. I also added the ability to thread these requests so the game thread isn't lagged. The end result will be nice for streamers and allow enhanced functionality in the future (I'll be making a score broadcaster as well, great for tournaments and conventions).

The last fix has to do with USB drive mounting. Every single tutorial, including, for example, this one: http://www.hackmycab.com/?portfolio=configuring-usbs shows USB mount points for windows using a trailing slash or backslash. The current mount code for windows now doesn't like the trailing slash. This change allows the legacy behavior in the configuration file by simply stripping slashes off the end until it doesn't see a slash.

P.S. Visual studio's auto formatter makes me weep. I'm very sorry for the BS it created in generating the diff. I used to use notepad2 and just write in there. 

Update:
I ended up painfully reverting all the msvc formatter changes so they would display cleanly. I also ended up sending both machine and profile guid to the score submission system.

In ezsockets I added the ability to actually affect the real socket blocking behavior as well as added function analogs that do not use select (for the rare instances you don't want that).

I corrected url encoding bugs from the function from screenpackages and allowed it to work for UTF8 strings as well.