### PR TITLE
Fix rate change resampling algorithm to eliminate high-pitched aliasing

### DIFF
--- a/src/RageSound.cpp
+++ b/src/RageSound.cpp
@@ -265,9 +265,15 @@ void RageSound::RateChange( char *pBuffer, int &iCount, int iInputSpeed, int iOu
 			{
 				float frac = fPosition - floorf( fPosition );
 				int iPosition = int(fPosition);
-				int iValue = int(samps[iPosition] * (1-frac));
-				if( s+1 < iOutputSpeed )
+				int iValue;
+
+				if( iPosition + 1 < iInputSpeed )
+				{
+					iValue = int(samps[iPosition] * (1-frac));
 					iValue += int(samps[iPosition+1] * frac);
+				} else {
+					iValue = int(samps[iPosition]);
+				}
 
 				*pOutput = int16_t(iValue);
 				fPosition += fIncrement;


### PR DESCRIPTION
There has been a long-standing bug in the resampling algorithm for changing the song rate that introduces a high-pitched aliasing noise, most noticeable on loud kick drums and isolated sub basses.  At the end of each 10-sample fragment of output audio, the linear interpolation starts discarding the later sample being interpolated, without assigning full weight to the earlier sample.  This patch fixes the interpolation weighting for this case, and also fixes the bounds check to use the correct variable.