### PR TITLE
fix arcade build params and compile errors

### DIFF
--- a/build/build-all.sh
+++ b/build/build-all.sh
@@ -5,6 +5,7 @@ set -e
 set -u
 
 PRIVATE_RSA="$1"
+PATCH_RSA="$2"
 
 function print_usage
 {
@@ -19,6 +20,6 @@ if [ ! -d "artifacts" ]; then
 fi
 
 ./build-source-package.sh ./artifacts
-./build-arcade-machine-revision.sh $PRIVATE_RSA
+./build-arcade-machine-revision.sh $PRIVATE_RSA $PATCH_RSA
 ./build-opensuse-package.sh
 ./build-ubuntu-packages.sh

--- a/build/build-all.sh
+++ b/build/build-all.sh
@@ -5,7 +5,6 @@ set -e
 set -u
 
 PRIVATE_RSA="$1"
-PATCH_RSA="$2"
 
 function print_usage
 {
@@ -20,6 +19,6 @@ if [ ! -d "artifacts" ]; then
 fi
 
 ./build-source-package.sh ./artifacts
-./build-arcade-machine-revision.sh $PRIVATE_RSA $PATCH_RSA
+./build-arcade-machine-revision.sh $PRIVATE_RSA
 ./build-opensuse-package.sh
 ./build-ubuntu-packages.sh

--- a/build/build-arcade-machine-revision.sh
+++ b/build/build-arcade-machine-revision.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 PRIVATE_RSA="$1"
-PATCH_RSA="$2"
 
 # exit immediately on nonzero exit code
 set -e
@@ -16,14 +15,13 @@ fi
 
 function print_usage
 {
-	echo "Usage: $0 [private RSA key] [public RSA key]"
+	echo "Usage: $0 [private RSA key]"
 	exit 0
 }
 
-if ! [ -f "$PRIVATE_RSA" ] || ! [ -f "$PATCH_RSA" ]; then print_usage; fi
+if ! [ -f "$PRIVATE_RSA" ]; then print_usage; fi
 
 PRIVATE_RSA=$(abspath $PRIVATE_RSA)
-PATCH_RSA=$(abspath $PATCH_RSA)
 
 # Calculate reasonable number of make jobs
 HAS_NPROC=1
@@ -58,7 +56,7 @@ make
 popd
 
 # Generate a machine revision package
-./gen-arcade-patch.sh $PRIVATE_RSA $PATCH_RSA
+./gen-arcade-patch.sh $PRIVATE_RSA
 
 mv ITG*.itg build/artifacts/
 cd build

--- a/gen-arcade-patch.sh
+++ b/gen-arcade-patch.sh
@@ -9,7 +9,6 @@
 
 # default to private.rsa in CWD (for the sake of a default value)
 PRIVATE_RSA=${1-private.rsa}
-PATCH_RSA=${2-Patch.rsa}
 
 # include the simple helper routines
 source common.sh
@@ -34,11 +33,11 @@ set -u
 
 function print_usage
 {
-	echo "Usage: $0 [private RSA key] [public RSA key]"
+	echo "Usage: $0 [private RSA key]"
 	exit 0
 }
 
-if ! [ -f "$PRIVATE_RSA" ] || ! [ -f "$PATCH_RSA" ]; then print_usage; fi
+if ! [ -f "$PRIVATE_RSA" ]; then print_usage; fi
 
 # clean up after ourselves on exit
 trap "rm -rf $TMP_DIR" EXIT
@@ -91,7 +90,8 @@ echo "Copying base patch data..."
 cp -a $PATCH_DATA_DIR/* "$TMP_DIR"
 
 # Replace Patch-OpenITG.rsa with the one actually used to sign the machine revision
-cp $PATCH_RSA "$PATCH_DIR/Data/Patch-OpenITG.rsa"
+openssl rsa -in $PRIVATE_RSA -inform DER \
+	-pubout -out "$PATCH_DIR/Data/Patch-OpenITG.rsa" -outform DER
 
 echo "Generating patch.zip..."
 ./gen-patch-zip.sh "$TMP_DIR/patch.zip" &> /dev/null

--- a/src/arch/COM/impl/list_ports/list_ports_linux.cc
+++ b/src/arch/COM/impl/list_ports/list_ports_linux.cc
@@ -130,7 +130,8 @@ usb_sysfs_friendly_name(const string& sys_usb_path)
 {
     unsigned int device_number = 0;
 
-    istringstream( read_line(sys_usb_path + "/devnum") ) >> device_number;
+    istringstream devnum_iss( read_line(sys_usb_path + "/devnum") );
+    devnum_iss >> device_number;
 
     string manufacturer = read_line( sys_usb_path + "/manufacturer" );
 


### PR DESCRIPTION
* during patch building in the arcade build, the public key is required as a param for gen-arcade-patch.sh but not passed through the build scripts. gen-arcade-patch now just extracts it from the private key.
* g++ 3.3 was not a fan of that raii one-liner in list_ports_linux.cc for whatever reason